### PR TITLE
Override default implementation of targetClass() for Enum and OneOfArray generators.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/array/OneOfArrayGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/generator/array/OneOfArrayGenerator.java
@@ -21,6 +21,8 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.OneOfArrayGeneratorSpec;
 import org.instancio.internal.ApiValidator;
 
+import java.util.Optional;
+
 public class OneOfArrayGenerator<T> extends AbstractGenerator<T> implements OneOfArrayGeneratorSpec<T> {
 
     private T[] values;
@@ -39,5 +41,10 @@ public class OneOfArrayGenerator<T> extends AbstractGenerator<T> implements OneO
     @Override
     public T generate(final Random random) {
         return random.oneOf(values);
+    }
+
+    @Override
+    public Optional<Class<?>> targetClass() {
+        return Optional.of(values.getClass().getComponentType());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/generator/lang/EnumGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/generator/lang/EnumGenerator.java
@@ -22,6 +22,7 @@ import org.instancio.internal.ApiValidator;
 
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Optional;
 
 public class EnumGenerator<E extends Enum<E>> implements EnumGeneratorSpec<E>, Generator<E> {
 
@@ -68,5 +69,10 @@ public class EnumGenerator<E extends Enum<E>> implements EnumGeneratorSpec<E>, G
     @Override
     public boolean supports(final Class<?> type) {
         return enumClass.isAssignableFrom(type);
+    }
+
+    @Override
+    public Optional<Class<?>> targetClass() {
+        return Optional.of(enumClass);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -50,6 +50,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Class for creating a node hierarchy for a given {@link Type}.
  */
+@SuppressWarnings("PMD.GodClass")
 public final class NodeFactory {
     private static final Logger LOG = LoggerFactory.getLogger(NodeFactory.class);
 
@@ -141,10 +142,9 @@ public final class NodeFactory {
                 .parent(parent)
                 .build();
 
-        final Optional<Class<?>> target = resolveSubtype(node);
+        final Class<?> targetClass = resolveSubtype(node).orElse(rawType);
 
-        if (target.isPresent()) {
-            final Class<?> targetClass = target.get();
+        if (!rawType.isPrimitive() && rawType != targetClass) {
             ApiValidator.validateSubtype(rawType, targetClass);
 
             if (LOG.isDebugEnabled()) {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/subtype/SubtypeUsingClassSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/subtype/SubtypeUsingClassSelectorTest.java
@@ -30,10 +30,10 @@ import org.instancio.test.support.pojo.person.RichPerson;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +44,17 @@ import static org.instancio.Select.scope;
 @FeatureTag({Feature.SCOPE, Feature.SUBTYPE})
 @ExtendWith(InstancioExtension.class)
 class SubtypeUsingClassSelectorTest {
+
+    @Test
+    void subtypeMappingSameClass() {
+        final ListInteger result = Instancio.of(ListInteger.class)
+                .subtype(all(List.class), List.class)
+                .create();
+
+        assertThat(result.getList()).isExactlyInstanceOf(ArrayList.class)
+                .isNotEmpty()
+                .doesNotContainNull();
+    }
 
     @Test
     @DisplayName("Map non-generic type to non-generic subtype")
@@ -112,26 +123,13 @@ class SubtypeUsingClassSelectorTest {
                 .allSatisfy(elem -> assertThat(elem).isNotBlank());
     }
 
-    @Nested
-    class ValidationTest {
-        @Test
-        void invalidSubtypeMappingArrayListToList() {
-            final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
-                    .subtype(all(List.class), String.class);
+    @Test
+    void invalidSubtypeMappingArrayListToList() {
+        final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
+                .subtype(all(List.class), String.class);
 
-            assertThatThrownBy(api::create)
-                    .isInstanceOf(InstancioApiException.class)
-                    .hasMessage("Class '%s' is not a subtype of '%s'", String.class.getName(), List.class.getName());
-        }
-
-        @Test
-        void invalidSubtypeMappingListToList() {
-            final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
-                    .subtype(all(List.class), List.class);
-
-            assertThatThrownBy(api::create)
-                    .isInstanceOf(InstancioApiException.class)
-                    .hasMessage("Invalid subtype mapping from '%s' to '%s'", List.class.getName(), List.class.getName());
-        }
+        assertThatThrownBy(api::create)
+                .isInstanceOf(InstancioApiException.class)
+                .hasMessage("Class '%s' is not a subtype of '%s'", String.class.getName(), List.class.getName());
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/subtype/SubtypeUsingFieldSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/subtype/SubtypeUsingFieldSelectorTest.java
@@ -30,10 +30,10 @@ import org.instancio.test.support.pojo.person.Person_;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +43,17 @@ import static org.instancio.Select.field;
 @FeatureTag(Feature.SUBTYPE)
 @ExtendWith(InstancioExtension.class)
 class SubtypeUsingFieldSelectorTest {
+
+    @Test
+    void subtypeMappingSameClass() {
+        final ListInteger result = Instancio.of(ListInteger.class)
+                .subtype(field("list"), List.class)
+                .create();
+
+        assertThat(result.getList()).isExactlyInstanceOf(ArrayList.class)
+                .isNotEmpty()
+                .doesNotContainNull();
+    }
 
     @Test
     @DisplayName("Map non-generic field type to non-generic subtype")
@@ -74,26 +85,13 @@ class SubtypeUsingFieldSelectorTest {
         assertThat(result.getItemInterfaceString().getValue()).isNotBlank();
     }
 
-    @Nested
-    class ValidationTest {
-        @Test
-        void invalidSubtypeMappingArrayListToList() {
-            final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
-                    .subtype(field("list"), String.class);
+    @Test
+    void invalidSubtypeMappingArrayListToList() {
+        final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
+                .subtype(field("list"), String.class);
 
-            assertThatThrownBy(api::create)
-                    .isInstanceOf(InstancioApiException.class)
-                    .hasMessage("Class '%s' is not a subtype of '%s'", String.class.getName(), List.class.getName());
-        }
-
-        @Test
-        void invalidSubtypeMappingListToList() {
-            final InstancioApi<ListInteger> api = Instancio.of(ListInteger.class)
-                    .subtype(field("list"), List.class);
-
-            assertThatThrownBy(api::create)
-                    .isInstanceOf(InstancioApiException.class)
-                    .hasMessage("Invalid subtype mapping from '%s' to '%s'", List.class.getName(), List.class.getName());
-        }
+        assertThatThrownBy(api::create)
+                .isInstanceOf(InstancioApiException.class)
+                .hasMessage("Class '%s' is not a subtype of '%s'", String.class.getName(), List.class.getName());
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/generator/lang/EnumGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/generator/lang/EnumGeneratorTest.java
@@ -83,6 +83,13 @@ class EnumGeneratorTest {
     }
 
     @Test
+    void supports() {
+        final EnumGenerator<Gender> generator = new EnumGenerator<>(Gender.class);
+        assertThat(generator.supports(Gender.class)).isTrue();
+        assertThat(generator.supports(SingleValueEnum.class)).isFalse();
+    }
+
+    @Test
     void validation() {
         final EnumGenerator<Gender> generator = new EnumGenerator<>(Gender.class);
         assertThatThrownBy(() -> generator.excluding(null))


### PR DESCRIPTION
This was causing 'Unhandled type: TypeVariableImpl' error when using the generators standalone.