### PR TITLE
Bug fix: handle primitive types in records when using `ignore()` and `withNullable()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -36,6 +36,7 @@ import org.instancio.internal.reflection.RecordHelper;
 import org.instancio.internal.reflection.RecordHelperImpl;
 import org.instancio.internal.util.ArrayUtils;
 import org.instancio.internal.util.CollectionUtils;
+import org.instancio.internal.util.ObjectUtils;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.internal.util.SystemProperties;
 import org.instancio.settings.Keys;
@@ -398,7 +399,14 @@ class InstancioEngine {
             final Optional<GeneratorResult> optResult = createObject(children.get(i));
 
             if (optResult.isPresent()) {
-                args[i] = optResult.get().getValue();
+                final GeneratorResult result = optResult.get();
+                if (result.isNullResult() && children.get(i).getRawType().isPrimitive()) {
+                    args[i] = ObjectUtils.defaultValue(children.get(i).getRawType());
+                } else {
+                    args[i] = result.getValue();
+                }
+            } else {
+                args[i] = ObjectUtils.defaultValue(children.get(i).getRawType());
             }
         }
 

--- a/instancio-core/src/main/java/org/instancio/internal/util/ObjectUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/ObjectUtils.java
@@ -21,8 +21,29 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
 public final class ObjectUtils {
-    private ObjectUtils() {
-        //non-instantiable
+
+    private static final Integer DEFAULT_INT = 0;
+    private static final Long DEFAULT_LONG = 0L;
+    private static final Boolean DEFAULT_BOOLEAN = Boolean.FALSE;
+    private static final Double DEFAULT_DOUBLE = 0d;
+    private static final Float DEFAULT_FLOAT = 0f;
+    private static final Character DEFAULT_CHAR = '\u0000';
+    private static final Byte DEFAULT_BYTE = (byte) 0;
+    private static final Short DEFAULT_SHORT = (short) 0;
+
+    @SuppressWarnings({"unchecked", "PMD.NPathComplexity", Sonar.COGNITIVE_COMPLEXITY_OF_METHOD})
+    public static <T> T defaultValue(final Class<T> type) {
+        if (type.isPrimitive()) {
+            if (type == int.class) return (T) DEFAULT_INT;
+            if (type == long.class) return (T) DEFAULT_LONG;
+            if (type == boolean.class) return (T) DEFAULT_BOOLEAN;
+            if (type == double.class) return (T) DEFAULT_DOUBLE;
+            if (type == float.class) return (T) DEFAULT_FLOAT;
+            if (type == char.class) return (T) DEFAULT_CHAR;
+            if (type == byte.class) return (T) DEFAULT_BYTE;
+            if (type == short.class) return (T) DEFAULT_SHORT;
+        }
+        return null;
     }
 
     @NotNull
@@ -32,5 +53,9 @@ public final class ObjectUtils {
 
     public static <T> T defaultIfNull(@Nullable final T value, final Supplier<T> defaultValue) {
         return value == null ? defaultValue.get() : value;
+    }
+
+    private ObjectUtils() {
+        //non-instantiable
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/util/ReflectionUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/ReflectionUtils.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -102,22 +103,7 @@ public final class ReflectionUtils {
     }
 
     public static boolean neitherNullNorPrimitiveWithDefaultValue(final Class<?> type, @Nullable final Object value) {
-        if (value == null) {
-            return false;
-        }
-
-        if (type.isPrimitive()) {
-            if (value instanceof Number) {
-                return Double.compare(((Number) value).doubleValue(), 0.0) != 0;
-            }
-            if (value instanceof Boolean) {
-                return (Boolean) value;
-            }
-            if (value instanceof Character) {
-                return (Character) value != 0;
-            }
-        }
-        return true;
+        return !Objects.equals(ObjectUtils.defaultValue(type), value);
     }
 
     public static Class<?> getClass(final String name) {

--- a/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
@@ -20,6 +20,7 @@ public final class Sonar {
     public static final String ACCESSIBILITY_UPDATE_SHOULD_BE_REMOVED = "java:S3011";
     public static final String ADD_ASSERTION = "java:S2699";
     public static final String CATCH_EXCEPTION_INSTEAD_OF_THROWABLE = "java:S1181";
+    public static final String COGNITIVE_COMPLEXITY_OF_METHOD = "java:S3776";
     public static final String DISABLED_TEST = "java:S1607";
     public static final String GENERIC_WILDCARD_IN_RETURN = "java:S1452";
     public static final String METHODS_RETURNS_SHOULD_NOT_BE_INVARIANT = "java:S3516";

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ignore/IgnoreTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ignore/IgnoreTest.java
@@ -18,6 +18,7 @@ package org.instancio.test.features.ignore;
 import org.instancio.Instancio;
 import org.instancio.Model;
 import org.instancio.test.support.pojo.basic.ClassWithInitializedField;
+import org.instancio.test.support.pojo.basic.PrimitiveFields;
 import org.instancio.test.support.pojo.basic.SupportedNumericTypes;
 import org.instancio.test.support.pojo.collections.maps.MapStringPerson;
 import org.instancio.test.support.pojo.person.Address;
@@ -26,7 +27,6 @@ import org.instancio.test.support.pojo.person.Pet;
 import org.instancio.test.support.pojo.person.Phone;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +35,7 @@ import static org.instancio.Select.all;
 import static org.instancio.Select.allShorts;
 import static org.instancio.Select.allStrings;
 import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
 import static org.instancio.Select.scope;
 
 @FeatureTag(Feature.IGNORE)
@@ -42,7 +43,6 @@ class IgnoreTest {
 
     @Test
     @DisplayName("Ignored field should retain the original value")
-    @NonDeterministicTag("Asserts generated primitive is not zero")
     void fieldIsIgnored() {
         final ClassWithInitializedField holder = Instancio.of(ClassWithInitializedField.class)
                 .ignore(field("stringValue"))
@@ -54,7 +54,22 @@ class IgnoreTest {
     }
 
     @Test
-    @NonDeterministicTag("Asserts generated primitive is not zero")
+    void ignoreAllPrimitives() {
+        final PrimitiveFields result = Instancio.of(PrimitiveFields.class)
+                .ignore(fields())
+                .create();
+
+        assertThat(result.isBooleanValue()).isFalse();
+        assertThat(result.getByteValue()).isZero();
+        assertThat(result.getShortValue()).isZero();
+        assertThat(result.getCharValue()).isEqualTo('\u0000');
+        assertThat(result.getIntValue()).isZero();
+        assertThat(result.getLongValue()).isZero();
+        assertThat(result.getFloatValue()).isZero();
+        assertThat(result.getDoubleValue()).isZero();
+    }
+
+    @Test
     void primitiveAndWrapperTypes() {
         final Model<SupportedNumericTypes> model = Instancio.of(SupportedNumericTypes.class)
                 .ignore(field("primitiveFloat"))

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorWithIgnoreTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorWithIgnoreTest.java
@@ -17,6 +17,7 @@ package org.instancio.test.features.selector;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.person.Address;
 import org.instancio.test.support.pojo.person.Person;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -40,6 +41,15 @@ class PredicateSelectorWithIgnoreTest {
                 .create();
 
         assertThat(result).hasAllNullFieldsOrPropertiesExcept("age", "finalField");
+    }
+
+    @Test
+    void ignoreFieldsNamed() {
+        final Person result = Instancio.of(Person.class)
+                .ignore(fields().named("phoneNumbers").declaredIn(Address.class))
+                .create();
+
+        assertThat(result.getAddress().getPhoneNumbers()).isNull();
     }
 
     @Test

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/ObjectUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/ObjectUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObjectUtilsTest {
+
+    @Test
+    void defaultValue() {
+        assertThat(ObjectUtils.defaultValue(boolean.class)).isFalse();
+        assertThat(ObjectUtils.defaultValue(byte.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(short.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(char.class)).isEqualTo('\u0000');
+        assertThat(ObjectUtils.defaultValue(int.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(long.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(float.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(double.class)).isZero();
+        assertThat(ObjectUtils.defaultValue(Object.class)).isNull();
+    }
+}

--- a/instancio-tests/java16-tests/pom.xml
+++ b/instancio-tests/java16-tests/pom.xml
@@ -33,8 +33,8 @@
                             <version>${version.lombok}</version>
                         </path>
                     </annotationProcessorPaths>
-                    <source>15</source>
-                    <target>15</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -57,6 +57,10 @@
             <artifactId>instancio-test-support</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/PrimitivesRecord.java
+++ b/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/PrimitivesRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.java16.record;
+
+public record PrimitivesRecord(
+        boolean booleanValue,
+        byte byteValue,
+        short shortValue,
+        char charValue,
+        int intValue,
+        long longValue,
+        float floatValue,
+        double doubleValue,
+        Object objectValue) {
+
+}
+

--- a/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/ChildRecord.java
+++ b/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/ChildRecord.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.java16.record.cyclic;
+
+public record ChildRecord(ParentRecord parent) {
+
+}

--- a/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/NodeRecord.java
+++ b/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/NodeRecord.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.java16.record.cyclic;
+
+public record NodeRecord<T>(NodeRecord<T> prev, NodeRecord<T> next, T value) {
+
+}

--- a/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/ParentRecord.java
+++ b/instancio-tests/java16-tests/src/main/java/org/instancio/test/support/java16/record/cyclic/ParentRecord.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.java16.record.cyclic;
+
+import java.util.List;
+
+public record ParentRecord(String name, List<ChildRecord> children) {
+
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/CyclicRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/CyclicRecordTest.java
@@ -15,39 +15,41 @@
  */
 package org.instancio.test.java16;
 
+import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.junit.InstancioExtension;
-import org.instancio.test.support.java16.record.GenericPairRecord;
-import org.instancio.test.support.tags.GenericsTag;
+import org.instancio.test.support.java16.record.cyclic.NodeRecord;
+import org.instancio.test.support.java16.record.cyclic.ParentRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * NOTE: this test fails in IntelliJ, run it using Maven
  */
-@GenericsTag
+@FeatureTag(Feature.CYCLIC)
 @ExtendWith(InstancioExtension.class)
-class GenericPairRecordTest {
+class CyclicRecordTest {
 
     @Test
-    void createGenericRecord() {
-        final GenericPairRecord<String, Integer> result = Instancio.create(new TypeToken<>() {});
-        assertThat(result.left()).isNotBlank().isExactlyInstanceOf(String.class);
-        assertThat(result.right()).isExactlyInstanceOf(Integer.class);
+    void cyclicGenericRecord() {
+        final NodeRecord<String> result = Instancio.create(new TypeToken<>() {});
+
+        assertThat(result.next()).isNull();
+        assertThat(result.prev()).isNull();
+        assertThat(result.value()).isNotBlank();
     }
 
     @Test
-    void genericRecordAsCollectionElement() {
-        final List<GenericPairRecord<String, Integer>> results = Instancio.create(new TypeToken<>() {});
+    void cyclicParentChild() {
+        final ParentRecord parent = Instancio.create(ParentRecord.class);
 
-        assertThat(results).isNotEmpty().allSatisfy(result -> {
-            assertThat(result.left()).isNotBlank().isExactlyInstanceOf(String.class);
-            assertThat(result.right()).isExactlyInstanceOf(Integer.class);
-        });
+        assertThat(parent.name()).isNotBlank();
+        assertThat(parent.children()).isNotEmpty()
+                .allSatisfy(child -> Assertions.assertThat(child.parent()).isNull());
     }
 }

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/PersonRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/PersonRecordTest.java
@@ -17,9 +17,12 @@ package org.instancio.test.java16;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.asserts.Asserts;
 import org.instancio.test.support.java16.record.AddressRecord;
 import org.instancio.test.support.java16.record.PersonRecord;
 import org.instancio.test.support.java16.record.PhoneRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,12 +30,21 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.all;
+import static org.instancio.Select.allStrings;
 import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
 import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
 
 /**
  * NOTE: this test fails in IntelliJ, run it using Maven
  */
+@FeatureTag({
+        Feature.IGNORE,
+        Feature.GENERATE,
+        Feature.ON_COMPLETE,
+        Feature.SET,
+        Feature.SUPPLY
+})
 @ExtendWith(InstancioExtension.class)
 class PersonRecordTest {
 
@@ -61,6 +73,25 @@ class PersonRecordTest {
                 .isNotEmpty()
                 .extracting(PhoneRecord::number)
                 .allSatisfy(number -> assertThat(number).hasSize(7).containsOnlyDigits());
+    }
+
+    @Test
+    void ignore() {
+        final PersonRecord result = Instancio.of(PersonRecord.class)
+                .ignore(all(
+                        allStrings(),
+                        field("age")))
+                .ignore(fields().named("phoneNumbers").declaredIn(AddressRecord.class))
+                .create();
+
+        assertThat(result.age()).isZero();
+
+        final AddressRecord address = result.address();
+        Asserts.assertAllNulls(
+                result.name(),
+                address.city(),
+                address.street(),
+                address.phoneNumbers());
     }
 
     @Test

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordAssignmentTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordAssignmentTest.java
@@ -1,0 +1,41 @@
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.assignment.AssignmentType;
+import org.instancio.assignment.OnSetMethodError;
+import org.instancio.assignment.OnSetMethodNotFound;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.java16.record.PhoneRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * NOTE: this test fails in IntelliJ, run it using Maven
+ */
+@FeatureTag(Feature.ASSIGNMENT)
+@ExtendWith(InstancioExtension.class)
+class RecordAssignmentTest {
+
+    @ParameterizedTest
+    @EnumSource(AssignmentType.class)
+    @DisplayName("Records are created via constructors, therefore no field or method assignment is done")
+    void assignmentTypeDoesNotAffectRecords(final AssignmentType assignmentType) {
+        final PhoneRecord result = Instancio.of(PhoneRecord.class)
+                .withSettings(Settings.create()
+                        .set(Keys.ASSIGNMENT_TYPE, assignmentType)
+                        .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL)
+                        .set(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.FAIL))
+                .create();
+
+        assertThat(result.countryCode()).isNotBlank();
+        assertThat(result.number()).isNotBlank();
+    }
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordCollectionsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordCollectionsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.GenericPairRecord;
+import org.instancio.test.support.java16.record.PersonRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
+import static org.instancio.Select.field;
+
+/**
+ * NOTE: this test fails in IntelliJ, run it using Maven
+ */
+@FeatureTag(Feature.OF_LIST)
+@ExtendWith(InstancioExtension.class)
+class RecordCollectionsTest {
+
+    @Test
+    void listWithGenericElement() {
+        final List<GenericPairRecord<String, Long>> result = Instancio.create(new TypeToken<>() {});
+
+        assertThat(result).isNotEmpty()
+                .allSatisfy(pair -> assertThatObject(pair).hasNoNullFieldsOrProperties());
+    }
+
+    @Test
+    void listUsingNonGenericElement() {
+        final List<PersonRecord> result = Instancio.of(new TypeToken<List<PersonRecord>>() {})
+                .set(field(PersonRecord.class, "name"), "foo")
+                .create();
+
+        assertThat(result)
+                .isNotEmpty()
+                .allSatisfy(person -> assertThatObject(person).hasNoNullFieldsOrProperties());
+    }
+
+    @Test
+    void ofList() {
+        final List<PersonRecord> result = Instancio.ofList(PersonRecord.class).size(3).create();
+
+        assertThat(result)
+                .hasSize(3)
+                .allSatisfy(person -> assertThatObject(person).hasNoNullFieldsOrProperties());
+    }
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordSelectorsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordSelectorsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.PersonRecord;
+import org.instancio.test.support.java16.record.PhoneRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.allStrings;
+import static org.instancio.Select.root;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+/**
+ * NOTE: this test fails in IntelliJ, run it using Maven
+ */
+@FeatureTag({
+        Feature.SELECTOR,
+        Feature.PREDICATE_SELECTOR,
+        Feature.ROOT_SELECTOR,
+        Feature.SCOPE,
+        Feature.TO_SCOPE
+})
+@ExtendWith(InstancioExtension.class)
+class RecordSelectorsTest {
+
+    @Test
+    void selectRoot() {
+        final PersonRecord result = Instancio.of(PersonRecord.class)
+                .set(root(), null)
+                .create();
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void predicateTargetingRecord() {
+        final PhoneRecord expected = Instancio.create(PhoneRecord.class);
+        final PersonRecord result = Instancio.of(PersonRecord.class)
+                .set(types().of(PhoneRecord.class), expected)
+                .create();
+
+        assertThat(result.address().phoneNumbers())
+                .isNotEmpty().containsOnly(expected);
+    }
+
+    @Test
+    void withinScope() {
+        final PersonRecord result = Instancio.of(PersonRecord.class)
+                .set(allStrings().within(all(PhoneRecord.class).toScope()), "foo")
+                .create();
+
+        assertThat(result.address().city()).isNotEqualTo("foo");
+        assertThat(result.address().phoneNumbers()).isNotEmpty()
+                .allSatisfy(phone -> assertThatObject(phone).hasAllFieldsOfTypeEqualTo(String.class, "foo"));
+    }
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordWithPrimitiveFieldsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/RecordWithPrimitiveFieldsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.PrimitivesRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.fields;
+
+/**
+ * NOTE: this test fails in IntelliJ, run it using Maven
+ */
+@FeatureTag({Feature.IGNORE, Feature.NULLABLE, Feature.SET})
+@ExtendWith(InstancioExtension.class)
+class RecordWithPrimitiveFieldsTest {
+
+    @Test
+    void ignored() {
+        final PrimitivesRecord result = Instancio.of(PrimitivesRecord.class)
+                .ignore(fields())
+                .create();
+
+        assertAllFieldsHaveDefaultValues(result);
+    }
+
+    @Test
+    void setNull() {
+        final PrimitivesRecord result = Instancio.of(PrimitivesRecord.class)
+                .set(fields(), null)
+                .create();
+
+        assertAllFieldsHaveDefaultValues(result);
+    }
+
+    @Test
+    void withNullable() {
+        final PrimitivesRecord result = Instancio.of(PrimitivesRecord.class)
+                .withNullable(fields())
+                .create();
+
+        assertThat(result).isNotNull();
+    }
+
+    private static void assertAllFieldsHaveDefaultValues(final PrimitivesRecord result) {
+        assertThat(result.booleanValue()).isFalse();
+        assertThat(result.byteValue()).isZero();
+        assertThat(result.shortValue()).isZero();
+        assertThat(result.charValue()).isEqualTo('\u0000');
+        assertThat(result.intValue()).isZero();
+        assertThat(result.longValue()).isZero();
+        assertThat(result.floatValue()).isZero();
+        assertThat(result.doubleValue()).isZero();
+        assertThat(result.objectValue()).isNull();
+    }
+}


### PR DESCRIPTION
- if a primitive field declared by a record was marked as nullable or the field was explicitly set to null using `set()`, a null record was generated

- using `ignore()` with a primitive field declared by a record was causing null record to be generated due to insufficient arguments for the canonical constructor.

The fix is to use default primitive values in both of these cases.