### PR TITLE
Updated `generate()` method signature to use `GeneratorSpecProvider` interface.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/GeneratorSpecProvider.java
+++ b/instancio-core/src/main/java/org/instancio/GeneratorSpecProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+import org.instancio.generator.GeneratorSpec;
+import org.instancio.generators.Generators;
+
+/**
+ * Provides access to built-in generators that support customisation
+ * of generated values using the API.
+ *
+ * @param <V> generated object type
+ * @since 2.2.0
+ */
+@FunctionalInterface
+public interface GeneratorSpecProvider<V> {
+
+    /**
+     * Returns a customised generator spec.
+     *
+     * @param gen specs available out of the box
+     * @return generator spec
+     */
+    GeneratorSpec<V> getSpec(Generators gen);
+}

--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -17,12 +17,9 @@ package org.instancio;
 
 import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
-import org.instancio.generator.GeneratorSpec;
-import org.instancio.generators.Generators;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -233,12 +230,11 @@ public interface InstancioApi<T> {
      * }</pre>
      *
      * @param selector for fields and/or classes this method should be applied to
-     * @param gen      provider of built-in generators
-     * @param <V>      type of the value to generate
-     * @param <S>      generator spec type
+     * @param gen      provider of customisable built-in generators (also known as specs)
+     * @param <V>      type of object to generate
      * @return API builder reference
      */
-    <V, S extends GeneratorSpec<V>> InstancioApi<T> generate(TargetSelector selector, Function<Generators, S> gen);
+    <V> InstancioApi<T> generate(TargetSelector selector, GeneratorSpecProvider<V> gen);
 
     /**
      * A callback that gets invoked after an object has been fully populated.

--- a/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
@@ -15,10 +15,10 @@
  */
 package org.instancio.internal;
 
+import org.instancio.GeneratorSpecProvider;
 import org.instancio.TypeTokenSupplier;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.generator.Generator;
-import org.instancio.generators.Generators;
 import org.instancio.internal.nodes.Node;
 import org.instancio.internal.util.Format;
 import org.instancio.internal.util.ReflectionUtils;
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 public final class ApiValidator {
@@ -150,7 +149,7 @@ public final class ApiValidator {
                 + (node.getField() == null ? "" : "%nField: " + node.getField());
     }
 
-    public static void validateGeneratorFunction(@Nullable final Function<Generators, ?> gen) {
+    public static void validateGeneratorFunction(final GeneratorSpecProvider<?> gen) {
         isTrue(gen != null, () ->
                 String.format("%nThe second argument of 'generate()' method must not be null."
                         + "%nTo generate a null value, use 'supply(SelectorGroup, () -> null)"

--- a/instancio-core/src/main/java/org/instancio/internal/InstancioApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioApiImpl.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.internal;
 
+import org.instancio.GeneratorSpecProvider;
 import org.instancio.InstancioApi;
 import org.instancio.Model;
 import org.instancio.OnCompleteCallback;
@@ -22,13 +23,10 @@ import org.instancio.Result;
 import org.instancio.TargetSelector;
 import org.instancio.TypeTokenSupplier;
 import org.instancio.generator.Generator;
-import org.instancio.generator.GeneratorSpec;
-import org.instancio.generators.Generators;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.settings.Settings;
 
 import java.util.Arrays;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -62,15 +60,11 @@ public class InstancioApiImpl<T> implements InstancioApi<T> {
     }
 
     @Override
-    public <V, S extends GeneratorSpec<V>> InstancioApi<T> generate(
-            final TargetSelector selector,
-            final Function<Generators, S> gen) {
-
+    public <V> InstancioApi<T> generate(final TargetSelector selector, final GeneratorSpecProvider<V> gen) {
         ApiValidator.validateGeneratorFunction(gen);
         modelContextBuilder.withGeneratorSpec(selector, gen);
         return this;
     }
-
 
     @Override
     public <V> InstancioApi<T> onComplete(

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -15,14 +15,13 @@
  */
 package org.instancio.internal.context;
 
+import org.instancio.GeneratorSpecProvider;
 import org.instancio.Mode;
 import org.instancio.OnCompleteCallback;
 import org.instancio.Random;
 import org.instancio.TargetSelector;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
-import org.instancio.generator.GeneratorSpec;
-import org.instancio.generators.Generators;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.ThreadLocalRandom;
 import org.instancio.internal.ThreadLocalSettings;
@@ -51,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.instancio.internal.context.ModelContextHelper.buildRootTypeMap;
@@ -222,7 +220,7 @@ public final class ModelContext<T> {
         private final Class<T> rootClass;
         private final List<Class<?>> rootTypeParameters = new ArrayList<>();
         private final Map<TargetSelector, Class<?>> subtypeSelectors = new LinkedHashMap<>();
-        private final Map<TargetSelector, Function<Generators, ? extends GeneratorSpec<?>>> generatorSpecSelectors = new LinkedHashMap<>();
+        private final Map<TargetSelector, GeneratorSpecProvider<?>> generatorSpecSelectors = new LinkedHashMap<>();
         private final Map<TargetSelector, Generator<?>> generatorSelectors = new LinkedHashMap<>();
         private final Map<TargetSelector, OnCompleteCallback<?>> onCompleteCallbacks = new LinkedHashMap<>();
         private final Set<TargetSelector> ignoredTargets = new LinkedHashSet<>();
@@ -258,7 +256,7 @@ public final class ModelContext<T> {
             return this;
         }
 
-        public Builder<T> withGeneratorSpec(final TargetSelector selector, final Function<Generators, ? extends GeneratorSpec<?>> spec) {
+        public <V> Builder<T> withGeneratorSpec(final TargetSelector selector, final GeneratorSpecProvider<V> spec) {
             this.generatorSpecSelectors.put(preProcess(selector, rootClass), spec);
             return this;
         }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
@@ -15,9 +15,9 @@
  */
 package org.instancio.test.features.validation;
 
+import org.instancio.GeneratorSpecProvider;
 import org.instancio.Instancio;
 import org.instancio.exception.InstancioApiException;
-import org.instancio.generator.GeneratorSpec;
 import org.instancio.generators.Generators;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.support.pojo.arrays.TwoArraysOfItemString;
@@ -46,7 +46,6 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.all;
@@ -149,7 +148,7 @@ class GeneratorMismatchTest {
     private static <T> void assertMessageContains(final Class<?> typeToCreate,
                                                   final Class<?> selectedType,
                                                   final String expectedGeneratorMethod,
-                                                  final Function<Generators, GeneratorSpec<T>> genFn) {
+                                                  final GeneratorSpecProvider<T> genFn) {
 
         assertThatThrownBy(() -> Instancio.of(typeToCreate)
                 .generate(all(selectedType), genFn)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.internal.context;
 
+import org.instancio.GeneratorSpecProvider;
 import org.instancio.Mode;
 import org.instancio.Random;
 import org.instancio.Select;
@@ -27,7 +28,6 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.Hints;
 import org.instancio.generator.specs.ArrayGeneratorSpec;
-import org.instancio.generator.specs.StringGeneratorSpec;
 import org.instancio.generators.Generators;
 import org.instancio.internal.generator.misc.GeneratorDecorator;
 import org.instancio.internal.generator.misc.SupplierAdapter;
@@ -49,12 +49,12 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.all;
+import static org.instancio.Select.allStrings;
 import static org.instancio.Select.field;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -171,11 +171,11 @@ class ModelContextTest {
 
         final ArrayGeneratorSpec<Object> petsSpec = generators.array().subtype(Pet[].class).length(3);
 
-        final StringGeneratorSpec stringSpec = generators.string().minLength(5).allowEmpty();
+        final GeneratorSpec<String> stringSpec = generators.string().minLength(5).allowEmpty();
 
         ModelContext<?> ctx = ModelContext.builder(Person.class)
                 .withGeneratorSpec(field("pets"), gens -> petsSpec)
-                .withGeneratorSpec(all(String.class), gen -> stringSpec)
+                .withGeneratorSpec(allStrings(), gen -> stringSpec)
                 .build();
 
         assertThat(ctx.getGenerator(mockNode(Person.class, PETS_FIELD))).isPresent().get().isSameAs(petsSpec);
@@ -257,10 +257,10 @@ class ModelContextTest {
 
     @Test
     void toBuilder() {
-        final Generator<?> allStringsGenerator = random -> "foo";
-        final Generator<?> addressCityGenerator = random -> "bar";
-        final Generator<?> petsGenerator = random -> new Pet[0];
-        final Function<Generators, ? extends GeneratorSpec<?>> petsGeneratorFn = (gen) -> petsGenerator;
+        final Generator<String> allStringsGenerator = random -> "foo";
+        final Generator<String> addressCityGenerator = random -> "bar";
+        final Generator<Pet[]> petsGenerator = random -> new Pet[0];
+        final GeneratorSpecProvider<Pet[]> petsGeneratorFn = (gen) -> petsGenerator;
         final Class<UUID> ignoredClass = UUID.class;
         final Class<Date> nullableClass = Date.class;
         final long seed = 37635;


### PR DESCRIPTION
This replaces `java.util.function.Function` argument making the API clearer while remaining backward compatible.