### PR TITLE
Make the best effort to create hash-based collections of requested size.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/util/Constants.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Constants.java
@@ -15,12 +15,21 @@
  */
 package org.instancio.internal.util;
 
+import java.util.Collection;
+import java.util.Map;
+
 public final class Constants {
 
     /**
      * Percentage by which to adjust a min/max range if min is set higher than max, or vice versa.
      */
     public static final int RANGE_ADJUSTMENT_PERCENTAGE = 50;
+
+    /**
+     * Number of times {@link Collection#add(Object)} or {@link Map#put(Object, Object)}
+     * can be unsuccessful before population is aborted.
+     */
+    public static final int FAILED_COLLECTION_ADD_THRESHOLD = 1000;
 
     /**
      * Default min array/collection size.

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorSupportedTypesTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorSupportedTypesTest.java
@@ -33,13 +33,18 @@ import java.util.NavigableSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.Stack;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TransferQueue;
 import java.util.stream.Stream;
 
@@ -55,11 +60,16 @@ class CollectionGeneratorSupportedTypesTest {
                 Arguments.of(new TypeToken<BlockingDeque<UUID>>() {}, LinkedBlockingDeque.class),
                 Arguments.of(new TypeToken<BlockingQueue<UUID>>() {}, LinkedBlockingQueue.class),
                 Arguments.of(new TypeToken<Collection<UUID>>() {}, ArrayList.class),
+                Arguments.of(new TypeToken<ConcurrentLinkedQueue<UUID>>() {}, ConcurrentLinkedQueue.class),
+                Arguments.of(new TypeToken<CopyOnWriteArrayList<UUID>>() {}, CopyOnWriteArrayList.class),
+                Arguments.of(new TypeToken<CopyOnWriteArraySet<UUID>>() {}, CopyOnWriteArraySet.class),
                 Arguments.of(new TypeToken<Deque<UUID>>() {}, ArrayDeque.class),
                 Arguments.of(new TypeToken<List<UUID>>() {}, ArrayList.class),
                 Arguments.of(new TypeToken<NavigableSet<UUID>>() {}, TreeSet.class),
+                Arguments.of(new TypeToken<PriorityBlockingQueue<UUID>>() {}, PriorityBlockingQueue.class),
                 Arguments.of(new TypeToken<Set<UUID>>() {}, HashSet.class),
                 Arguments.of(new TypeToken<SortedSet<UUID>>() {}, TreeSet.class),
+                Arguments.of(new TypeToken<Stack<UUID>>() {}, Stack.class),
                 Arguments.of(new TypeToken<TransferQueue<UUID>>() {}, LinkedTransferQueue.class),
                 Arguments.of(new TypeToken<Queue<UUID>>() {}, ArrayDeque.class)
         );

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorSupportedTypesTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorSupportedTypesTest.java
@@ -24,11 +24,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
@@ -46,9 +48,11 @@ class MapGeneratorSupportedTypesTest {
                 Arguments.of(new TypeToken<ConcurrentHashMap<UUID, String>>() {}, ConcurrentHashMap.class),
                 Arguments.of(new TypeToken<ConcurrentMap<UUID, String>>() {}, ConcurrentHashMap.class),
                 Arguments.of(new TypeToken<ConcurrentNavigableMap<UUID, String>>() {}, ConcurrentSkipListMap.class),
+                Arguments.of(new TypeToken<Hashtable<UUID, String>>() {}, Hashtable.class),
                 Arguments.of(new TypeToken<Map<UUID, String>>() {}, HashMap.class),
                 Arguments.of(new TypeToken<NavigableMap<UUID, String>>() {}, TreeMap.class),
-                Arguments.of(new TypeToken<SortedMap<UUID, String>>() {}, TreeMap.class)
+                Arguments.of(new TypeToken<SortedMap<UUID, String>>() {}, TreeMap.class),
+                Arguments.of(new TypeToken<WeakHashMap<UUID, String>>() {}, WeakHashMap.class)
         );
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/mode/StrictModeLargeClassTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/mode/StrictModeLargeClassTest.java
@@ -27,6 +27,7 @@ import org.instancio.test.support.pojo.generics.foobarbaz.Foo;
 import org.instancio.test.support.pojo.performance.LargeClass;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -50,6 +51,7 @@ class StrictModeLargeClassTest {
             .set(Keys.COLLECTION_MIN_SIZE, 1000);
 
     @Test
+    @NonDeterministicTag("Callback counts are approximate")
     @FeatureTag({Feature.ON_COMPLETE, Feature.SCOPE})
     void largeClassWithScopedSelectors() {
         final AtomicInteger callbackCount = new AtomicInteger();
@@ -84,6 +86,6 @@ class StrictModeLargeClassTest {
                 .create();
 
         // Verify roughly the expected number of callbacks
-        assertThat(callbackCount.get()).isBetween(200_000, 250_000);
+        assertThat(callbackCount.get()).isBetween(200_000, 300_000);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamTest.java
@@ -72,7 +72,7 @@ class CreateStreamTest {
 
         assertThat(results)
                 .hasSize(EXPECTED_SIZE)
-                .allSatisfy(s -> assertThat(s.length()).isEqualTo(overriddenLength));
+                .allSatisfy(s -> assertThat(s).hasSize(overriddenLength));
     }
 
     @Test
@@ -85,7 +85,7 @@ class CreateStreamTest {
 
         assertThat(results)
                 .hasSize(EXPECTED_SIZE)
-                .allSatisfy(s -> assertThat(s.length()).isEqualTo(overriddenLength));
+                .allSatisfy(s -> assertThat(s).hasSize(overriddenLength));
     }
 
     @Test


### PR DESCRIPTION
For instance, if a `Set<Integer>` of size 10 is requested, with integer range `[1..10]`, there is a high chance of collisions which may result in a set of size less than 10. This commit address this edge case. It also handles the case where requested size is impossible, e.g. `Set<Boolean>` of size 5.