### PR TITLE
Renamed static util methods in Format.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/assigners/FieldAssigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/FieldAssigner.java
@@ -61,7 +61,7 @@ public class FieldAssigner implements Assigner {
             // Wrong type is being assigned to a field.
             // Always propagate type mismatch errors as it's either a bug or user error.
             final String msg = AssignerErrorUtil.getFieldAssignmentErrorMessage(
-                    value, Format.field(field), ex);
+                    value, Format.formatField(field), ex);
 
             throw new InstancioApiException(msg, ex);
         } catch (Exception ex) {
@@ -72,7 +72,7 @@ public class FieldAssigner implements Assigner {
     private void handleError(final Field field, final Object value, final Exception ex) {
         if (onSetFieldError == OnSetFieldError.FAIL) {
             final String msg = AssignerErrorUtil.getFieldAssignmentErrorMessage(
-                    value, Format.field(field), ex);
+                    value, Format.formatField(field), ex);
 
             throw new InstancioApiException(msg, ex);
         }

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
@@ -112,7 +112,7 @@ public class MethodAssigner implements Assigner {
 
         if (onSetMethodError == OnSetMethodError.FAIL) {
             throw new InstancioApiException(AssignerErrorUtil.getSetterInvocationErrorMessage(
-                    arg, onSetMethodError, Format.method(method), ex), ex);
+                    arg, onSetMethodError, Format.formatMethod(method), ex), ex);
         }
 
         if (onSetMethodError == OnSetMethodError.ASSIGN_FIELD) {
@@ -133,7 +133,7 @@ public class MethodAssigner implements Assigner {
 
         if (onSetMethodNotFound == OnSetMethodNotFound.FAIL) {
             throw new InstancioApiException(AssignerErrorUtil.getSetterNotFoundMessage(
-                    Format.field(node.getField()), methodName, setterStyle));
+                    Format.formatField(node.getField()), methodName, setterStyle));
         }
 
         if (onSetMethodNotFound == OnSetMethodNotFound.ASSIGN_FIELD) {
@@ -151,7 +151,7 @@ public class MethodAssigner implements Assigner {
                 final Class<?> klass = field.getDeclaringClass();
                 return Optional.of(klass.getDeclaredMethod(methodName, field.getType()));
             } catch (NoSuchMethodException ex) {
-                logException("Resolved setter method '{}' for field '{}' does not exist", ex, methodName, Format.field(field));
+                logException("Resolved setter method '{}' for field '{}' does not exist", ex, methodName, Format.formatField(field));
             }
         }
         return Optional.empty();

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
@@ -100,7 +100,7 @@ public final class PrimitiveAndWrapperSelectorImpl implements Selector, Flattene
     public String toString() {
         String str = API_METHOD_NAMES.get(primitive.getTargetClass());
         if (!primitive.getScopes().isEmpty()) {
-            str += ", " + Format.scopes(primitive.getScopes());
+            str += ", " + Format.formatScopes(primitive.getScopes());
         }
         return str;
     }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
@@ -189,7 +189,7 @@ public class SelectorImpl implements Selector, GroupableSelector, Flattener, Unu
             sb.append(')');
 
             if (!scopes.isEmpty()) {
-                sb.append(", ").append(Format.scopes(scopes));
+                sb.append(", ").append(Format.formatScopes(scopes));
             }
         }
         return sb.toString();

--- a/instancio-core/src/main/java/org/instancio/internal/util/Format.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Format.java
@@ -31,14 +31,14 @@ import static java.util.stream.Collectors.joining;
 public final class Format {
     private static final Pattern PACKAGE_PATTERN = Pattern.compile("\\w+\\.");
 
-    public static String field(final Field field) {
+    public static String formatField(final Field field) {
         return String.format("%s %s.%s",
                 withoutPackage(field.getType()),
                 withoutPackage(field.getDeclaringClass()),
                 field.getName());
     }
 
-    public static String method(final Method method) {
+    public static String formatMethod(final Method method) {
         return String.format("%s.%s(%s)",
                 withoutPackage(method.getDeclaringClass()),
                 method.getName(),
@@ -49,7 +49,7 @@ public final class Format {
         return PACKAGE_PATTERN.matcher(type.getTypeName()).replaceAll("");
     }
 
-    public static String scopes(final List<Scope> scopes) {
+    public static String formatScopes(final List<Scope> scopes) {
         return scopes.stream()
                 .map(ScopeImpl.class::cast)
                 .map(s -> s.getFieldName() == null

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/FormatTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/FormatTest.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.util;
 
 import org.instancio.test.support.pojo.generics.foobarbaz.Foo;
+import org.instancio.test.support.pojo.person.Address;
 import org.instancio.test.support.pojo.person.Person;
 import org.instancio.testsupport.fixtures.Types;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.scope;
 
 class FormatTest {
 
@@ -41,21 +43,32 @@ class FormatTest {
     }
 
     @Test
-    void field() {
-        assertThat(Format.field(ReflectionUtils.getField(Person.class, "name")))
+    void formatField() {
+        assertThat(Format.formatField(ReflectionUtils.getField(Person.class, "name")))
                 .isEqualTo("String Person.name");
 
-        assertThat(Format.field(ReflectionUtils.getField(Nested1.Nested2.class, "nested")))
+        assertThat(Format.formatField(ReflectionUtils.getField(Nested1.Nested2.class, "nested")))
                 .isEqualTo("String FormatTest$Nested1$Nested2.nested");
     }
 
     @Test
-    void method() throws NoSuchMethodException {
-        assertThat(Format.method(Person.class.getMethod("setName", String.class)))
+    void formatMethod() throws NoSuchMethodException {
+        assertThat(Format.formatMethod(Person.class.getMethod("setName", String.class)))
                 .isEqualTo("Person.setName(String)");
 
-        assertThat(Format.method(Nested1.Nested2.class.getMethod("setNested", String.class)))
+        assertThat(Format.formatMethod(Nested1.Nested2.class.getMethod("setNested", String.class)))
                 .isEqualTo("FormatTest$Nested1$Nested2.setNested(String)");
+    }
+
+    @Test
+    void formatScopes() {
+        assertThat(Format.formatScopes(Collections.emptyList())).isEmpty();
+
+        assertThat(Format.formatScopes(Collections.singletonList(scope(Person.class))))
+                .isEqualTo("scope(Person)");
+
+        assertThat(Format.formatScopes(Arrays.asList(scope(Person.class), scope(Address.class, "city"))))
+                .isEqualTo("scope(Person), scope(Address, \"city\")");
     }
 
     @Test


### PR DESCRIPTION
This is to avoid confusion between the public API `Select.field()` and the util method `Format.field()`.