### PR TITLE
Bug fix: specifying size 0 for `EnumMap` was generating a null map.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.instancio.internal.util.ExceptionHandler.conditionalFailOnError;
 import static org.instancio.internal.util.ObjectUtils.defaultIfNull;
@@ -197,7 +198,12 @@ class InstancioEngine {
 
         return context.getContainerFactories()
                 .stream()
-                .map(it -> it.createFromOtherFunction(node.getTargetClass()))
+                .map(it -> it.createFromOtherFunction(
+                        node.getTargetClass(),
+                        node.getChildren()
+                                .stream()
+                                .map(Node::getTargetClass)
+                                .collect(Collectors.toList())))
                 .filter(Objects::nonNull)
                 .findFirst()
                 .map(fn -> fn.apply(generatorResult.getValue()))

--- a/instancio-core/src/main/java/org/instancio/internal/context/InternalContainerFactoryProviderImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/InternalContainerFactoryProviderImpl.java
@@ -18,6 +18,7 @@ package org.instancio.internal.context;
 import org.instancio.internal.spi.InternalContainerFactoryProvider;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -25,14 +26,22 @@ class InternalContainerFactoryProviderImpl implements InternalContainerFactoryPr
 
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public <T, R> Function<T, R> createFromOtherFunction(final Class<R> type) {
+    public <S, T> Function<S, T> createFromOtherFunction(
+            final Class<T> targetType,
+            final List<Class<?>> typeArguments) {
+
         Function<?, ?> result = null;
 
-        if (type == EnumMap.class) {
-            result = (Function<Map<?, ?>, EnumMap<?, ?>>) other -> new EnumMap(other);
+        if (targetType == EnumMap.class) {
+            result = (Function<Map<?, ?>, EnumMap<?, ?>>) other -> {
+                if (other.isEmpty()) {
+                    return new EnumMap(typeArguments.iterator().next());
+                }
+                return new EnumMap(other);
+            };
         }
 
-        return (Function<T, R>) result;
+        return (Function<S, T>) result;
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/spi/InternalContainerFactoryProvider.java
+++ b/instancio-core/src/main/java/org/instancio/internal/spi/InternalContainerFactoryProvider.java
@@ -17,6 +17,7 @@ package org.instancio.internal.spi;
 
 import org.instancio.documentation.InternalApi;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -28,7 +29,18 @@ import java.util.function.Function;
 @InternalApi
 public interface InternalContainerFactoryProvider {
 
-    <T, R> Function<T, R> createFromOtherFunction(Class<R> type);
+    /**
+     * Returns a function that converts a source object of type
+     * {@code S} to the target type {@code T}.
+     *
+     * @param targetType    the type to be created
+     * @param typeArguments type arguments of the source object, or an empty list
+     *                      if the source object is not generic
+     * @param <S>           source type
+     * @param <T>           target type
+     * @return conversion function
+     */
+    <S, T> Function<S, T> createFromOtherFunction(Class<T> targetType, List<Class<?>> typeArguments);
 
     boolean isContainerClass(Class<?> type);
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/EnumMapTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/EnumMapTest.java
@@ -49,6 +49,15 @@ class EnumMapTest {
                 .isExactlyInstanceOf(EnumMap.class);
     }
 
+    @Test
+    void createEmpty() {
+        final EnumMap<Gender, String> result = Instancio.of(ENUM_MAP)
+                .generate(root(), gen -> gen.map().size(0))
+                .create();
+
+        assertThat(result).isEmpty();
+    }
+
     @RepeatedTest(10)
     void with() {
         final EnumMap<Gender, String> result = Instancio.of(ENUM_MAP)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/spi/FeatureTestsContainerFactoryProvider.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/spi/FeatureTestsContainerFactoryProvider.java
@@ -19,12 +19,13 @@ import org.instancio.internal.spi.InternalContainerFactoryProvider;
 import org.instancio.test.support.pojo.containers.BuildableList;
 import org.instancio.test.support.pojo.containers.OptionalLike;
 
+import java.util.List;
 import java.util.function.Function;
 
 public class FeatureTestsContainerFactoryProvider implements InternalContainerFactoryProvider {
 
     @Override
-    public <T, R> Function<T, R> createFromOtherFunction(final Class<R> type) {
+    public <T, R> Function<T, R> createFromOtherFunction(final Class<R> type, final List<Class<?>> typeArguments) {
         return null; // none yet
     }
 


### PR DESCRIPTION
Expectation: should generate an empty map instead of null.