### PR TITLE
Modified predicate selector precedence rules - last one wins.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
@@ -134,9 +134,10 @@ final class SelectorMap<V> {
     private Optional<V> getPredicateSelectorMatch(final Node node) {
         PredicateSelectorEntry<V> classPredicate = null;
 
-        // If there's a field predicate anywhere in the list, then return the first one found.
-        // Otherwise, return the first class predicate.
-        for (PredicateSelectorEntry<V> entry : predicateSelectors) {
+        // If there's a field predicate anywhere in the list, then return the last one found.
+        // Otherwise, return the last class predicate.
+        for (int i = predicateSelectors.size() - 1; i >= 0; i--) {
+            final PredicateSelectorEntry<V> entry = predicateSelectors.get(i);
             if (entry.predicateSelector.getSelectorTargetKind() == SelectorTargetKind.FIELD) {
                 if (isPredicateMatch(node, entry)) {
                     entry.matched = true;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorPrecedenceTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorPrecedenceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.selector;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.pojo.misc.StringFields;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.asserts.Asserts.assertAllNulls;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.PREDICATE_SELECTOR, Feature.SELECTOR_PRECEDENCE,})
+@ExtendWith(InstancioExtension.class)
+class PredicateSelectorPrecedenceTest {
+
+    @Test
+    void lastFieldSelectorWins() {
+        final StringHolder result = Instancio.of(StringHolder.class)
+                .set(fields().ofType(String.class), "foo") // unused
+                .set(fields().ofType(String.class), "bar") // wins
+                .lenient()
+                .create();
+
+        assertThat(result.getValue()).isEqualTo("bar");
+    }
+
+    @Test
+    void lastClassSelectorWins() {
+        final StringFields result = Instancio.of(StringFields.class)
+                .set(types().of(String.class), "foo") // unused
+                .set(types().of(String.class), "bar") // wins
+                .lenient()
+                .create();
+
+        assertThatObject(result).hasAllFieldsOfTypeEqualTo(String.class, "bar");
+    }
+
+    @Test
+    void fieldSelectorWinsOverClassSelector() {
+        final StringFields result = Instancio.of(StringFields.class)
+                .set(types().of(String.class), "foo") // unused
+                .set(fields().ofType(String.class), "bar") // wins
+                .lenient()
+                .create();
+
+        assertThatObject(result).hasAllFieldsOfTypeEqualTo(String.class, "bar");
+    }
+
+    @Test
+    void setAllFieldsNullToAndOverrideSomeFields() {
+        final StringFields result = Instancio.of(StringFields.class)
+                .set(fields(), null)
+                .set(fields().annotated(StringFields.Two.class), "foo")
+                .create();
+
+        assertThat(result.getTwo()).isEqualTo("foo");
+        assertAllNulls(result.getOne(), result.getThree(), result.getFour());
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectorPrecedenceTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectorPrecedenceTest.java
@@ -66,7 +66,7 @@ class SelectorPrecedenceTest {
     void verifySelectorPrecedenceUsingSet() {
         // Note: the order of set() methods in this particular test does not matter.
         // It would have mattered, if there was more than 1 selector per target,
-        // in which case the first wins and the other(s) result in "unused selectors" error.
+        // in which case the last wins and the other(s) result in "unused selectors" error.
         final StringFields result = Instancio.of(StringFields.class)
                 .set(field("four"), REGULAR_FIELD)
                 .set(types().of(String.class), PREDICATE_TYPE)
@@ -100,10 +100,10 @@ class SelectorPrecedenceTest {
     @DisplayName("supply() using a field selector should take precedence over class selector, regardless of method order")
     void supplyUsingFieldSelectorShouldTakePrecedenceOverClassSelector() {
         final Person result = Instancio.of(Person.class)
-                // field() first
+                // Target address using field first, then class
                 .supply(field("address"), () -> null)
                 .supply(all(Address.class), Address::new)
-                // all() first
+                // Target strings using class first, then field
                 .set(allStrings(), "foo")
                 .set(field("name"), "bar")
                 .lenient()
@@ -111,7 +111,10 @@ class SelectorPrecedenceTest {
 
         assertThat(result.getAddress()).isNull();
         assertThat(result.getName()).isEqualTo("bar");
-        assertThat(result.getPets()).extracting(Pet::getName).containsOnly("foo");
+        assertThat(result.getPets())
+                .as("Field selector should win")
+                .extracting(Pet::getName)
+                .containsOnly("foo");
     }
 
     @Test

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -324,9 +324,10 @@ Address address = Instancio.of(Address.class)
 ```
 
 This will produce an address object with all strings set to "foo". However, since field selectors
-have higher precedence, the city will be set to "bar". Similarly, in the following example,
-the city will also be set to "bar" because the predicate selector created by the `fields()`
-method has lower precedence than the regular `field()` selector:
+have higher precedence, the city will be set to "bar".
+
+In the following example, the city will also be set to "bar" because predicate `fields()` selector
+has lower precedence than the regular `field()` selector:
 
 ``` java linenums="1"
 Address address = Instancio.of(Address.class)
@@ -334,6 +335,36 @@ Address address = Instancio.of(Address.class)
     .set(field("city"), "bar")
     .create();
 ```
+
+#### Multiple matching selectors
+
+When more than one selector matches a given target, then the last selector wins.
+This rule applies to both, regular and predicate selectors.
+
+In case of regular selectors, if the two are identical, the last selector simply
+replaces the first (internally, regular selectors are stored as `Map` keys).
+
+``` java linenums="1"
+Address address = Instancio.of(Address.class)
+    .set(field(Address.class, "city"), "foo")
+    .set(field(Address.class, "city"), "bar") // wins!
+    .create();
+```
+
+Predicate selectors, on the other hand, are stored as a `List` and evaluated
+sequentially starting from the last entry.
+
+``` java linenums="1"
+Address address = Instancio.of(Address.class)
+    .set(fields().named("city"), "foo")
+    .set(fields().named("city"), "bar") // wins!
+    .lenient()
+    .create();
+```
+
+In this particular example, the first entry remains unused,
+therefore  `lenient()` mode must be enabled to prevent unused selector error
+(see [Selector Strictness](#selector-strictness)).
 
 ### Selector Scopes
 


### PR DESCRIPTION
This change makes the behaviour consistent with regular selectors.