### PR TITLE
Resolve `@ParameterizedTest` argument types from the test method.

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/InstancioArgumentsProvider.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/InstancioArgumentsProvider.java
@@ -40,11 +40,9 @@ import java.util.stream.Stream;
  */
 public class InstancioArgumentsProvider implements ArgumentsProvider, AnnotationConsumer<InstancioSource> {
 
-    private InstancioSource instancioSource;
-
     @Override
     public void accept(final InstancioSource instancioSource) {
-        this.instancioSource = instancioSource;
+        // no-op - don't need anything from ths annotation
     }
 
     @Override
@@ -56,8 +54,9 @@ public class InstancioArgumentsProvider implements ArgumentsProvider, Annotation
 
         final Random random = threadLocalRandom.get();
         final Settings settings = threadLocalSettings.get();
-        final Object[] args = createObjectsGroupingByType(instancioSource.value(), random, settings);
-        return Stream.of(Arguments.of(args));
+        final Class<?>[] paramTypes = context.getRequiredTestMethod().getParameterTypes();
+        final Object[] args = createObjectsGroupingByType(paramTypes, random, settings);
+        return args.length == 0 ? Stream.of() : Stream.of(Arguments.of(args));
     }
 
     /*

--- a/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * class ExampleTest {
  *
  *     &#064;ParameterizedTest
- *     <b>&#064;InstancioSource(Person.class)</b>
+ *     <b>&#064;InstancioSource</b>
  *     void someTestMethod(Person person) {
  *         // ... use supplied person
  *     }
@@ -52,6 +52,10 @@ public @interface InstancioSource {
      * represents a parameter in the {@code ParameterizedTest} method.
      *
      * @return parameter types to generate
+     * @deprecated parameter types will be resolved from method arguments,
+     * therefore specifying the types via the annotation is no longer necessary
+     * (this method will be removed in version {@code 3.0.0}).
      */
-    Class<?>[] value();
+    @Deprecated
+    Class<?>[] value() default {};
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/WithSettingsAnnotationTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/WithSettingsAnnotationTest.java
@@ -49,8 +49,8 @@ class WithSettingsAnnotationTest {
     @Test
     void withSettingsOverride() {
         assertThat(Instancio.of(int.class).withSettings(Settings.create()
-                        .set(Keys.INTEGER_MIN, -2)
-                        .set(Keys.INTEGER_MAX, -2))
+                .set(Keys.INTEGER_MIN, -2)
+                .set(Keys.INTEGER_MAX, -2))
                 .create())
                 .isEqualTo(-2);
     }
@@ -60,7 +60,7 @@ class WithSettingsAnnotationTest {
         assertThat(Instancio.create(int.class)).isEqualTo(-1);
     }
 
-    @InstancioSource(int.class)
+    @InstancioSource
     @ParameterizedTest
     void withSettingsWithParameterizedTest(int value) {
         assertThat(value).isEqualTo(-1);

--- a/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedInstancioSourceTest.java
+++ b/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedInstancioSourceTest.java
@@ -34,7 +34,7 @@ class GlobalSeedInstancioSourceTest {
     private static final long ANNOTATION_SEED = -123;
 
     @ParameterizedTest
-    @InstancioSource(value = {String.class, String.class})
+    @InstancioSource
     void parameterized(final String param1, final String param2) {
         assertThat(param1)
                 .as("Distinct parameter values should be generated")
@@ -50,7 +50,7 @@ class GlobalSeedInstancioSourceTest {
 
     @Seed(ANNOTATION_SEED)
     @ParameterizedTest
-    @InstancioSource(value = {String.class, String.class})
+    @InstancioSource
     void parameterizedWithSeedAnnotation(final String param1, final String param2) {
         assertThat(param1)
                 .as("Distinct parameter values should be generated")

--- a/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedWithInstancioExtensionWithSettingsTest.java
+++ b/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedWithInstancioExtensionWithSettingsTest.java
@@ -88,7 +88,7 @@ class GlobalSeedWithInstancioExtensionWithSettingsTest {
     }
 
     @ParameterizedTest
-    @InstancioSource(value = {String.class, String.class})
+    @InstancioSource
     void parameterized(final String s1, final String s2) {
         assertThat(s1)
                 .as("Distinct values should be generated")

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioArgumentsProviderTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioArgumentsProviderTest.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,24 +43,18 @@ class InstancioArgumentsProviderTest {
     }
 
     @Test
-    void provideArguments() throws Exception {
+    void typesProvidedByTheAnnotationShouldBeIgnored() throws Exception {
         final Method method = InstancioArgumentsProviderTest.class.getDeclaredMethod("dummy");
         final InstancioSource instancioSource = method.getAnnotation(InstancioSource.class);
         final ExtensionContext mockContext = mock(ExtensionContext.class);
         when(mockContext.getTestMethod()).thenReturn(Optional.of(method));
+        when(mockContext.getRequiredTestMethod()).thenReturn(method);
 
         // Methods under test
         provider.accept(instancioSource);
         final Stream<? extends Arguments> stream = provider.provideArguments(mockContext);
 
-        assertThat(stream.collect(toList()))
-                .hasSize(1)
-                .extracting(Arguments::get)
-                .allSatisfy(params -> {
-                    assertThat(params).hasSize(2);
-                    assertThat(params[0]).isInstanceOf(String.class);
-                    assertThat(params[1]).isInstanceOf(Integer.class);
-                });
+        assertThat(stream).isEmpty();
     }
 
     @MethodSource("types")

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithSettingsAnnotationTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithSettingsAnnotationTest.java
@@ -17,9 +17,9 @@ package org.instancio.junit;
 
 import org.instancio.Instancio;
 import org.instancio.internal.ThreadLocalRandom;
+import org.instancio.internal.util.Sonar;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.internal.util.Sonar;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -83,7 +83,7 @@ class InstancioExtensionWithSettingsAnnotationTest {
         private final Settings nonStaticSettings = Settings.create();
 
         @ParameterizedTest
-        @InstancioSource(String.class)
+        @InstancioSource
         @DisplayName("Expecting the test to fail without running")
         @Disabled("Need to find a way to verify the error. JUnit's EngineTestKit swallows the exception.")
         @SuppressWarnings(Sonar.ADD_ASSERTION)

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
@@ -21,19 +21,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class InstancioSourceTest {
 
-    @InstancioSource(String.class)
+    @InstancioSource
     @ParameterizedTest
     void oneArg(final String arg) {
         assertThat(arg).isNotBlank();
     }
 
-    @InstancioSource({String.class, String.class})
+    @InstancioSource
     @ParameterizedTest
     void twoArgsSameType(final String first, final String second) {
         assertThat(first).isNotBlank().isNotEqualTo(second);
     }
 
-    @InstancioSource({First.class, Second.class})
+    @InstancioSource
     @ParameterizedTest
     void twoArgs(final First first, final Second second) {
         assertThat(first).isNotNull();

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceWithSeedTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceWithSeedTest.java
@@ -45,7 +45,7 @@ class InstancioSourceWithSeedTest {
             .set(Keys.STRING_MIN_LENGTH, STRING_MIN_LENGTH);
 
     @Seed(SEED)
-    @InstancioSource(String.class)
+    @InstancioSource
     @ParameterizedTest
     @DisplayName("Parameterized test: generate value using seed")
     void parameterizedWithSeed(final String value) {
@@ -64,7 +64,7 @@ class InstancioSourceWithSeedTest {
     }
 
     @NonDeterministicTag("Assuming the random seed will not be equal to the SEED constant")
-    @InstancioSource(StringHolder.class)
+    @InstancioSource
     @ParameterizedTest
     void withSettings(final StringHolder holder) {
         LOG.debug("ThreadLocalRandom seed: {}", ThreadLocalRandom.getInstance().get().getSeed());


### PR DESCRIPTION
Deprecate InstancioSource.values() for removal in v3.