### PR TITLE
Refactored handling of ignored nodes.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/ArrayElementNodePopulationFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ArrayElementNodePopulationFilter.java
@@ -18,6 +18,7 @@ package org.instancio.internal;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.util.ReflectionUtils;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +35,9 @@ class ArrayElementNodePopulationFilter implements NodePopulationFilter {
                               final AfterGenerate afterGenerate,
                               @Nullable final Object currentElementValue) {
 
+        if (elementNode.is(NodeKind.IGNORED)) {
+            return true;
+        }
         if (afterGenerate == AfterGenerate.DO_NOT_MODIFY) {
             return true;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/FieldNodePopulationFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/FieldNodePopulationFilter.java
@@ -19,6 +19,7 @@ import org.instancio.exception.InstancioException;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.util.ExceptionHandler;
 import org.instancio.internal.util.ReflectionUtils;
 
@@ -35,6 +36,9 @@ class FieldNodePopulationFilter implements NodePopulationFilter {
                               final AfterGenerate afterGenerate,
                               final Object objectContainingField) {
 
+        if (fieldNode.is(NodeKind.IGNORED)) {
+            return true;
+        }
         if (afterGenerate == AfterGenerate.DO_NOT_MODIFY) {
             return true;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
@@ -30,6 +30,7 @@ import org.instancio.internal.handlers.NodeHandler;
 import org.instancio.internal.handlers.UserSuppliedGeneratorHandler;
 import org.instancio.internal.handlers.UsingGeneratorResolverHandler;
 import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.reflection.instantiation.Instantiator;
 import org.instancio.settings.Keys;
 import org.slf4j.Logger;
@@ -70,12 +71,12 @@ class GeneratorFacade {
         return isEnabled ? new BeanValidationProcessor() : new NoopBeanValidationProvider();
     }
 
-    private boolean isIgnored(final Node node) {
-        return context.isIgnored(node) || (node.getField() != null && Modifier.isStatic(node.getField().getModifiers()));
+    private boolean hasStaticField(final Node node) {
+        return node.getField() != null && Modifier.isStatic(node.getField().getModifiers());
     }
 
     GeneratorResult generateNodeValue(final Node node) {
-        if (isIgnored(node)) {
+        if (node.is(NodeKind.IGNORED) || hasStaticField(node)) {
             return GeneratorResult.ignoredResult();
         }
 

--- a/instancio-core/src/main/java/org/instancio/internal/InternalModel.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InternalModel.java
@@ -43,6 +43,7 @@ final class InternalModel<T> implements Model<T> {
         final NodeContext nodeContext = NodeContext.builder()
                 .maxDepth(modelContext.getMaxDepth())
                 .rootTypeMap(modelContext.getRootTypeMap())
+                .ignoredSelectorMap(modelContext.getIgnoredSelectorMap())
                 .subtypeSelectorMap(modelContext.getSubtypeSelectorMap())
                 .subtypeMappingFromSettings(modelContext.getSettings().getSubtypeMap())
                 .containerFactories(modelContext.getContainerFactories())

--- a/instancio-core/src/main/java/org/instancio/internal/context/BooleanSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/BooleanSelectorMap.java
@@ -22,12 +22,12 @@ import org.instancio.internal.selectors.Flattener;
 import java.util.Collections;
 import java.util.Set;
 
-class BooleanSelectorMap {
+public class BooleanSelectorMap {
 
     private final Set<TargetSelector> targetSelectors;
     private final SelectorMap<Boolean> selectorMap = new SelectorMap<>();
 
-    BooleanSelectorMap(final Set<TargetSelector> targetSelectors) {
+    public BooleanSelectorMap(final Set<TargetSelector> targetSelectors) {
         this.targetSelectors = Collections.unmodifiableSet(targetSelectors);
         putAll(targetSelectors);
     }
@@ -40,7 +40,7 @@ class BooleanSelectorMap {
         return targetSelectors;
     }
 
-    boolean isTrue(final Node node) {
+    public boolean isTrue(final Node node) {
         return Boolean.TRUE.equals(selectorMap.getValue(node).orElse(false));
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -164,6 +164,10 @@ public final class ModelContext<T> {
         return onCompleteCallbackSelectorMap.getCallbacks(node);
     }
 
+    public BooleanSelectorMap getIgnoredSelectorMap() {
+        return ignoredSelectorMap;
+    }
+
     public SubtypeSelectorMap getSubtypeSelectorMap() {
         return subtypeSelectorMap;
     }

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/Node.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/Node.java
@@ -28,6 +28,15 @@ import java.util.Objects;
 
 public final class Node {
 
+    private static final Node IGNORED_NODE = builder()
+            .type(Object.class)
+            .rawType(Object.class)
+            .targetClass(Object.class)
+            .nodeKind(NodeKind.IGNORED)
+            .children(Collections.emptyList())
+            .nodeContext(NodeContext.builder().build())
+            .build();
+
     private final NodeContext nodeContext;
     private final Type type;
     private final Class<?> rawType;
@@ -50,6 +59,10 @@ public final class Node {
         nodeKind = builder.nodeKind;
         typeMap = new TypeMap(type, nodeContext.getRootTypeMap(), builder.additionalTypeMap);
         depth = parent == null ? 0 : parent.depth + 1;
+    }
+
+    public static Node ignoredNode() {
+        return IGNORED_NODE;
     }
 
     public NodeKind getNodeKind() {
@@ -210,6 +223,9 @@ public final class Node {
 
     @Override
     public String toString() {
+        if (nodeKind == NodeKind.IGNORED) {
+            return "Node[IGNORED]";
+        }
         final String nodeName = field == null
                 ? Format.withoutPackage(targetClass)
                 : Format.withoutPackage(parent.targetClass) + '.' + field.getName();

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
@@ -15,8 +15,10 @@
  */
 package org.instancio.internal.nodes;
 
+import jakarta.validation.constraints.NotNull;
 import org.instancio.InstancioApi;
 import org.instancio.TargetSelector;
+import org.instancio.internal.context.BooleanSelectorMap;
 import org.instancio.internal.context.SubtypeSelectorMap;
 import org.instancio.internal.nodes.resolvers.NodeKindArrayResolver;
 import org.instancio.internal.nodes.resolvers.NodeKindCollectionResolver;
@@ -37,6 +39,7 @@ import java.util.Optional;
 public final class NodeContext {
     private final int maxDepth;
     private final Map<TypeVariable<?>, Class<?>> rootTypeMap;
+    private final BooleanSelectorMap ignoredSelectorMap;
     private final SubtypeSelectorMap subtypeSelectorMap;
     private final Map<Class<?>, Class<?>> subtypeMappingFromSettings;
     private final TypeResolverFacade typeResolverFacade;
@@ -45,6 +48,7 @@ public final class NodeContext {
     private NodeContext(final Builder builder) {
         maxDepth = builder.maxDepth;
         rootTypeMap = builder.rootTypeMap;
+        ignoredSelectorMap = builder.ignoredSelectorMap;
         subtypeSelectorMap = builder.subtypeSelectorMap;
         subtypeMappingFromSettings = builder.subtypeMappingFromSettings;
         typeResolverFacade = new TypeResolverFacade();
@@ -79,7 +83,7 @@ public final class NodeContext {
      *   <li>a generator's {@code subtype()} method, e.g. {@code gen.collection().subtype()}</li>
      * </ol>
      */
-    Optional<Class<?>> getSubtype(final Node node) {
+    Optional<Class<?>> getSubtype(@NotNull final Node node) {
         final Optional<Class<?>> subtype = subtypeSelectorMap.getSubtype(node);
         if (subtype.isPresent()) {
             return subtype;
@@ -92,6 +96,10 @@ public final class NodeContext {
                 : Optional.of(subtypeFromSettings);
     }
 
+    boolean isIgnored(@NotNull final Node node) {
+        return ignoredSelectorMap.isTrue(node);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -99,6 +107,7 @@ public final class NodeContext {
     public static final class Builder {
         private int maxDepth;
         private Map<TypeVariable<?>, Class<?>> rootTypeMap = Collections.emptyMap();
+        private BooleanSelectorMap ignoredSelectorMap;
         private SubtypeSelectorMap subtypeSelectorMap;
         private Map<Class<?>, Class<?>> subtypeMappingFromSettings = Collections.emptyMap();
         private List<InternalContainerFactoryProvider> containerFactories = Collections.emptyList();
@@ -113,6 +122,11 @@ public final class NodeContext {
 
         public Builder rootTypeMap(final Map<TypeVariable<?>, Class<?>> rootTypeMap) {
             this.rootTypeMap = rootTypeMap;
+            return this;
+        }
+
+        public Builder ignoredSelectorMap(final BooleanSelectorMap ignoredSelectorMap) {
+            this.ignoredSelectorMap = ignoredSelectorMap;
             return this;
         }
 

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 /**
  * Helper class for creating a {@link Node} without its children.
  */
+@SuppressWarnings("PMD.CyclomaticComplexity")
 class NodeCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeCreator.class);
@@ -81,7 +82,11 @@ class NodeCreator {
             throw new InstancioException("Unsupported type: " + type.getClass());
         }
 
-        LOG.trace("Created node: {}", node);
+        if (node != null && nodeContext.isIgnored(node)) {
+            return Node.ignoredNode();
+        }
+
+        LOG.trace("Created node {} for type {}", node, type);
         return node;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -80,6 +80,10 @@ public final class NodeFactory {
      */
     @NotNull
     private List<Node> createChildlessChildren(@NotNull final Node node) {
+        if (node.is(NodeKind.IGNORED)) {
+            return Collections.emptyList();
+        }
+
         if (node.getDepth() >= nodeContext.getMaxDepth()) {
             LOG.trace("Maximum depth ({}) reached {}", nodeContext.getMaxDepth(), node);
             return Collections.emptyList();

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeKind.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeKind.java
@@ -21,6 +21,14 @@ package org.instancio.internal.nodes;
 public enum NodeKind {
 
     /**
+     * Represents a node marked with the {@code ignore()} method.
+     * An ignored node has no children.
+     *
+     * @since 2.10.0
+     */
+    IGNORED,
+
+    /**
      * Fallback kind. A node of this kind could represent either a POJO class
      * or a JDK type that is considered to be a leaf node, such as
      * {@code String}, {@code LocalDate}, {@code BigDecimal}, etc.

--- a/instancio-core/src/main/java/org/instancio/internal/util/RecordUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/RecordUtils.java
@@ -30,4 +30,10 @@ public final class RecordUtils {
         // no-op implementation until java 16
         return null;
     }
+
+    @SuppressWarnings({"PMD.ReturnEmptyCollectionRatherThanNull", "unused"})
+    public static Class<?>[] getComponentTypes(final Class<?> recordClass) {
+        // no-op implementation until java 16
+        return null; // NOSONAR
+    }
 }

--- a/instancio-core/src/main/java16/org/instancio/internal/util/RecordUtils.java
+++ b/instancio-core/src/main/java16/org/instancio/internal/util/RecordUtils.java
@@ -16,13 +16,11 @@
 package org.instancio.internal.util;
 
 import org.instancio.exception.InstancioException;
-import org.instancio.internal.util.Verify;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
-import java.util.Arrays;
 
 public final class RecordUtils {
     private static final Logger LOG = LoggerFactory.getLogger(RecordUtils.class);
@@ -42,10 +40,17 @@ public final class RecordUtils {
         }
     }
 
+    public static Class<?>[] getComponentTypes(final Class<?> recordClass) {
+        final RecordComponent[] components = recordClass.getRecordComponents();
+        final Class<?>[] args = new Class<?>[components.length];
+        for (int i = 0; i < args.length; i++) {
+            args[i] = components[i].getType();
+        }
+        return args;
+    }
+
     private static Constructor<?> getCanonicalConstructor(final Class<?> recordClass) {
-        final Class<?>[] componentTypes = Arrays.stream(recordClass.getRecordComponents())
-                .map(RecordComponent::getType)
-                .toArray(Class<?>[]::new);
+        final Class<?>[] componentTypes = getComponentTypes(recordClass);
         try {
             return recordClass.getDeclaredConstructor(componentTypes);
         } catch (NoSuchMethodException ex) {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cyclic/LargeCyclicSubclassTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cyclic/LargeCyclicSubclassTest.java
@@ -39,7 +39,7 @@ class LargeCyclicSubclassTest {
             .set(Keys.MAX_DEPTH, Integer.MAX_VALUE);
 
     @Test
-    @Timeout(value = 2)
+    @Timeout(2)
     void largeCyclicShouldBeGeneratedWithinGivenTimeout() {
         final LargeCyclicSubclass result = Instancio.create(LargeCyclicSubclass.class);
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/SelectorMapTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/SelectorMapTest.java
@@ -50,6 +50,7 @@ import static org.instancio.Select.scope;
 class SelectorMapTest {
     private final NodeContext nodeContext = NodeContext.builder()
             .maxDepth(Integer.MAX_VALUE)
+            .ignoredSelectorMap(new BooleanSelectorMap(Collections.emptySet()))
             .subtypeSelectorMap(new SubtypeSelectorMap(Collections.emptyMap()))
             .build();
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeTest.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.nodes;
 
 import org.instancio.TypeToken;
+import org.instancio.internal.context.BooleanSelectorMap;
 import org.instancio.internal.context.SubtypeSelectorMap;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.test.support.pojo.collections.lists.ListString;
@@ -44,10 +45,23 @@ import static org.instancio.testsupport.utils.NodeUtils.getChildNode;
 class NodeTest {
     private static final NodeContext NODE_CONTEXT = NodeContext.builder()
             .maxDepth(Integer.MAX_VALUE)
+            .ignoredSelectorMap(new BooleanSelectorMap(Collections.emptySet()))
             .subtypeSelectorMap(new SubtypeSelectorMap(Collections.emptyMap()))
             .build();
 
     private static final NodeFactory NODE_FACTORY = new NodeFactory(NODE_CONTEXT);
+
+    @Test
+    void ignoredNode() {
+        final Node node = Node.ignoredNode();
+        assertNode(node)
+                .hasChildrenOfSize(0)
+                .isOfKind(NodeKind.IGNORED)
+                .hasType(Object.class)
+                .hasRawType(Object.class)
+                .hasTargetClass(Object.class)
+                .hasEmptyTypeMap();
+    }
 
     @Test
     void getNodeKind() {
@@ -216,6 +230,11 @@ class NodeTest {
 
             assertThat(NODE_FACTORY.createRootNode(new TypeToken<Pair<Item<String>, Foo<List<Integer>>>>() {}.get()))
                     .hasToString("Node[Pair, depth=0, #chn=2, Pair<Item<String>, Foo<List<Integer>>>]");
+        }
+
+        @Test
+        void ignoredNode() {
+            assertThat(Node.ignoredNode()).hasToString("Node[IGNORED]");
         }
     }
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/templates/NodeTestTemplate.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/templates/NodeTestTemplate.java
@@ -16,6 +16,7 @@
 package org.instancio.testsupport.templates;
 
 import org.instancio.TypeTokenSupplier;
+import org.instancio.internal.context.BooleanSelectorMap;
 import org.instancio.internal.context.SubtypeSelectorMap;
 import org.instancio.internal.nodes.Node;
 import org.instancio.internal.nodes.NodeContext;
@@ -45,6 +46,7 @@ public abstract class NodeTestTemplate<T> {
     protected final void verifyingModelFromTypeToken() {
         final NodeContext nodeContext = NodeContext.builder()
                 .maxDepth(Integer.MAX_VALUE)
+                .ignoredSelectorMap(new BooleanSelectorMap(Collections.emptySet()))
                 .subtypeSelectorMap(new SubtypeSelectorMap(Collections.emptyMap()))
                 .build();
         final NodeFactory nodeFactory = new NodeFactory(nodeContext);

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/internal/reflection/RecordUtilsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/internal/reflection/RecordUtilsTest.java
@@ -16,6 +16,8 @@
 package org.instancio.internal.reflection;
 
 import org.instancio.internal.util.RecordUtils;
+import org.instancio.test.support.java16.record.AddressRecord;
+import org.instancio.test.support.java16.record.PersonRecord;
 import org.instancio.test.support.java16.record.PhoneRecord;
 import org.instancio.test.support.pojo.basic.IntegerHolderWithoutDefaultConstructor;
 import org.junit.jupiter.api.Test;
@@ -37,9 +39,18 @@ class RecordUtilsTest {
     @Test
     void instantiateNonRecordClass() {
         final Class<?> nonRecordClass = IntegerHolderWithoutDefaultConstructor.class;
-        assertThatThrownBy(() ->
-                RecordUtils.instantiate(nonRecordClass, 123, 345))
+        assertThatThrownBy(() -> RecordUtils.instantiate(nonRecordClass, 123, 345))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Class '%s' is not a record!", nonRecordClass.getName());
     }
+
+    @Test
+    void getComponentTypes() {
+        assertThat(RecordUtils.getComponentTypes(PersonRecord.class))
+                .containsExactly(String.class, int.class, AddressRecord.class);
+
+        assertThat(RecordUtils.getComponentTypes(RecordWithoutArgs.class)).isEmpty();
+    }
+
+    private record RecordWithoutArgs() {}
 }


### PR DESCRIPTION
In the original implementation, Instancio would generate an entire node hierarchy even if a node was marked with ignore(). The ignore logic itself was applied during object generation within the engine.

With the updated implementation, ignored nodes are handled by the node factory (no children are created for ignored nodes). This results in better performance when ignoring targets within cyclic classes.

Issue #391, #429