### PR TITLE
Added generator specs for internal generators.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Gen.java
+++ b/instancio-core/src/main/java/org/instancio/Gen.java
@@ -27,6 +27,8 @@ import org.instancio.generator.specs.OneOfArraySpec;
 import org.instancio.generator.specs.OneOfCollectionSpec;
 import org.instancio.generator.specs.ShortSpec;
 import org.instancio.generator.specs.StringSpec;
+import org.instancio.generators.FinanceSpecs;
+import org.instancio.generators.IdSpecs;
 import org.instancio.generators.IoSpecs;
 import org.instancio.generators.MathSpecs;
 import org.instancio.generators.NetSpecs;
@@ -237,6 +239,26 @@ public final class Gen {
      */
     public static TextSpecs text() {
         return new TextSpecs();
+    }
+
+    /**
+     * Provides identifier generators.
+     *
+     * @return built-in identifier generators
+     * @since 2.11.0
+     */
+    public static IdSpecs id() {
+        return new IdSpecs();
+    }
+
+    /**
+     * Provides finance-related generators.
+     *
+     * @return built-in finance-related generators
+     * @since 2.11.0
+     */
+    public static FinanceSpecs finance() {
+        return new FinanceSpecs();
     }
 
     private Gen() {

--- a/instancio-core/src/main/java/org/instancio/generator/ValueSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/ValueSpec.java
@@ -126,4 +126,12 @@ public interface ValueSpec<T> extends GeneratorSpec<T> {
                 .generate(all(typeArg), this)
                 .toModel();
     }
+
+    /**
+     * Specifies that a {@code null} value can be generated
+     *
+     * @return spec builder reference
+     * @since 2.11.0
+     */
+    ValueSpec<T> nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/CreditCardGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/CreditCardGeneratorSpec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+/**
+ * Spec for generating credit card numbers.
+ *
+ * @since 2.11.0
+ */
+public interface CreditCardGeneratorSpec extends NullableGeneratorSpec<String> {
+
+    /**
+     * Specifies that Visa credit card numbers should be generated.
+     *
+     * @return spec builder
+     * @since 2.11.0
+     */
+    CreditCardGeneratorSpec visa();
+
+    /**
+     * Specifies that MasterCard credit card numbers should be generated.
+     *
+     * @return spec builder
+     * @since 2.11.0
+     */
+    CreditCardGeneratorSpec masterCard();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    CreditCardGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/CreditCardSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/CreditCardSpec.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.ValueSpec;
+
+/**
+ * Spec for generating credit card numbers.
+ *
+ * @since 2.11.0
+ */
+public interface CreditCardSpec extends CreditCardGeneratorSpec, ValueSpec<String> {
+
+    @Override
+    CreditCardSpec visa();
+
+    @Override
+    CreditCardSpec masterCard();
+
+    @Override
+    CreditCardSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/EanGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/EanGeneratorSpec.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+/**
+ * Spec for generating
+ * <a href="https://en.wikipedia.org/wiki/International_Article_Number">European Article Number</a>
+ * (EAN).
+ *
+ * @since 2.11.0
+ */
+public interface EanGeneratorSpec extends NullableGeneratorSpec<String> {
+
+    /**
+     * Specifies that EAN-8 should be generated.
+     *
+     * @return spec builder
+     * @since 2.11.0
+     */
+    EanGeneratorSpec type8();
+
+    /**
+     * Specifies that EAN-13 should be generated
+     * (default behaviour if the type is not specified).
+     *
+     * @return spec builder
+     * @since 2.11.0
+     */
+    EanGeneratorSpec type13();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EanGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/EanSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/EanSpec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.ValueSpec;
+
+/**
+ * Spec for generating
+ * <a href="https://en.wikipedia.org/wiki/International_Article_Number">European Article Number</a>
+ * (EAN).
+ *
+ * @since 2.11.0
+ */
+public interface EanSpec extends ValueSpec<String>, EanGeneratorSpec {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EanSpec type8();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EanSpec type13();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EanSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/EmailAsGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/EmailAsGeneratorSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+/**
+ * Spec for generating email addresses
+ * that supports {@link AsGeneratorSpec}.
+ *
+ * @since 2.11.0
+ */
+public interface EmailAsGeneratorSpec extends EmailGeneratorSpec, AsGeneratorSpec<String> {
+
+    @Override
+    EmailAsGeneratorSpec length(int length);
+
+    @Override
+    EmailAsGeneratorSpec length(int min, int max);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EmailAsGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/EmailGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/EmailGeneratorSpec.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+/**
+ * Spec for generating email addresses.
+ *
+ * @since 2.11.0
+ */
+public interface EmailGeneratorSpec extends NullableGeneratorSpec<String> {
+
+    /**
+     * Specifies email address length.
+     *
+     * @param length of email address
+     * @return spec builder
+     * @since 2.11.0
+     */
+    EmailGeneratorSpec length(int length);
+
+    /**
+     * Specifies email address length range.
+     *
+     * @param min minimum length of address (inclusive)
+     * @param max maximum length of address (inclusive)
+     * @return spec builder
+     * @since 2.11.0
+     */
+    EmailGeneratorSpec length(int min, int max);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    EmailGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/EmailSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/EmailSpec.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.ValueSpec;
+
+/**
+ * Spec for generating email addresses.
+ *
+ * @since 2.11.0
+ */
+public interface EmailSpec extends ValueSpec<String>, EmailGeneratorSpec {
+
+    @Override
+    EmailSpec length(int length);
+
+    @Override
+    EmailSpec length(int min, int max);
+
+    @Override
+    EmailSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/IsbnGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/IsbnGeneratorSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+/**
+ * Spec for generating <a href="https://en.wikipedia.org/wiki/ISBN">ISBN</a>.
+ *
+ * @since 2.11.0
+ */
+public interface IsbnGeneratorSpec extends NullableGeneratorSpec<String> {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    IsbnGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/IsbnSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/IsbnSpec.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.ValueSpec;
+
+/**
+ * Spec for generating <a href="https://en.wikipedia.org/wiki/ISBN">ISBN</a>.
+ *
+ * @since 2.11.0
+ */
+public interface IsbnSpec extends ValueSpec<String>, IsbnGeneratorSpec {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.11.0
+     */
+    @Override
+    IsbnSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LoremIpsumSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LoremIpsumSpec.java
@@ -29,4 +29,7 @@ public interface LoremIpsumSpec extends ValueSpec<String>, LoremIpsumGeneratorSp
 
     @Override
     LoremIpsumSpec paragraphs(int paragraphs);
+
+    @Override
+    LoremIpsumSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OneOfArraySpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OneOfArraySpec.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.generator.specs;
 
+import org.instancio.Model;
+import org.instancio.exception.InstancioApiException;
 import org.instancio.generator.ValueSpec;
 
 /**
@@ -27,4 +29,9 @@ public interface OneOfArraySpec<T> extends ValueSpec<T>, OneOfArrayGeneratorSpec
 
     @Override
     OneOfArraySpec<T> oneOf(T... values);
+
+    @Override
+    default Model<T> toModel() {
+        throw new InstancioApiException("oneOf() spec does not support toModel()");
+    }
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OneOfCollectionSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OneOfCollectionSpec.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.generator.specs;
 
+import org.instancio.Model;
+import org.instancio.exception.InstancioApiException;
 import org.instancio.generator.ValueSpec;
 
 import java.util.Collection;
@@ -29,4 +31,9 @@ public interface OneOfCollectionSpec<T> extends ValueSpec<T>, OneOfCollectionGen
 
     @Override
     OneOfCollectionSpec<T> oneOf(Collection<T> values);
+
+    @Override
+    default Model<T> toModel() {
+        throw new InstancioApiException("oneOf() spec does not support toModel()");
+    }
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/URISpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/URISpec.java
@@ -50,4 +50,7 @@ public interface URISpec extends ValueSpec<URI>, URIGeneratorSpec {
 
     @Override
     URISpec fragment(Generator<String> fragmentGenerator);
+
+    @Override
+    URISpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/URLSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/URLSpec.java
@@ -41,4 +41,7 @@ public interface URLSpec extends ValueSpec<URL>, URLGeneratorSpec {
 
     @Override
     URLSpec file(Generator<String> fileGenerator);
+
+    @Override
+    URLSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/UUIDStringSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/UUIDStringSpec.java
@@ -31,4 +31,7 @@ public interface UUIDStringSpec extends ValueSpec<String>, UUIDStringGeneratorSp
 
     @Override
     UUIDStringSpec withoutDashes();
+
+    @Override
+    UUIDStringSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generators/FinanceGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/FinanceGenerators.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.generators;
+
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.CreditCardGeneratorSpec;
+import org.instancio.internal.generator.domain.finance.CreditCardNumberGenerator;
+
+/**
+ * Contains built-in finance-related generators.
+ *
+ * @since 2.11.0
+ */
+public class FinanceGenerators {
+
+    private final GeneratorContext context;
+
+    public FinanceGenerators(final GeneratorContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Generates credit card numbers.
+     *
+     * <p>By default, either a Visa or MasterCard will be generated.
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public CreditCardGeneratorSpec creditCard() {
+        return new CreditCardNumberGenerator(context);
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/generators/FinanceSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/FinanceSpecs.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generators;
+
+import org.instancio.generator.specs.CreditCardSpec;
+import org.instancio.internal.generator.domain.finance.CreditCardNumberGenerator;
+
+/**
+ * Provides finance-related generators.
+ *
+ * @since 2.11.0
+ */
+public final class FinanceSpecs {
+
+    /**
+     * Generates credit card numbers.
+     *
+     * <p>By default, either a Visa or MasterCard will be generated.
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public CreditCardSpec creditCard() {
+        return new CreditCardNumberGenerator();
+    }
+
+}

--- a/instancio-core/src/main/java/org/instancio/generators/Generators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/Generators.java
@@ -288,4 +288,24 @@ public class Generators {
     public TextGenerators text() {
         return new TextGenerators(context);
     }
+
+    /**
+     * Provides access to identifier generators.
+     *
+     * @return built-in id generators
+     * @since 2.11.0
+     */
+    public IdGenerators id() {
+        return new IdGenerators(context);
+    }
+
+    /**
+     * Provides access to finance-related generators.
+     *
+     * @return built-in finance-related generators
+     * @since 2.11.0s
+     */
+    public FinanceGenerators finance() {
+        return new FinanceGenerators(context);
+    }
 }

--- a/instancio-core/src/main/java/org/instancio/generators/IdGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/IdGenerators.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.generators;
+
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.EanGeneratorSpec;
+import org.instancio.generator.specs.IsbnGeneratorSpec;
+import org.instancio.internal.generator.domain.id.EanGenerator;
+import org.instancio.internal.generator.domain.id.IsbnGenerator;
+
+/**
+ * Contains built-in generators for various types of identifiers.
+ *
+ * @since 2.11.0
+ */
+public class IdGenerators {
+
+    private final GeneratorContext context;
+
+    public IdGenerators(final GeneratorContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Generates European Article Number (EAN).
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public EanGeneratorSpec ean() {
+        return new EanGenerator(context);
+    }
+
+    /**
+     * Generates ISBN numbers.
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public IsbnGeneratorSpec isbn() {
+        return new IsbnGenerator(context);
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/generators/IdSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/IdSpecs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generators;
+
+import org.instancio.generator.specs.EanSpec;
+import org.instancio.generator.specs.IsbnSpec;
+import org.instancio.internal.generator.domain.id.EanGenerator;
+import org.instancio.internal.generator.domain.id.IsbnGenerator;
+
+/**
+ * Provides generators for various types of identifiers.
+ *
+ * @since 2.11.0
+ */
+public final class IdSpecs {
+
+    /**
+     * Generates European Article Number (EAN).
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public EanSpec ean() {
+        return new EanGenerator();
+    }
+
+    /**
+     * Generates ISBN numbers.
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public IsbnSpec isbn() {
+        return new IsbnGenerator();
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/generators/NetGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/NetGenerators.java
@@ -16,8 +16,10 @@
 package org.instancio.generators;
 
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.EmailAsGeneratorSpec;
 import org.instancio.generator.specs.URIAsGeneratorSpec;
 import org.instancio.generator.specs.URLAsGeneratorSpec;
+import org.instancio.internal.generator.domain.internet.EmailGenerator;
 import org.instancio.internal.generator.net.URIGenerator;
 import org.instancio.internal.generator.net.URLGenerator;
 
@@ -55,5 +57,15 @@ public class NetGenerators {
      */
     public URLAsGeneratorSpec url() {
         return new URLGenerator(context);
+    }
+
+    /**
+     * Customises generated email addresses.
+     *
+     * @return generator spec
+     * @since 2.11.0
+     */
+    public EmailAsGeneratorSpec email() {
+        return new EmailGenerator(context);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/generators/NetSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/NetSpecs.java
@@ -15,8 +15,10 @@
  */
 package org.instancio.generators;
 
+import org.instancio.generator.specs.EmailSpec;
 import org.instancio.generator.specs.URISpec;
 import org.instancio.generator.specs.URLSpec;
+import org.instancio.internal.generator.domain.internet.EmailGenerator;
 import org.instancio.internal.generator.net.URIGenerator;
 import org.instancio.internal.generator.net.URLGenerator;
 
@@ -48,5 +50,15 @@ public final class NetSpecs {
      */
     public URLSpec url() {
         return new URLGenerator();
+    }
+
+    /**
+     * Generates email addresses.
+     *
+     * @return API builder reference
+     * @since 2.11.0
+     */
+    public EmailSpec email() {
+        return new EmailGenerator();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/HibernateBeanValidationProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/HibernateBeanValidationProcessor.java
@@ -107,7 +107,7 @@ final class HibernateBeanValidationProcessor extends AbstractBeanValidationProvi
     private static EanGenerator getEanGenerator(final EAN ean, final GeneratorContext context) {
         final EanGenerator generator = new EanGenerator(context);
         if (ean.type() == EAN.Type.EAN8) {
-            generator.ean8();
+            generator.type8();
         }
         return generator;
     }

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JakartaBeanValidationProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JakartaBeanValidationProcessor.java
@@ -19,7 +19,7 @@ import jakarta.validation.constraints.Email;
 import org.instancio.exception.InstancioException;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
-import org.instancio.internal.generator.domain.internet.EmailAddressGenerator;
+import org.instancio.internal.generator.domain.internet.EmailGenerator;
 
 import java.lang.annotation.Annotation;
 
@@ -40,7 +40,7 @@ final class JakartaBeanValidationProcessor extends AbstractBeanValidationProvide
 
         final Class<?> annotationType = annotation.annotationType();
         if (annotationType == Email.class) {
-            return new EmailAddressGenerator(context);
+            return new EmailGenerator(context);
         }
         throw new InstancioException("Unmapped primary annotation:  " + annotationType.getName());
     }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/AbstractGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/AbstractGenerator.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.internal.generator;
 
+import org.instancio.Random;
 import org.instancio.documentation.InternalApi;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
@@ -47,8 +48,24 @@ public abstract class AbstractGenerator<T> implements Generator<T>, NullableGene
      */
     public abstract String apiMethod();
 
-    public GeneratorContext getContext() {
-        return context;
+    /**
+     * Makes the best effort to return a non-null value.
+     * However, in certain cases this method will produce a {@code null}.
+     *
+     * @param random for generating the value
+     * @return generated value, either a null or non-null
+     */
+    protected abstract T tryGenerateNonNull(Random random);
+
+    /**
+     * Base implementation that handles nullable values.
+     *
+     * @param random generating random the value
+     * @return generated value, either a null or non-null
+     */
+    @Override
+    public final T generate(final Random random) {
+        return random.diceRoll(isNullable()) ? null : tryGenerateNonNull(random);
     }
 
     @Override
@@ -64,6 +81,10 @@ public abstract class AbstractGenerator<T> implements Generator<T>, NullableGene
 
     public final boolean isNullable() {
         return nullable;
+    }
+
+    public GeneratorContext getContext() {
+        return context;
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/generator/array/ArrayGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/array/ArrayGenerator.java
@@ -119,12 +119,8 @@ public class ArrayGenerator<T> extends AbstractGenerator<T> implements ArrayGene
 
     @Override
     @SuppressWarnings("unchecked")
-    public T generate(final Random random) {
+    protected T tryGenerateNonNull(final Random random) {
         ApiValidator.isTrue(arrayType != null && arrayType.isArray(), "Expected an array type: %s", arrayType);
-
-        if (random.diceRoll(isNullable())) {
-            return null;
-        }
 
         final int length = random.intRange(minLength, maxLength)
                 + (withElements == null ? 0 : withElements.size());

--- a/instancio-core/src/main/java/org/instancio/internal/generator/array/OneOfArrayGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/array/OneOfArrayGenerator.java
@@ -49,7 +49,13 @@ public class OneOfArrayGenerator<T> extends AbstractGenerator<T> implements OneO
     }
 
     @Override
-    public T generate(final Random random) {
+    public OneOfArrayGenerator<T> nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected T tryGenerateNonNull(final Random random) {
         return random.oneOf(values);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/CCTypeImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/CCTypeImpl.java
@@ -19,32 +19,25 @@ import org.instancio.internal.util.CollectionUtils;
 
 import java.util.List;
 
-public enum CreditCardType {
+// Avoid naming CreditCard* to prevent it from appearing in IDE completion
+public enum CCTypeImpl {
 
-    AMEX(15, 34, 37),
-    DINERS(14, 36, 38, 300, 301, 302, 303, 304, 305),
-    DISCOVER(16, 6011),
-    JCB15(15, 1800, 2123),
-    JCB16(16, 3),
-    MC(16, 51, 52, 53, 54, 55),
-    VISA13(13, 4),
-    VISA16(16, 4);
+    CC_MASTERCARD(16, 51, 52, 53, 54, 55),
+    CC_VISA(16, 4);
 
     private final int length;
     private final List<Integer> prefixes;
 
-    CreditCardType(final int length, final Integer... prefixes) {
+    CCTypeImpl(final int length, final Integer... prefixes) {
         this.length = length;
         this.prefixes = CollectionUtils.asList(prefixes);
     }
 
-    int getLength() {
+    public int getLength() {
         return length;
     }
 
-    List<Integer> getPrefixes() {
+    public List<Integer> getPrefixes() {
         return prefixes;
     }
 }
-
-

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/EanGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/EanGenerator.java
@@ -17,11 +17,17 @@ package org.instancio.internal.generator.domain.id;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.EanSpec;
+import org.instancio.internal.context.Global;
 import org.instancio.internal.generator.AbstractGenerator;
 
-public class EanGenerator extends AbstractGenerator<String> {
+public class EanGenerator extends AbstractGenerator<String> implements EanSpec {
 
     private EanType type = EanType.EAN13;
+
+    public EanGenerator() {
+        super(Global.generatorContext());
+    }
 
     public EanGenerator(final GeneratorContext context) {
         super(context);
@@ -29,16 +35,29 @@ public class EanGenerator extends AbstractGenerator<String> {
 
     @Override
     public String apiMethod() {
-        return null;
+        return "ean()";
     }
 
-    public EanGenerator ean8() {
+    @Override
+    public EanGenerator type13() {
+        type = EanType.EAN13;
+        return this;
+    }
+
+    @Override
+    public EanGenerator type8() {
         type = EanType.EAN8;
         return this;
     }
 
     @Override
-    public String generate(final Random random) {
+    public EanGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
         final String withoutCheckDigit = random.digits(type.length - 1);
         final int checkDigit = getCheckDigit(withoutCheckDigit, type);
         return withoutCheckDigit + checkDigit;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/IsbnGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/IsbnGenerator.java
@@ -17,11 +17,17 @@ package org.instancio.internal.generator.domain.id;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.IsbnSpec;
+import org.instancio.internal.context.Global;
 import org.instancio.internal.generator.AbstractGenerator;
 
-public class IsbnGenerator extends AbstractGenerator<String> {
+public class IsbnGenerator extends AbstractGenerator<String> implements IsbnSpec {
 
     private final EanGenerator delegate;
+
+    public IsbnGenerator() {
+        this(Global.generatorContext());
+    }
 
     public IsbnGenerator(final GeneratorContext context) {
         super(context);
@@ -30,12 +36,18 @@ public class IsbnGenerator extends AbstractGenerator<String> {
 
     @Override
     public String apiMethod() {
-        return null;
+        return "isbn()";
     }
 
     @Override
-    public String generate(final Random random) {
-        return delegate.generate(random);
+    public IsbnGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
+        return delegate.tryGenerateNonNull(random);
     }
 }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/internet/EmailGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/internet/EmailGenerator.java
@@ -17,7 +17,9 @@ package org.instancio.internal.generator.domain.internet;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
-import org.instancio.generator.specs.NullableGeneratorSpec;
+import org.instancio.generator.specs.EmailAsGeneratorSpec;
+import org.instancio.generator.specs.EmailSpec;
+import org.instancio.internal.context.Global;
 import org.instancio.internal.generator.AbstractGenerator;
 import org.instancio.internal.generator.specs.InternalLengthGeneratorSpec;
 import org.instancio.internal.util.Verify;
@@ -28,37 +30,41 @@ import java.util.Locale;
  * Internal generator used for generating email addresses for fields annotated
  * with {@code @Email} annotation from Jakarta Bean Validation API.
  */
-public class EmailAddressGenerator extends AbstractGenerator<String>
-        implements NullableGeneratorSpec<String>, InternalLengthGeneratorSpec<String> {
+public class EmailGenerator extends AbstractGenerator<String>
+        implements EmailSpec, EmailAsGeneratorSpec, InternalLengthGeneratorSpec<String> {
 
     private static final String[] TLDS = {"com", "edu", "net", "org"};
 
     private int minLength = 7;
     private int maxLength = 24;
 
-    public EmailAddressGenerator(final GeneratorContext context) {
+    public EmailGenerator() {
+        super(Global.generatorContext());
+    }
+
+    public EmailGenerator(final GeneratorContext context) {
         super(context);
     }
 
     @Override
     public String apiMethod() {
-        return null;
+        return "email()";
     }
 
     @Override
-    public EmailAddressGenerator nullable() {
+    public EmailGenerator nullable() {
         super.nullable();
         return this;
     }
 
     @Override
-    public EmailAddressGenerator nullable(final boolean isNullable) {
+    public EmailGenerator nullable(final boolean isNullable) {
         super.nullable(isNullable);
         return this;
     }
 
     @Override
-    public EmailAddressGenerator length(final int min, final int max) {
+    public EmailGenerator length(final int min, final int max) {
         Verify.isTrue(min >= 3, "Email length must be at least 3 characters long");
         Verify.isTrue(min <= max, "Min must be less than or equal to max");
 
@@ -67,17 +73,14 @@ public class EmailAddressGenerator extends AbstractGenerator<String>
         return this;
     }
 
-    public EmailAddressGenerator length(final int length) {
+    @Override
+    public EmailGenerator length(final int length) {
         length(length, length);
         return this;
     }
 
     @Override
-    public String generate(final Random random) {
-        if (random.diceRoll(isNullable())) {
-            return null;
-        }
-
+    protected String tryGenerateNonNull(final Random random) {
         final int len = random.intRange(minLength, maxLength);
 
         // If length is at least 7, can generate with TLD: x@y.com

--- a/instancio-core/src/main/java/org/instancio/internal/generator/io/FileGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/io/FileGenerator.java
@@ -95,7 +95,13 @@ public class FileGenerator extends AbstractGenerator<File>
     }
 
     @Override
-    public File generate(final Random random) {
-        return delegate.generate(random).toFile();
+    public FileGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected File tryGenerateNonNull(final Random random) {
+        return delegate.tryGenerateNonNull(random).toFile();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/AbstractRandomNumberGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/AbstractRandomNumberGeneratorSpec.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.internal.generator.lang;
 
-import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.NumberAsGeneratorSpec;
 import org.instancio.internal.ApiValidator;
@@ -35,8 +34,6 @@ public abstract class AbstractRandomNumberGeneratorSpec<T extends Number>
         this.min = min;
         this.max = max;
     }
-
-    protected abstract T generateNonNullValue(Random random);
 
     protected T getMin() {
         return min;
@@ -75,10 +72,5 @@ public abstract class AbstractRandomNumberGeneratorSpec<T extends Number>
         this.min = ApiValidator.notNull(min, "'min' must not be null");
         this.max = ApiValidator.notNull(max, "'max' must not be null");
         return this;
-    }
-
-    @Override
-    public final T generate(final Random random) {
-        return random.diceRoll(isNullable()) ? null : generateNonNullValue(random);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/BooleanGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/BooleanGenerator.java
@@ -47,7 +47,7 @@ public class BooleanGenerator extends AbstractGenerator<Boolean>
     }
 
     @Override
-    public Boolean generate(final Random random) {
+    protected Boolean tryGenerateNonNull(final Random random) {
         return random.diceRoll(isNullable()) ? null : random.trueOrFalse();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/ByteGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/ByteGenerator.java
@@ -71,7 +71,7 @@ public class ByteGenerator extends AbstractRandomComparableNumberGeneratorSpec<B
     }
 
     @Override
-    protected Byte generateNonNullValue(final Random random) {
+    protected Byte tryGenerateNonNull(final Random random) {
         return random.byteRange(getMin(), getMax());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/CharacterGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/CharacterGenerator.java
@@ -61,9 +61,7 @@ public class CharacterGenerator extends AbstractGenerator<Character>
     }
 
     @Override
-    public Character generate(final Random random) {
-        return random.diceRoll(isNullable())
-                ? null
-                : random.characterRange(min, max);
+    protected Character tryGenerateNonNull(final Random random) {
+        return random.characterRange(min, max);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/DoubleGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/DoubleGenerator.java
@@ -71,7 +71,7 @@ public class DoubleGenerator extends AbstractRandomComparableNumberGeneratorSpec
     }
 
     @Override
-    protected Double generateNonNullValue(final Random random) {
+    protected Double tryGenerateNonNull(final Random random) {
         return random.doubleRange(getMin(), getMax());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/EnumGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/EnumGenerator.java
@@ -66,8 +66,8 @@ public class EnumGenerator<E extends Enum<E>> extends AbstractGenerator<E> imple
     }
 
     @Override
-    public E generate(final Random random) {
-        if (values.isEmpty() || random.diceRoll(isNullable())) {
+    protected E tryGenerateNonNull(final Random random) {
+        if (values.isEmpty()) {
             return null;
         }
         return valuesWithExclusions.isEmpty()

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/FloatGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/FloatGenerator.java
@@ -71,7 +71,7 @@ public class FloatGenerator extends AbstractRandomComparableNumberGeneratorSpec<
     }
 
     @Override
-    protected Float generateNonNullValue(final Random random) {
+    protected Float tryGenerateNonNull(final Random random) {
         return random.floatRange(getMin(), getMax());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/IntegerGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/IntegerGenerator.java
@@ -71,7 +71,7 @@ public class IntegerGenerator extends AbstractRandomComparableNumberGeneratorSpe
     }
 
     @Override
-    protected Integer generateNonNullValue(final Random random) {
+    protected Integer tryGenerateNonNull(final Random random) {
         return random.intRange(getMin(), getMax());
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/LongGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/LongGenerator.java
@@ -71,7 +71,7 @@ public class LongGenerator extends AbstractRandomComparableNumberGeneratorSpec<L
     }
 
     @Override
-    protected Long generateNonNullValue(final Random random) {
+    protected Long tryGenerateNonNull(final Random random) {
         return random.longRange(getMin(), getMax());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/ShortGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/ShortGenerator.java
@@ -71,7 +71,7 @@ public class ShortGenerator extends AbstractRandomComparableNumberGeneratorSpec<
     }
 
     @Override
-    protected Short generateNonNullValue(final Random random) {
+    protected Short tryGenerateNonNull(final Random random) {
         return random.shortRange(getMin(), getMax());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringBuilderGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringBuilderGenerator.java
@@ -40,7 +40,7 @@ public class StringBuilderGenerator extends AbstractGenerator<StringBuilder> {
     }
 
     @Override
-    public StringBuilder generate(final Random random) {
+    protected StringBuilder tryGenerateNonNull(final Random random) {
         final int length = random.intRange(minLength, maxLength + 1);
         return new StringBuilder(random.upperCaseAlphabetic(length));
     }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
@@ -181,13 +181,10 @@ public class StringGenerator extends AbstractGenerator<String> implements String
     }
 
     @Override
-    public String generate(final Random random) {
+    protected String tryGenerateNonNull(final Random random) {
         if (delegate != null) {
             final Object result = delegate.generate(random);
             return result == null ? null : result.toString();
-        }
-        if (random.diceRoll(isNullable())) {
-            return null;
         }
         if (random.diceRoll(allowEmpty)) {
             return "";

--- a/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
@@ -89,7 +89,7 @@ public class BigDecimalGenerator extends AbstractRandomComparableNumberGenerator
     }
 
     @Override
-    protected BigDecimal generateNonNullValue(final Random random) {
+    protected BigDecimal tryGenerateNonNull(final Random random) {
         final BigDecimal delta = getMax().subtract(getMin());
         final BigDecimal rndDelta = delta.multiply(BigDecimal.valueOf(random.doubleRange(0.01, 1)));
         return getMin().add(rndDelta).setScale(scale, RoundingMode.HALF_UP);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/math/BigIntegerGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/math/BigIntegerGenerator.java
@@ -78,7 +78,7 @@ public class BigIntegerGenerator extends AbstractRandomComparableNumberGenerator
     }
 
     @Override
-    protected BigInteger generateNonNullValue(final Random random) {
+    protected BigInteger tryGenerateNonNull(final Random random) {
         final BigInteger delta = getMax().subtract(getMin());
         final BigInteger rndDelta = delta
                 .multiply(BigInteger.valueOf(random.intRange(1, 100)))

--- a/instancio-core/src/main/java/org/instancio/internal/generator/net/URIGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/net/URIGenerator.java
@@ -97,7 +97,13 @@ public class URIGenerator extends AbstractURIGenerator<URI>
     }
 
     @Override
-    public URI generate(final Random random) {
+    public URIGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected URI tryGenerateNonNull(final Random random) {
         final String scheme = getScheme(random);
         final int port = getPort(random);
         final String host = getHost(random);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/net/URLGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/net/URLGenerator.java
@@ -75,7 +75,13 @@ public class URLGenerator extends AbstractURIGenerator<URL>
     }
 
     @Override
-    public URL generate(final Random random) {
+    public URLGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected URL tryGenerateNonNull(final Random random) {
         final String protocol = getScheme(random);
         final String host = getHost(random);
         final int portNumber = getPort(random);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/nio/file/PathGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/nio/file/PathGenerator.java
@@ -120,7 +120,13 @@ public class PathGenerator extends AbstractGenerator<Path>
     }
 
     @Override
-    public Path generate(final Random random) {
+    public PathGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    public Path tryGenerateNonNull(final Random random) {
         final Path directoryPath = getDirectoryPath();
         final Path leafNameAsPath = getLeafNameAsPath(random);
         final Path completePath = directoryPath == null

--- a/instancio-core/src/main/java/org/instancio/internal/generator/sql/SqlDateGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/sql/SqlDateGenerator.java
@@ -62,9 +62,7 @@ public class SqlDateGenerator extends AbstractGenerator<Date> implements Tempora
     }
 
     @Override
-    public Date generate(final Random random) {
-        return random.diceRoll(isNullable())
-                ? null
-                : Date.valueOf(delegate.generateNonNullValue(random));
+    public Date tryGenerateNonNull(final Random random) {
+        return Date.valueOf(delegate.tryGenerateNonNull(random));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/sql/TimestampGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/sql/TimestampGenerator.java
@@ -62,9 +62,7 @@ public class TimestampGenerator extends AbstractGenerator<Timestamp> implements 
     }
 
     @Override
-    public Timestamp generate(final Random random) {
-        return random.diceRoll(isNullable())
-                ? null
-                : Timestamp.from(delegate.generateNonNullValue(random));
+    public Timestamp tryGenerateNonNull(final Random random) {
+        return Timestamp.from(delegate.tryGenerateNonNull(random));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/LoremIpsumGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/LoremIpsumGenerator.java
@@ -70,7 +70,13 @@ public class LoremIpsumGenerator extends AbstractGenerator<String>
     }
 
     @Override
-    public String generate(final Random random) {
+    public LoremIpsumGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
         ApiValidator.isTrue(words >= paragraphs,
                 "The number of paragraphs (%s) is greater than the number of words (%s)", paragraphs, words);
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/LuhnGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/LuhnGenerator.java
@@ -95,10 +95,7 @@ public class LuhnGenerator extends AbstractGenerator<String>
     }
 
     @Override
-    public String generate(final Random random) {
-        if (random.diceRoll(isNullable())) {
-            return null;
-        }
+    protected String tryGenerateNonNull(final Random random) {
         final int size = random.intRange(minSize, maxSize);
         final int start = Math.max(0, startIndex);
         final int end = endIndex == -1 ? size - 1 : endIndex;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/TextPatternGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/TextPatternGenerator.java
@@ -55,7 +55,13 @@ public class TextPatternGenerator extends AbstractGenerator<String>
     }
 
     @Override
-    public String generate(final Random random) {
+    public TextPatternGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
         final StringBuilder res = new StringBuilder(pattern.length());
         final char[] p = pattern.toCharArray();
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/UUIDStringGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/UUIDStringGenerator.java
@@ -58,8 +58,14 @@ public class UUIDStringGenerator extends AbstractGenerator<String> implements UU
     }
 
     @Override
-    public String generate(final Random random) {
-        String uuid = delegate.generate(random).toString();
+    public UUIDStringGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
+        String uuid = delegate.tryGenerateNonNull(random).toString();
         if (isUpperCase) {
             uuid = uuid.toUpperCase(Locale.ROOT);
         }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/DurationGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/DurationGenerator.java
@@ -87,7 +87,13 @@ public class DurationGenerator extends AbstractGenerator<Duration> implements Du
     }
 
     @Override
-    public Duration generate(final Random random) {
+    public DurationGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected Duration tryGenerateNonNull(final Random random) {
         return random.diceRoll(allowZero)
                 ? Duration.ZERO
                 : Duration.of(random.longRange(min.toNanos(), max.toNanos()), ChronoUnit.NANOS);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/InstantGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/InstantGenerator.java
@@ -84,7 +84,7 @@ public class InstantGenerator extends JavaTimeTemporalGenerator<Instant>
     }
 
     @Override
-    public Instant generateNonNullValue(final Random random) {
+    public Instant tryGenerateNonNull(final Random random) {
         final long sec = random.longRange(min.getEpochSecond(), max.getEpochSecond());
         final int nano;
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/JavaTimeTemporalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/JavaTimeTemporalGenerator.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.internal.generator.time;
 
-import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.TemporalAaStringGeneratorSpec;
 import org.instancio.internal.ApiValidator;
@@ -39,8 +38,6 @@ abstract class JavaTimeTemporalGenerator<T extends Temporal> extends AbstractGen
         this.min = min;
         this.max = max;
     }
-
-    protected abstract T generateNonNullValue(Random random);
 
     abstract T getLatestPast();
 
@@ -68,10 +65,5 @@ abstract class JavaTimeTemporalGenerator<T extends Temporal> extends AbstractGen
         max = ApiValidator.notNull(end, "End parameter must not be null");
         validateRange();
         return this;
-    }
-
-    @Override
-    public final T generate(final Random random) {
-        return random.diceRoll(isNullable()) ? null : generateNonNullValue(random);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateGenerator.java
@@ -85,7 +85,7 @@ public class LocalDateGenerator extends JavaTimeTemporalGenerator<LocalDate>
     }
 
     @Override
-    public LocalDate generateNonNullValue(final Random random) {
+    public LocalDate tryGenerateNonNull(final Random random) {
         return LocalDate.ofEpochDay(random.longRange(
                 min.getLong(EPOCH_DAY),
                 max.getLong(EPOCH_DAY)));

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateTimeGenerator.java
@@ -89,7 +89,7 @@ public class LocalDateTimeGenerator extends JavaTimeTemporalGenerator<LocalDateT
     }
 
     @Override
-    public LocalDateTime generateNonNullValue(final Random random) {
+    protected LocalDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toInstant(ZONE_OFFSET), max.toInstant(ZONE_OFFSET));
         return LocalDateTime.ofInstant(delegate.generate(random), ZONE_OFFSET);
     }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalTimeGenerator.java
@@ -96,7 +96,7 @@ public class LocalTimeGenerator extends JavaTimeTemporalGenerator<LocalTime>
     }
 
     @Override
-    public LocalTime generateNonNullValue(final Random random) {
+    protected LocalTime tryGenerateNonNull(final Random random) {
         return LocalTime.ofNanoOfDay(random.longRange(
                 min.toNanoOfDay(),
                 max.toNanoOfDay()));

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/MonthDayGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/MonthDayGenerator.java
@@ -60,7 +60,7 @@ public class MonthDayGenerator extends AbstractGenerator<MonthDay> implements Mo
     }
 
     @Override
-    public MonthDay generate(final Random random) {
+    protected MonthDay tryGenerateNonNull(final Random random) {
         final int minMonth = min.getMonthValue();
         final int maxMonth = max.getMonthValue();
         final int month = random.intRange(minMonth, maxMonth);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetDateTimeGenerator.java
@@ -89,7 +89,7 @@ public class OffsetDateTimeGenerator extends JavaTimeTemporalGenerator<OffsetDat
     }
 
     @Override
-    public OffsetDateTime generateNonNullValue(final Random random) {
+    protected OffsetDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toLocalDateTime(), max.toLocalDateTime());
         final LocalDateTime ldt = delegate.generate(random);
         return ldt == null ? null : OffsetDateTime.of(ldt, ZONE_OFFSET);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetTimeGenerator.java
@@ -98,7 +98,7 @@ public class OffsetTimeGenerator extends JavaTimeTemporalGenerator<OffsetTime>
     }
 
     @Override
-    public OffsetTime generateNonNullValue(final Random random) {
+    protected OffsetTime tryGenerateNonNull(final Random random) {
         int hour = random.intRange(min.getHour(), max.getHour());
         int minute = random.intRange(min.getMinute(), max.getMinute());
         int second = random.intRange(min.getSecond(), max.getSecond());

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/PeriodGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/PeriodGenerator.java
@@ -74,7 +74,13 @@ public class PeriodGenerator extends AbstractGenerator<Period> implements Period
     }
 
     @Override
-    public Period generate(final Random random) {
+    public PeriodGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected Period tryGenerateNonNull(final Random random) {
         return Period.of(
                 random.intRange(minYears, maxYears),
                 random.intRange(minMonths, maxMonths),

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/YearGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/YearGenerator.java
@@ -83,7 +83,7 @@ public class YearGenerator extends JavaTimeTemporalGenerator<Year>
     }
 
     @Override
-    public Year generateNonNullValue(final Random random) {
+    protected Year tryGenerateNonNull(final Random random) {
         return Year.of(random.intRange(min.getValue(), max.getValue()));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/YearMonthGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/YearMonthGenerator.java
@@ -83,7 +83,7 @@ public class YearMonthGenerator extends JavaTimeTemporalGenerator<YearMonth>
     }
 
     @Override
-    public YearMonth generateNonNullValue(final Random random) {
+    protected YearMonth tryGenerateNonNull(final Random random) {
         final int minMonth = min.getYear() * 12 + min.getMonthValue() - 1;
         final int maxMonth = max.getYear() * 12 + max.getMonthValue() - 1;
         final int result = random.intRange(minMonth, maxMonth);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/ZoneIdGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/ZoneIdGenerator.java
@@ -33,7 +33,7 @@ public class ZoneIdGenerator extends AbstractGenerator<ZoneId> {
     }
 
     @Override
-    public ZoneId generate(final Random random) {
+    protected ZoneId tryGenerateNonNull(final Random random) {
         return ZoneId.of(random.oneOf(ZoneId.getAvailableZoneIds()));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/ZoneOffsetGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/ZoneOffsetGenerator.java
@@ -36,7 +36,7 @@ public class ZoneOffsetGenerator extends AbstractGenerator<ZoneOffset> {
     }
 
     @Override
-    public ZoneOffset generate(final Random random) {
+    protected ZoneOffset tryGenerateNonNull(final Random random) {
         final int hours = random.intRange(MIN_HOURS, MAX_HOURS);
 
         if (Math.abs(hours) == MAX_HOURS) {

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/ZonedDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/ZonedDateTimeGenerator.java
@@ -89,8 +89,8 @@ public class ZonedDateTimeGenerator extends JavaTimeTemporalGenerator<ZonedDateT
     }
 
     @Override
-    public ZonedDateTime generateNonNullValue(final Random random) {
+    public ZonedDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toInstant(), max.toInstant());
-        return ZonedDateTime.ofInstant(delegate.generateNonNullValue(random), ZONE_OFFSET);
+        return ZonedDateTime.ofInstant(delegate.tryGenerateNonNull(random), ZONE_OFFSET);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/CalendarGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/CalendarGenerator.java
@@ -66,9 +66,7 @@ public class CalendarGenerator extends AbstractGenerator<Calendar> implements Te
     }
 
     @Override
-    public Calendar generate(final Random random) {
-        return random.diceRoll(isNullable())
-                ? null
-                : GregorianCalendar.from(delegate.generateNonNullValue(random));
+    protected Calendar tryGenerateNonNull(final Random random) {
+        return GregorianCalendar.from(delegate.tryGenerateNonNull(random));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGenerator.java
@@ -126,11 +126,9 @@ public class CollectionGenerator<T> extends AbstractGenerator<Collection<T>> imp
 
     @Override
     @SuppressWarnings({"unchecked", Sonar.RETURN_EMPTY_COLLECTION})
-    public Collection<T> generate(final Random random) {
+    protected Collection<T> tryGenerateNonNull(final Random random) {
         try {
-            return random.diceRoll(isNullable())
-                    ? null
-                    : (Collection<T>) collectionType.getDeclaredConstructor().newInstance();
+            return (Collection<T>) collectionType.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
             LOG.debug("Error creating instance of: {}", collectionType, ex);
             return null; // NOPMD

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGeneratorSpecImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGeneratorSpecImpl.java
@@ -32,7 +32,7 @@ public class CollectionGeneratorSpecImpl<T> extends CollectionGenerator<T> {
     }
 
     @Override
-    public Collection<T> generate(final Random random) {
+    protected Collection<T> tryGenerateNonNull(final Random random) {
         throw new InstancioException(getClass() + " should delegate to another generator");
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/DateGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/DateGenerator.java
@@ -62,9 +62,7 @@ public class DateGenerator extends AbstractGenerator<Date> implements TemporalGe
     }
 
     @Override
-    public Date generate(final Random random) {
-        return random.diceRoll(isNullable())
-                ? null
-                : Date.from((delegate).generateNonNullValue(random));
+    protected Date tryGenerateNonNull(final Random random) {
+        return Date.from((delegate).tryGenerateNonNull(random));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/EnumSetGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/EnumSetGenerator.java
@@ -95,7 +95,7 @@ public class EnumSetGenerator<E extends Enum<E>> extends AbstractGenerator<EnumS
 
     @Override
     @SuppressWarnings({"PMD.ReturnEmptyCollectionRatherThanNull", Sonar.RETURN_EMPTY_COLLECTION})
-    public EnumSet<E> generate(final Random random) {
+    protected EnumSet<E> tryGenerateNonNull(final Random random) {
         // If enum class is known at this time (i.e. it was supplied by the user via the spec)
         // then generate an EnumSet internally.
         if (enumClass != null) {

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/LocaleGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/LocaleGenerator.java
@@ -33,7 +33,7 @@ public class LocaleGenerator extends AbstractGenerator<Locale> {
     }
 
     @Override
-    public Locale generate(final Random random) {
+    public Locale tryGenerateNonNull(final Random random) {
         return random.oneOf(Locale.getAvailableLocales());
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/MapEntryGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/MapEntryGenerator.java
@@ -36,7 +36,7 @@ public class MapEntryGenerator<K, V> extends AbstractGenerator<Map.Entry<K, V>> 
     }
 
     @Override
-    public Map.Entry<K, V> generate(final Random random) {
+    public Map.Entry<K, V> tryGenerateNonNull(final Random random) {
         return null; // must be null to delegate creation to the engine
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGenerator.java
@@ -137,11 +137,9 @@ public class MapGenerator<K, V> extends AbstractGenerator<Map<K, V>> implements 
 
     @Override
     @SuppressWarnings({"unchecked", Sonar.RETURN_EMPTY_COLLECTION})
-    public Map<K, V> generate(final Random random) {
+    public Map<K, V> tryGenerateNonNull(final Random random) {
         try {
-            return random.diceRoll(isNullable())
-                    ? null
-                    : (Map<K, V>) mapType.getDeclaredConstructor().newInstance();
+            return (Map<K, V>) mapType.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
             LOG.debug("Error creating instance of: {}", mapType, ex);
             return null; // NOPMD

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGeneratorSpecImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGeneratorSpecImpl.java
@@ -32,7 +32,7 @@ public class MapGeneratorSpecImpl<K, V> extends MapGenerator<K, V> {
     }
 
     @Override
-    public Map<K, V> generate(final Random random) {
+    public Map<K, V> tryGenerateNonNull(final Random random) {
         throw new InstancioException(getClass() + " should delegate to another generator");
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/OneOfCollectionGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/OneOfCollectionGenerator.java
@@ -48,7 +48,13 @@ public class OneOfCollectionGenerator<T> extends AbstractGenerator<T> implements
     }
 
     @Override
-    public T generate(final Random random) {
+    public OneOfCollectionGenerator<T> nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    public T tryGenerateNonNull(final Random random) {
         return random.oneOf(values);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/OptionalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/OptionalGenerator.java
@@ -37,7 +37,7 @@ public class OptionalGenerator<T> extends AbstractGenerator<Optional<T>> {
 
     @Override
     @SuppressWarnings({"OptionalAssignedToNull", Sonar.NULL_OPTIONAL})
-    public Optional<T> generate(final Random random) {
+    public Optional<T> tryGenerateNonNull(final Random random) {
         return null; // must be null to delegate creation to the engine
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/UUIDGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/UUIDGenerator.java
@@ -33,7 +33,7 @@ public class UUIDGenerator extends AbstractGenerator<UUID> {
     }
 
     @Override
-    public UUID generate(final Random random) {
+    public UUID tryGenerateNonNull(final Random random) {
         final byte[] randomBytes = new byte[16];
         for (int i = 0; i < randomBytes.length; i++) {
             randomBytes[i] = random.byteRange(Byte.MIN_VALUE, Byte.MAX_VALUE);

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/AtomicIntegerGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/AtomicIntegerGenerator.java
@@ -41,7 +41,7 @@ public class AtomicIntegerGenerator extends AbstractRandomNumberGeneratorSpec<At
     }
 
     @Override
-    protected AtomicInteger generateNonNullValue(final Random random) {
+    protected AtomicInteger tryGenerateNonNull(final Random random) {
         return new AtomicInteger(random.intRange(getMin().intValue(), getMax().intValue()));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/AtomicLongGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/AtomicLongGenerator.java
@@ -41,7 +41,7 @@ public class AtomicLongGenerator extends AbstractRandomNumberGeneratorSpec<Atomi
     }
 
     @Override
-    protected AtomicLong generateNonNullValue(final Random random) {
+    protected AtomicLong tryGenerateNonNull(final Random random) {
         return new AtomicLong(random.intRange(getMin().intValue(), getMax().intValue()));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/xml/XMLGregorianCalendarGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/xml/XMLGregorianCalendarGenerator.java
@@ -44,7 +44,7 @@ public class XMLGregorianCalendarGenerator extends AbstractGenerator<XMLGregoria
     }
 
     @Override
-    public XMLGregorianCalendar generate(final Random random) {
+    protected XMLGregorianCalendar tryGenerateNonNull(final Random random) {
         LocalDateTime localDateTime = localDateTimeGenerator.generate(random);
         try {
             return DatatypeFactory.newInstance().newXMLGregorianCalendar(

--- a/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CreditCardNumberBV.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CreditCardNumberBV.java
@@ -15,12 +15,14 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.CreditCardNumber;
 
 @Data
 public class CreditCardNumberBV {
 
+    @NotNull
     @CreditCardNumber
     private String value;
 }

--- a/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckAndLengthBV.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckAndLengthBV.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.LuhnCheck;
@@ -23,6 +24,7 @@ public class LuhnCheckAndLengthBV {
 
     @Data
     public static class WithDefaults {
+        @NotNull
         @Length(min = 10)
         @LuhnCheck
         private String value;
@@ -30,10 +32,12 @@ public class LuhnCheckAndLengthBV {
 
     @Data
     public static class WithStartEndIndices {
+        @NotNull
         @Length(min = 8, max = 8)
         @LuhnCheck(startIndex = 0, endIndex = 7)
         private String value0;
 
+        @NotNull
         @Length(min = 20, max = 22)
         @LuhnCheck(startIndex = 5, endIndex = 10)
         private String value1;
@@ -41,10 +45,12 @@ public class LuhnCheckAndLengthBV {
 
     @Data
     public static class WithStartEndAndCheckDigitIndices {
+        @NotNull
         @Length(min = 17)
         @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 7)
         private String value0;
 
+        @NotNull
         @Length(max = 20) // min = 0
         @LuhnCheck(startIndex = 5, endIndex = 10, checkDigitIndex = 3)
         private String value1;

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/CreditCardNumberBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/CreditCardNumberBVTest.java
@@ -44,7 +44,7 @@ class CreditCardNumberBVTest {
 
             assertThat(result.getValue())
                     .as("Should generate a 16-digit Visa credit card number by default")
-                    .startsWith("4")
+                    .matches("^[45]\\d+$")
                     .hasSize(16);
         });
     }

--- a/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/EmailBV.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/EmailBV.java
@@ -16,18 +16,21 @@
 package org.instancio.test.pojo.beanvalidation;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 public class EmailBV {
 
     @Data
     public static class OnString {
+        @NotNull
         @Email
         private String email;
     }
 
     @Data
     public static class OnCharSequence {
+        @NotNull
         @Email
         private CharSequence email;
     }

--- a/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/EmailComboBV.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/EmailComboBV.java
@@ -24,10 +24,12 @@ public class EmailComboBV {
 
     @Data
     public static class EmailWithSize {
+        @NotNull
         @Email
         @Size(min = 7, max = 12)
         private String emailThenSize;
 
+        @NotNull
         @Size(min = 10, max = 10)
         @Email
         private String sizeThenEmail;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/finance/CreditCardNumberGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/finance/CreditCardNumberGeneratorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.finance;
+
+import org.instancio.GeneratorSpecProvider;
+import org.instancio.Instancio;
+import org.instancio.internal.util.LuhnUtils;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class CreditCardNumberGeneratorTest {
+
+    private static String create(final GeneratorSpecProvider<String> spec) {
+        return Instancio.of(String.class)
+                .generate(root(), spec)
+                .create();
+    }
+
+    @Test
+    void randomCardTypesShouldBeGeneratedByDefault() {
+        final Set<String> result = Stream.generate(() -> create(gen -> gen.finance().creditCard()))
+                .limit(Constants.SAMPLE_SIZE_DD)
+                .map(s -> s.substring(0, 1))
+                .collect(Collectors.toSet());
+
+        assertThat(result)
+                .as("Should contain Visa and MasterCard prefixes")
+                .contains("4", "5");
+    }
+
+    @Test
+    void visa() {
+        final String result = create(gen -> gen.finance().creditCard().visa());
+        assertThat(result).startsWith("4");
+    }
+
+    @Test
+    void masterCard() {
+        final String result = create(gen -> gen.finance().creditCard().masterCard());
+        assertThat(result).startsWith("5");
+    }
+
+    @Test
+    void nullable() {
+        final Stream<String> result = Stream.generate(() -> create(gen -> gen.finance().creditCard().nullable()))
+                .limit(Constants.SAMPLE_SIZE_DDD);
+
+        assertThat(result).containsNull();
+    }
+
+    private static void assertResult(final String actual, final int expectedLength) {
+        assertThat(actual).containsOnlyDigits().hasSize(expectedLength);
+        assertThat(LuhnUtils.isLuhnValid(actual))
+                .as("Expected credit card number '%s' to pass Luhn check", actual)
+                .isTrue();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/EanGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/EanGeneratorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.id;
+
+import org.instancio.GeneratorSpecProvider;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class EanGeneratorTest {
+
+    private static String createEan(final GeneratorSpecProvider<String> spec) {
+        return Instancio.of(String.class)
+                .generate(root(), spec)
+                .create();
+    }
+
+    @Test
+    void defaultEanIsType13() {
+        final String result = createEan(gen -> gen.id().ean());
+
+        assertEan(result, 13);
+    }
+
+    @Test
+    void ean13() {
+        final String result = createEan(gen -> gen.id().ean().type13());
+
+        assertEan(result, 13);
+    }
+
+    @Test
+    void ean8() {
+        final String result = createEan(gen -> gen.id().ean().type8());
+
+        assertEan(result, 8);
+    }
+
+    @Test
+    void nullable() {
+        final Stream<String> result = Stream.generate(() -> createEan(gen -> gen.id().ean().nullable()))
+                .limit(Constants.SAMPLE_SIZE_DDD);
+
+        assertThat(result).containsNull();
+    }
+
+    private static void assertEan(final String result, final int expected) {
+        assertThat(result)
+                .hasSize(expected)
+                .containsOnlyDigits();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/IsbnGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/IsbnGeneratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.id;
+
+import org.instancio.GeneratorSpecProvider;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class IsbnGeneratorTest {
+
+    private static String create(final GeneratorSpecProvider<String> spec) {
+        return Instancio.of(String.class)
+                .generate(root(), spec)
+                .create();
+    }
+
+    @Test
+    void defaultEanIsType13() {
+        final String result = create(gen -> gen.id().isbn());
+
+        assertThat(result)
+                .hasSize(13)
+                .containsOnlyDigits();
+    }
+
+    @Test
+    void nullable() {
+        final Stream<String> result = Stream.generate(() -> create(gen -> gen.id().isbn().nullable()))
+                .limit(Constants.SAMPLE_SIZE_DDD);
+
+        assertThat(result).containsNull();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/net/EmailGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/net/EmailGeneratorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.net;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+class EmailGeneratorTest {
+
+    @Test
+    void create() {
+        final String result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.net().email())
+                .create();
+
+        assertThat(result).contains("@");
+    }
+
+    @Test
+    void asEmailObject() {
+        class Email {
+            final String email;
+
+            Email(String email) {
+                this.email = email;
+            }
+        }
+        class Contact {
+            Email email;
+        }
+
+        final Contact result = Instancio.of(Contact.class)
+                .generate(field("email"), gen -> gen.net().email().as(Email::new))
+                .create();
+
+        final Email email = result.email;
+        assertThat(email.email).contains("@");
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
@@ -134,6 +134,11 @@ class GeneratorMismatchTest {
     }
 
     @Test
+    void assertIdGenerators() {
+        assertMessageContains("ean()", gen -> gen.id().ean());
+    }
+
+    @Test
     void assertBoolean() {
         assertMessageContains("booleans()", Generators::booleans);
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractNumberSpecTestTemplate.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractNumberSpecTestTemplate.java
@@ -20,42 +20,25 @@ import org.instancio.generator.specs.NumberSpec;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class AbstractNumberSpecTestTemplate<T extends Number> {
+public abstract class AbstractNumberSpecTestTemplate<T extends Number>
+        extends AbstractValueSpecTestTemplate<T> {
 
-    protected abstract NumberSpec<T> getSpec();
+    protected abstract NumberSpec<T> spec();
 
     protected abstract Pair<T, T> getRange();
 
-    @Test
-    void get() {
-        final T actual = getSpec().get();
-        assertThat(actual).isNotNull();
+    @Override
+    protected void assertDefaultSpecValue(final T actual) {
         assertThat(actual.longValue()).isPositive();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<T> results = getSpec().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final BigDecimal result = getSpec().map(n -> new BigDecimal(n.toString()));
-        assertThat(result).isPositive();
     }
 
     @Test
     void min() {
         final T bound = getRange().getLeft();
-        final T actual = getSpec().min(bound).get();
+        final T actual = spec().min(bound).get();
 
         assertThat(new BigDecimal(actual.toString()))
                 .isGreaterThanOrEqualTo(new BigDecimal(bound.toString()));
@@ -64,25 +47,17 @@ public abstract class AbstractNumberSpecTestTemplate<T extends Number> {
     @Test
     void max() {
         final T bound = getRange().getLeft();
-        final T actual = getSpec().max(bound).get();
+        final T actual = spec().max(bound).get();
 
         assertThat(new BigDecimal(actual.toString()))
                 .isLessThanOrEqualTo(new BigDecimal(bound.toString()));
     }
 
     @Test
-    void nullable() {
-        final Stream<T> results = IntStream.range(0, 500)
-                .mapToObj(i -> getSpec().nullable().get());
-
-        assertThat(results).containsNull();
-    }
-
-    @Test
     void range() {
         final Pair<T, T> range = getRange();
 
-        final T actual = getSpec()
+        final T actual = spec()
                 .range(range.getLeft(), range.getRight())
                 .get();
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractValueSpecTestTemplate.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractValueSpecTestTemplate.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values;
+
+import org.assertj.core.api.Assertions;
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.generator.ValueSpec;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+public abstract class AbstractValueSpecTestTemplate<T> {
+
+    /**
+     * Returns the spec under test.
+     */
+    protected abstract ValueSpec<T> spec();
+
+    protected void assertDefaultSpecValue(T actual) {
+        // other asserts, if needed,
+        // in addition to the not null check done by this template
+    }
+
+    @Test
+    protected final void get() {
+        final T actual = spec().get();
+        assertThat(actual).isNotNull();
+        assertDefaultSpecValue(actual);
+    }
+
+    @Test
+    protected final void list() {
+        final int size = 10;
+        final List<T> results = spec().list(size);
+        assertThat(results)
+                .hasSize(size)
+                .allSatisfy(this::assertDefaultSpecValue);
+    }
+
+    @Test
+    protected final void map() {
+        final String result = spec().map(Object::toString);
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
+    protected final void nullable() {
+        for (int i = 0; i < Constants.SAMPLE_SIZE_DDD; i++) {
+            final T result = spec().nullable().get();
+            if (result == null) {
+                return;
+            }
+        }
+
+        Assertions.fail("%s.nullable() did not generate null after %s attempts",
+                spec().getClass().getSimpleName(), Constants.SAMPLE_SIZE_DDD);
+    }
+
+    @Test
+    protected final void stream() {
+        final int size = 10;
+        final Stream<T> results = spec().stream().limit(size);
+        assertThat(results)
+                .hasSize(size)
+                .allSatisfy(this::assertDefaultSpecValue);
+    }
+
+    @Test
+    protected void toModel() {
+        final Model<T> model = spec().toModel();
+        final T result = Instancio.create(model);
+        assertDefaultSpecValue(result);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/BooleanSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/BooleanSpecTest.java
@@ -15,43 +15,16 @@
  */
 package org.instancio.test.features.values;
 
+import org.instancio.Gen;
+import org.instancio.generator.ValueSpec;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.booleans;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class BooleanSpecTest {
+class BooleanSpecTest extends AbstractValueSpecTestTemplate<Boolean> {
 
-    @Test
-    void get() {
-        assertThat(booleans().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<Boolean> results = booleans().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final Integer result = booleans().map(b -> b ? 1 : 0);
-        assertThat(result).isIn(0, 1);
-    }
-
-    @Test
-    void nullable() {
-        final Stream<Boolean> result = IntStream.range(0, 500)
-                .mapToObj(i -> booleans().nullable().get());
-
-        assertThat(result).containsNull();
+    @Override
+    protected ValueSpec<Boolean> spec() {
+        return Gen.booleans();
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/CharacterSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/CharacterSpecTest.java
@@ -15,36 +15,23 @@
  */
 package org.instancio.test.features.values;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.CharacterSpec;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Gen.chars;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class CharacterSpecTest {
+class CharacterSpecTest extends AbstractValueSpecTestTemplate<Character> {
 
-    @Test
-    void get() {
-        assertThat(chars().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<Character> results = chars().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final String result = chars().map(c -> c.toString().toLowerCase());
-        assertThat(result).isLowerCase().hasSize(1);
+    @Override
+    protected CharacterSpec spec() {
+        return Gen.chars();
     }
 
     @Test
@@ -52,13 +39,5 @@ class CharacterSpecTest {
         final int size = 1000;
         final List<Character> result = chars().range('x', 'z').list(size);
         assertThat(result).containsOnly('x', 'y', 'z');
-    }
-
-    @Test
-    void nullable() {
-        final Stream<Character> result = IntStream.range(0, 500)
-                .mapToObj(i -> chars().nullable().get());
-
-        assertThat(result).containsNull();
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/NumberSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/NumberSpecTest.java
@@ -34,7 +34,7 @@ class NumberSpecTest {
     @Nested
     class ByteSpecTest extends AbstractNumberSpecTestTemplate<Byte> {
         @Override
-        protected NumberSpec<Byte> getSpec() {
+        protected NumberSpec<Byte> spec() {
             return bytes();
         }
 
@@ -47,7 +47,7 @@ class NumberSpecTest {
     @Nested
     class ShortSpecTest extends AbstractNumberSpecTestTemplate<Short> {
         @Override
-        protected NumberSpec<Short> getSpec() {
+        protected NumberSpec<Short> spec() {
             return shorts();
         }
 
@@ -60,7 +60,7 @@ class NumberSpecTest {
     @Nested
     class IntegerSpecTest extends AbstractNumberSpecTestTemplate<Integer> {
         @Override
-        protected NumberSpec<Integer> getSpec() {
+        protected NumberSpec<Integer> spec() {
             return ints();
         }
 
@@ -73,7 +73,7 @@ class NumberSpecTest {
     @Nested
     class LongSpecTest extends AbstractNumberSpecTestTemplate<Long> {
         @Override
-        protected NumberSpec<Long> getSpec() {
+        protected NumberSpec<Long> spec() {
             return longs();
         }
 
@@ -86,7 +86,7 @@ class NumberSpecTest {
     @Nested
     class FloatSpecTest extends AbstractNumberSpecTestTemplate<Float> {
         @Override
-        protected NumberSpec<Float> getSpec() {
+        protected NumberSpec<Float> spec() {
             return floats();
         }
 
@@ -99,7 +99,7 @@ class NumberSpecTest {
     @Nested
     class DoubleSpecTest extends AbstractNumberSpecTestTemplate<Double> {
         @Override
-        protected NumberSpec<Double> getSpec() {
+        protected NumberSpec<Double> spec() {
             return doubles();
         }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.test.features.values;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.StringSpec;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
@@ -25,76 +27,51 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.math.BigInteger;
-import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.string;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class StringSpecTest {
+class StringSpecTest extends AbstractValueSpecTestTemplate<String> {
 
-    @Test
-    void get() {
-        assertThat(string().get()).isNotBlank();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<String> results = string().length(50).list(size);
-        assertThat(new HashSet<>(results)).hasSize(size);
-    }
-
-    @Test
-    void stream() {
-        final int size = 10;
-        final Stream<String> result = string().stream().filter(s -> s.contains("X"))
-                .limit(size);
-
-        assertThat(result).hasSize(size).allMatch(s -> s.contains("X"));
-    }
-
-    @Test
-    void map() {
-        final BigInteger result = string().digits().map(BigInteger::new);
-        assertThat(result).isPositive();
+    @Override
+    protected StringSpec spec() {
+        return Gen.string();
     }
 
     @Test
     void prefix() {
-        assertThat(string().prefix("foo").get()).startsWith("foo");
+        assertThat(spec().prefix("foo").get()).startsWith("foo");
     }
 
     @Test
     void suffix() {
-        assertThat(string().suffix("foo").get()).endsWith("foo");
+        assertThat(spec().suffix("foo").get()).endsWith("foo");
     }
 
     @Test
     void length() {
-        assertThat(string().length(5).get()).hasSize(5);
-        assertThat(string().length(5, 7).get()).hasSizeBetween(5, 7);
-        assertThat(string().minLength(10).get()).hasSizeGreaterThanOrEqualTo(10);
-        assertThat(string().maxLength(1).get()).hasSizeLessThanOrEqualTo(1);
+        assertThat(spec().length(5).get()).hasSize(5);
+        assertThat(spec().length(5, 7).get()).hasSizeBetween(5, 7);
+        assertThat(spec().minLength(10).get()).hasSizeGreaterThanOrEqualTo(10);
+        assertThat(spec().maxLength(1).get()).hasSizeLessThanOrEqualTo(1);
     }
 
     @Test
     void cases() {
-        assertThat(string().upperCase().get()).isUpperCase();
-        assertThat(string().lowerCase().get()).isLowerCase();
-        assertThat(string().mixedCase().length(20).get()).isMixedCase();
-        assertThat(string().alphaNumeric().length(20).get()).isAlphanumeric();
-        assertThat(string().digits().get()).containsOnlyDigits();
+        assertThat(spec().upperCase().get()).isUpperCase();
+        assertThat(spec().lowerCase().get()).isLowerCase();
+        assertThat(spec().mixedCase().length(20).get()).isMixedCase();
+        assertThat(spec().alphaNumeric().length(20).get()).isAlphanumeric();
+        assertThat(spec().digits().get()).containsOnlyDigits();
     }
 
     @Test
     void allowEmptyAndNullable() {
         final Stream<String> result = IntStream.range(0, 500)
-                .mapToObj(i -> string().allowEmpty().nullable().get());
+                .mapToObj(i -> spec().allowEmpty().nullable().get());
 
         assertThat(result).contains("").containsNull();
     }
@@ -109,7 +86,7 @@ class StringSpecTest {
 
         @Test
         void disallowEmpty() {
-            final List<String> results = string().allowEmpty(false).list(500);
+            final List<String> results = spec().allowEmpty(false).list(500);
 
             assertThat(results).hasSize(500).doesNotContain("");
         }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/array/OneOfArraySpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/array/OneOfArraySpecTest.java
@@ -16,33 +16,39 @@
 package org.instancio.test.features.values.array;
 
 import org.instancio.Gen;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.generator.specs.OneOfArraySpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class OneOfArraySpecTest {
+class OneOfArraySpecTest extends AbstractValueSpecTestTemplate<String> {
 
     private static final String[] CHOICES = {"foo", "bar", "baz"};
 
-    @Test
-    void get() {
-        final String result = Gen.oneOf(CHOICES).get();
-        assertThat(result).isIn((Object[]) CHOICES);
+    @Override
+    protected OneOfArraySpec<String> spec() {
+        return Gen.oneOf(CHOICES);
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).isIn(Arrays.asList(CHOICES));
     }
 
     @Test
-    void list() {
-        final List<String> result = Gen.oneOf(CHOICES).list(100);
-        assertThat(result).contains(CHOICES);
-    }
-
-    @Test
-    void map() {
-        assertThat(Gen.oneOf(CHOICES).map(String::length)).isEqualTo(3);
+    @Override
+    protected void toModel() {
+        final OneOfArraySpec<String> spec = spec();
+        assertThatThrownBy(spec::toModel)
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("oneOf() spec does not support toModel()");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/collection/OneOfCollectionSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/collection/OneOfCollectionSpecTest.java
@@ -16,6 +16,9 @@
 package org.instancio.test.features.values.collection;
 
 import org.instancio.Gen;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.generator.specs.OneOfCollectionSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
@@ -24,26 +27,29 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class OneOfCollectionSpecTest {
+class OneOfCollectionSpecTest extends AbstractValueSpecTestTemplate<String> {
 
     private static final List<String> CHOICES = Arrays.asList("foo", "bar", "baz");
 
-    @Test
-    void get() {
-        final String result = Gen.oneOf(CHOICES).get();
-        assertThat(result).isIn(CHOICES);
+    @Override
+    protected OneOfCollectionSpec<String> spec() {
+        return Gen.oneOf(CHOICES);
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).isIn(CHOICES);
     }
 
     @Test
-    void list() {
-        final List<String> result = Gen.oneOf(CHOICES).list(100);
-        assertThat(result).containsAll(CHOICES);
-    }
-
-    @Test
-    void map() {
-        assertThat(Gen.oneOf(CHOICES).map(String::length)).isEqualTo(3);
+    @Override
+    protected void toModel() {
+        final OneOfCollectionSpec<String> spec = spec();
+        assertThatThrownBy(spec::toModel)
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("oneOf() spec does not support toModel()");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/finance/CreditCardSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/finance/CreditCardSpecTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.finance;
+
+import org.instancio.Gen;
+import org.instancio.generator.specs.CreditCardSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+class CreditCardSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected CreditCardSpec spec() {
+        return Gen.finance().creditCard();
+    }
+
+    @Test
+    void visa() {
+        assertThat(spec().visa().get()).startsWith("4");
+    }
+
+    @Test
+    void masterCard() {
+        assertThat(spec().masterCard().get()).startsWith("5");
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/id/EanSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/id/EanSpecTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.id;
+
+import org.instancio.Gen;
+import org.instancio.generator.specs.EanSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+class EanSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected EanSpec spec() {
+        return Gen.id().ean();
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).containsOnlyDigits().hasSize(13);
+    }
+
+    @Test
+    void type8() {
+        assertThat(spec().type8().get())
+                .containsOnlyDigits()
+                .hasSize(8);
+    }
+
+    @Test
+    void type13() {
+        assertThat(spec().type13().get())
+                .containsOnlyDigits()
+                .hasSize(13);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/id/IsbnSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/id/IsbnSpecTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.id;
+
+import org.instancio.Gen;
+import org.instancio.generator.ValueSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+class IsbnSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected ValueSpec<String> spec() {
+        return Gen.id().isbn();
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).containsOnlyDigits().hasSize(13);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/io/FileValueSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/io/FileValueSpecTest.java
@@ -15,6 +15,9 @@
  */
 package org.instancio.test.features.values.io;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.FileSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
@@ -22,69 +25,53 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.net.URI;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.io;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class FileValueSpecTest {
+class FileValueSpecTest extends AbstractValueSpecTestTemplate<File> {
 
-    @Test
-    void get() {
-        assertThat(io().file().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<File> results = io().file().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final URI result = io().file().map(File::toURI);
-        assertThat(result).isNotNull();
+    @Override
+    protected FileSpec spec() {
+        return Gen.io().file();
     }
 
     @Test
     void name() {
-        assertThat(io().file().name(r -> "foo").get()).hasFileName("foo");
+        assertThat(spec().name(r -> "foo").get()).hasFileName("foo");
     }
 
     @Test
     void prefix() {
-        assertThat(io().file().prefix("prefix").get().toString()).startsWith("prefix");
+        assertThat(spec().prefix("prefix").get().toString()).startsWith("prefix");
     }
 
     @Test
     void suffix() {
-        assertThat(io().file().suffix("suffix").get().toString()).endsWith("suffix");
+        assertThat(spec().suffix("suffix").get().toString()).endsWith("suffix");
     }
 
     @Test
     void tmp() {
-        assertThat(io().file().tmp().get().toString()).contains(System.getProperty("java.io.tmpdir"));
+        assertThat(spec().tmp().get().toString()).contains(System.getProperty("java.io.tmpdir"));
     }
 
     @Test
     void createDirectory() {
-        final File actual = io().file().tmp().createDirectory().get();
+        final File actual = spec().tmp().createDirectory().get();
         assertThat(actual).exists().isDirectory();
     }
 
     @Test
     void createFile() {
-        final File actual = io().file().tmp().createFile().get();
+        final File actual = spec().tmp().createFile().get();
         assertThat(actual).exists().isEmpty();
     }
 
     @Test
     void createFileWithContent() {
         final InputStream is = new ByteArrayInputStream("foo".getBytes());
-        final File actual = io().file().tmp().createFile(is).get();
+        final File actual = spec().tmp().createFile(is).get();
         assertThat(actual).hasContent("foo");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigDecimalSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigDecimalSpecTest.java
@@ -15,68 +15,46 @@
  */
 package org.instancio.test.features.values.math;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.BigDecimalSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.math;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class BigDecimalSpecTest {
+class BigDecimalSpecTest extends AbstractValueSpecTestTemplate<BigDecimal> {
 
-    @Test
-    void get() {
-        assertThat(math().bigDecimal().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<BigDecimal> results = math().bigDecimal().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final String result = math().bigDecimal().map(BigDecimal::toString);
-        assertThat(result).isNotBlank();
-    }
-
-    @Test
-    void nullable() {
-        final Stream<BigDecimal> result = IntStream.range(0, 500)
-                .mapToObj(i -> math().bigDecimal().nullable().get());
-
-        assertThat(result).containsNull();
+    @Override
+    protected BigDecimalSpec spec() {
+        return Gen.math().bigDecimal();
     }
 
     @Test
     void scale() {
-        final BigDecimal result = math().bigDecimal().scale(10).get();
+        final BigDecimal result = spec().scale(10).get();
         assertThat(result).hasScaleOf(10);
     }
 
     @Test
     void min() {
-        final BigDecimal result = math().bigDecimal().min(new BigDecimal(Integer.MAX_VALUE)).get();
+        final BigDecimal result = spec().min(new BigDecimal(Integer.MAX_VALUE)).get();
         assertThat(result).isGreaterThanOrEqualTo(new BigDecimal(Integer.MAX_VALUE));
     }
 
     @Test
     void max() {
-        final BigDecimal result = math().bigDecimal().max(new BigDecimal(Integer.MIN_VALUE)).get();
+        final BigDecimal result = spec().max(new BigDecimal(Integer.MIN_VALUE)).get();
         assertThat(result).isLessThanOrEqualTo(new BigDecimal(Integer.MIN_VALUE));
     }
 
     @Test
     void range() {
-        final BigDecimal result = math().bigDecimal().range(BigDecimal.ZERO, BigDecimal.ONE).get();
+        final BigDecimal result = spec().range(BigDecimal.ZERO, BigDecimal.ONE).get();
         assertThat(result).isBetween(BigDecimal.ZERO, BigDecimal.ONE);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigIntegerValueSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigIntegerValueSpecTest.java
@@ -28,7 +28,7 @@ import java.math.BigInteger;
 class BigIntegerValueSpecTest extends AbstractNumberSpecTestTemplate<BigInteger> {
 
     @Override
-    protected NumberSpec<BigInteger> getSpec() {
+    protected NumberSpec<BigInteger> spec() {
         return Gen.math().bigInteger();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/EmailSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/EmailSpecTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.net;
+
+import org.instancio.Gen;
+import org.instancio.generator.specs.EmailSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+class EmailSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected EmailSpec spec() {
+        return Gen.net().email();
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).matches("^\\w+@\\w+\\.\\p{Lower}{3}$");
+    }
+
+    @Test
+    void length() {
+        final String result = spec().length(20).get();
+        assertThat(result).hasSize(20);
+    }
+
+    @Test
+    void lengthRange() {
+        final String result = spec().length(3, 10).get();
+        assertThat(result).hasSizeBetween(3, 20);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/URISpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/URISpecTest.java
@@ -15,35 +15,24 @@
  */
 package org.instancio.test.features.values.net;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.URISpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Gen.net;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class URISpecTest {
+class URISpecTest extends AbstractValueSpecTestTemplate<URI> {
 
-    @Test
-    void get() {
-        assertThat(net().uri().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<URI> results = net().uri().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final String result = net().uri().map(URI::toString);
-        assertThat(result).isNotBlank();
+    @Override
+    protected URISpec spec() {
+        return Gen.net().uri();
     }
 
     @Test

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/URLSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/URLSpecTest.java
@@ -15,54 +15,42 @@
  */
 package org.instancio.test.features.values.net;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.URLSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.net;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class URLSpecTest {
+class URLSpecTest extends AbstractValueSpecTestTemplate<URL> {
 
-    @Test
-    void get() {
-        assertThat(net().url().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<URL> results = net().url().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final String result = net().url().map(URL::toString);
-        assertThat(result).isNotBlank();
+    @Override
+    protected URLSpec spec() {
+        return Gen.net().url();
     }
 
     @Test
     void protocol() {
-        assertThat(net().url().protocol("ftp").get()).hasProtocol("ftp");
+        assertThat(spec().protocol("ftp").get()).hasProtocol("ftp");
     }
 
     @Test
     void host() {
-        assertThat(net().url().host(r -> "foo").get()).hasHost("foo");
+        assertThat(spec().host(r -> "foo").get()).hasHost("foo");
     }
 
     @Test
     void port() {
-        assertThat(net().url().port(1234).get()).hasPort(1234);
+        assertThat(spec().port(1234).get()).hasPort(1234);
     }
 
     @Test
     void file() {
-        assertThat(net().url().file(r -> "foo").get()).hasPath("foo");
+        assertThat(spec().file(r -> "foo").get()).hasPath("foo");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/nio/PathSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/nio/PathSpecTest.java
@@ -15,76 +15,63 @@
  */
 package org.instancio.test.features.values.nio;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.PathSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.net.URI;
 import java.nio.file.Path;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.nio;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class PathSpecTest {
+class PathSpecTest extends AbstractValueSpecTestTemplate<Path> {
 
-    @Test
-    void get() {
-        assertThat(nio().path().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<Path> results = nio().path().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final URI result = nio().path().map(Path::toUri);
-        assertThat(result).isNotNull();
+    @Override
+    protected PathSpec spec() {
+        return Gen.nio().path();
     }
 
     @Test
     void name() {
-        assertThat(nio().path().name(r -> "foo").get()).hasFileName("foo");
+        assertThat(spec().name(r -> "foo").get()).hasFileName("foo");
     }
 
     @Test
     void prefix() {
-        assertThat(nio().path().prefix("prefix").get().toString()).startsWith("prefix");
+        assertThat(spec().prefix("prefix").get().toString()).startsWith("prefix");
     }
 
     @Test
     void suffix() {
-        assertThat(nio().path().suffix("suffix").get().toString()).endsWith("suffix");
+        assertThat(spec().suffix("suffix").get().toString()).endsWith("suffix");
     }
 
     @Test
     void tmp() {
-        assertThat(nio().path().tmp().get().toString()).contains(System.getProperty("java.io.tmpdir"));
+        assertThat(spec().tmp().get().toString()).contains(System.getProperty("java.io.tmpdir"));
     }
 
     @Test
     void createDirectory() {
-        final Path actual = nio().path().tmp().createDirectory().get();
+        final Path actual = spec().tmp().createDirectory().get();
         assertThat(actual).exists().isDirectory();
     }
 
     @Test
     void createFile() {
-        final Path actual = nio().path().tmp().createFile().get();
+        final Path actual = spec().tmp().createFile().get();
         assertThat(actual).exists().isEmptyFile();
     }
 
     @Test
     void createFileWithContent() {
         final InputStream is = new ByteArrayInputStream("foo".getBytes());
-        final Path actual = nio().path().tmp().createFile(is).get();
+        final Path actual = spec().tmp().createFile(is).get();
         assertThat(actual).hasContent("foo");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/AbstractTemporalSpecTestTemplate.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/AbstractTemporalSpecTestTemplate.java
@@ -17,66 +17,44 @@ package org.instancio.test.features.values.temporal;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.instancio.generator.specs.TemporalSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.time.temporal.Temporal;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-abstract class AbstractTemporalSpecTestTemplate<T extends Temporal & Comparable<? super T>> {
-
-    abstract TemporalSpec<T> getSpec();
+abstract class AbstractTemporalSpecTestTemplate<T extends Temporal & Comparable<? super T>>
+        extends AbstractValueSpecTestTemplate<T> {
 
     abstract Pair<T, T> getRangeFromNow();
 
-    @Test
-    void get() {
-        final T actual = getSpec().get();
-        assertThat(actual).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<T> results = getSpec().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final String result = getSpec().map(Object::toString);
-        assertThat(result).isNotBlank();
-    }
+    @Override
+    protected abstract TemporalSpec<T> spec();
 
     @Test
     void past() {
-        final T actual = getSpec().past().get();
+        final T actual = spec().past().get();
         assertThat(actual).isLessThan(getNow());
     }
 
     @Test
     void future() {
-        final T actual = getSpec().future().get();
+        final T actual = spec().future().get();
         assertThat(actual).isGreaterThan(getNow());
     }
 
-    @Test
+    @RepeatedTest(Constants.SAMPLE_SIZE_DD)
     void range() {
         final Pair<T, T> range = getRangeFromNow();
 
-        final T actual = getSpec()
+        final T actual = spec()
                 .range(range.getLeft(), range.getRight())
                 .get();
 
         assertThat(actual).isBetween(range.getLeft(), range.getRight());
-    }
-
-    @Test
-    void nullable() {
-        final int size = 500;
-        final List<T> actual = getSpec().nullable().list(size);
-        assertThat(actual).containsNull();
     }
 
     private T getNow() {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/DurationValueSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/DurationValueSpecTest.java
@@ -15,6 +15,9 @@
  */
 package org.instancio.test.features.values.temporal;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.DurationSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
@@ -25,34 +28,20 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.temporal;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class DurationValueSpecTest {
+class DurationValueSpecTest extends AbstractValueSpecTestTemplate<Duration> {
 
-    @Test
-    void get() {
-        assertThat(temporal().duration().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<Duration> results = temporal().duration().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final Long result = temporal().duration().map(Duration::toNanos);
-        assertThat(result).isPositive();
+    @Override
+    protected DurationSpec spec() {
+        return Gen.temporal().duration();
     }
 
     @Test
     void min() {
         final Duration min = Duration.of(1000, ChronoUnit.DAYS);
 
-        final List<Duration> actual = temporal().duration().min(min.toDays(), ChronoUnit.DAYS)
+        final List<Duration> actual = spec().min(min.toDays(), ChronoUnit.DAYS)
                 .list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
@@ -64,7 +53,7 @@ class DurationValueSpecTest {
     void max() {
         final Duration max = Duration.of(-1000, ChronoUnit.DAYS);
 
-        final List<Duration> actual = temporal().duration().max(max.toDays(), ChronoUnit.DAYS)
+        final List<Duration> actual = spec().max(max.toDays(), ChronoUnit.DAYS)
                 .list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
@@ -77,7 +66,7 @@ class DurationValueSpecTest {
         final Duration min = Duration.of(1, ChronoUnit.SECONDS);
         final Duration max = Duration.of(10, ChronoUnit.SECONDS);
 
-        final List<Duration> actual = temporal().duration()
+        final List<Duration> actual = spec()
                 .min(min.toNanos(), ChronoUnit.NANOS)
                 .max(max.toNanos(), ChronoUnit.NANOS)
                 .list(Constants.SAMPLE_SIZE_DDD);
@@ -92,7 +81,7 @@ class DurationValueSpecTest {
         final Duration min = Duration.of(1, ChronoUnit.DAYS);
         final Duration max = Duration.of(9, ChronoUnit.DAYS);
 
-        final List<Duration> actual = temporal().duration().of(1, 9, ChronoUnit.DAYS)
+        final List<Duration> actual = spec().of(1, 9, ChronoUnit.DAYS)
                 .list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
@@ -102,7 +91,7 @@ class DurationValueSpecTest {
 
     @Test
     void allowZero() {
-        final List<Duration> actual = temporal().duration().allowZero().list(Constants.SAMPLE_SIZE_DDD);
+        final List<Duration> actual = spec().allowZero().list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
                 .hasSize(Constants.SAMPLE_SIZE_DDD)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/PeriodValueSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/PeriodValueSpecTest.java
@@ -15,6 +15,9 @@
  */
 package org.instancio.test.features.values.temporal;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.PeriodSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
@@ -24,35 +27,21 @@ import java.time.Period;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.temporal;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class PeriodValueSpecTest {
+class PeriodValueSpecTest extends AbstractValueSpecTestTemplate<Period> {
 
     private static final int MIN = 1;
     private static final int MAX = 9;
 
-    @Test
-    void get() {
-        assertThat(temporal().period().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<Period> results = temporal().period().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final Integer result = temporal().period().map(Period::getDays);
-        assertThat(result).isPositive();
+    @Override
+    protected PeriodSpec spec() {
+        return Gen.temporal().period();
     }
 
     @Test
     void days() {
-        final List<Period> actual = temporal().period().days(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
+        final List<Period> actual = spec().days(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
                 .hasSize(Constants.SAMPLE_SIZE_DDD)
@@ -61,7 +50,7 @@ class PeriodValueSpecTest {
 
     @Test
     void months() {
-        final List<Period> actual = temporal().period().months(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
+        final List<Period> actual = spec().months(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
                 .hasSize(Constants.SAMPLE_SIZE_DDD)
@@ -70,7 +59,7 @@ class PeriodValueSpecTest {
 
     @Test
     void years() {
-        final List<Period> actual = temporal().period().years(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
+        final List<Period> actual = spec().years(MIN, MAX).list(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(actual)
                 .hasSize(Constants.SAMPLE_SIZE_DDD)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/TemporalSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/TemporalSpecTest.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.instancio.generator.specs.TemporalSpec;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Nested;
 
 import java.time.Instant;
@@ -41,7 +40,7 @@ class TemporalSpecTest {
     @Nested
     class InstantValueSpecTest extends AbstractTemporalSpecTestTemplate<Instant> {
         @Override
-        TemporalSpec<Instant> getSpec() {
+        protected TemporalSpec<Instant> spec() {
             return temporal().instant();
         }
 
@@ -55,7 +54,7 @@ class TemporalSpecTest {
     @Nested
     class LocalDateValueSpecTest extends AbstractTemporalSpecTestTemplate<LocalDate> {
         @Override
-        TemporalSpec<LocalDate> getSpec() {
+        protected TemporalSpec<LocalDate> spec() {
             return temporal().localDate();
         }
 
@@ -69,7 +68,7 @@ class TemporalSpecTest {
     @Nested
     class LocalDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<LocalDateTime> {
         @Override
-        TemporalSpec<LocalDateTime> getSpec() {
+        protected TemporalSpec<LocalDateTime> spec() {
             return temporal().localDateTime();
         }
 
@@ -81,53 +80,51 @@ class TemporalSpecTest {
     }
 
     @Nested
-    @NonDeterministicTag("This test will fail if run less than 5 nanos before midnight")
     class LocalTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<LocalTime> {
         @Override
-        TemporalSpec<LocalTime> getSpec() {
+        protected TemporalSpec<LocalTime> spec() {
             return temporal().localTime();
         }
 
         @Override
         Pair<LocalTime, LocalTime> getRangeFromNow() {
             final LocalTime now = LocalTime.now();
-            return Pair.of(now, now.plusNanos(5));
+            return Pair.of(now, LocalTime.MAX);
         }
     }
 
     @Nested
     class OffsetDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<OffsetDateTime> {
         @Override
-        TemporalSpec<OffsetDateTime> getSpec() {
+        protected TemporalSpec<OffsetDateTime> spec() {
             return temporal().offsetDateTime();
         }
 
         @Override
         Pair<OffsetDateTime, OffsetDateTime> getRangeFromNow() {
-            final OffsetDateTime now = OffsetDateTime.now();
+            final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             return Pair.of(now, now.plusDays(400));
         }
     }
 
     @Nested
-    @NonDeterministicTag("This test will fail if run less than 5 nanos before midnight")
     class OffsetTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<OffsetTime> {
         @Override
-        TemporalSpec<OffsetTime> getSpec() {
+        protected TemporalSpec<OffsetTime> spec() {
             return temporal().offsetTime();
         }
 
         @Override
         Pair<OffsetTime, OffsetTime> getRangeFromNow() {
             final OffsetTime now = OffsetTime.now(ZoneOffset.UTC);
-            return Pair.of(now, now.plusNanos(5));
+            return Pair.of(now, OffsetTime.MAX);
         }
     }
 
     @Nested
     class YearValueSpecTest extends AbstractTemporalSpecTestTemplate<Year> {
         @Override
-        TemporalSpec<Year> getSpec() {
+        protected TemporalSpec<Year> spec() {
             return temporal().year();
         }
 
@@ -141,7 +138,7 @@ class TemporalSpecTest {
     @Nested
     class YearMonthValueSpecTest extends AbstractTemporalSpecTestTemplate<YearMonth> {
         @Override
-        TemporalSpec<YearMonth> getSpec() {
+        protected TemporalSpec<YearMonth> spec() {
             return temporal().yearMonth();
         }
 
@@ -155,7 +152,7 @@ class TemporalSpecTest {
     @Nested
     class ZonedDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<ZonedDateTime> {
         @Override
-        TemporalSpec<ZonedDateTime> getSpec() {
+        protected TemporalSpec<ZonedDateTime> spec() {
             return temporal().zonedDateTime();
         }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/LoremIpsumSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/LoremIpsumSpecTest.java
@@ -15,45 +15,32 @@
  */
 package org.instancio.test.features.values.text;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.LoremIpsumSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.text;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class LoremIpsumSpecTest {
+class LoremIpsumSpecTest extends AbstractValueSpecTestTemplate<String> {
 
-    @Test
-    void get() {
-        assertThat(text().loremIpsum().get()).isNotNull();
-    }
-
-    @Test
-    void list() {
-        final int size = 10;
-        final List<String> results = text().loremIpsum().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final Integer result = text().loremIpsum().map(String::length);
-        assertThat(result).isPositive();
+    @Override
+    protected LoremIpsumSpec spec() {
+        return Gen.text().loremIpsum();
     }
 
     @Test
     void words() {
-        final String result = text().loremIpsum().words(2).get();
+        final String result = spec().words(2).get();
         assertThat(result).matches("\\w+ \\w+\\.");
     }
 
     @Test
     void paragraphs() {
-        final String result = text().loremIpsum().paragraphs(1).get();
+        final String result = spec().paragraphs(1).get();
         assertThat(result.split(System.lineSeparator())).hasSize(1);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/TextPatternValueSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/TextPatternValueSpecTest.java
@@ -15,33 +15,24 @@
  */
 package org.instancio.test.features.values.text;
 
+import org.instancio.Gen;
+import org.instancio.generator.ValueSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.text;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class TextPatternValueSpecTest {
+class TextPatternValueSpecTest extends AbstractValueSpecTestTemplate<String> {
 
-    @Test
-    void get() {
-        assertThat(text().pattern("#d#d#d").get()).hasSize(3).containsOnlyDigits();
+    @Override
+    protected ValueSpec<String> spec() {
+        return Gen.text().pattern("#d#d#d");
     }
 
-    @Test
-    void list() {
-        final int size = 10;
-        final List<String> results = text().pattern("foo").list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final Integer result = text().pattern("#d").map(Integer::valueOf);
-        assertThat(result).isBetween(0, 9);
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).hasSize(3).containsOnlyDigits();
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/UUIDStringSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/UUIDStringSpecTest.java
@@ -15,46 +15,32 @@
  */
 package org.instancio.test.features.values.text;
 
+import org.instancio.Gen;
+import org.instancio.generator.specs.UUIDStringSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Gen.text;
 
 @FeatureTag(Feature.VALUE_SPEC)
-class UUIDStringSpecTest {
+class UUIDStringSpecTest extends AbstractValueSpecTestTemplate<String> {
 
-    @Test
-    void get() {
-        assertThat(text().uuid().get()).isNotNull();
+    @Override
+    protected UUIDStringSpec spec() {
+        return Gen.text().uuid();
     }
 
     @Test
-    void list() {
-        final int size = 10;
-        final List<String> results = text().uuid().list(size);
-        assertThat(results).hasSize(size);
-    }
-
-    @Test
-    void map() {
-        final UUID result = text().uuid().map(UUID::fromString);
-        assertThat(result).isNotNull();
-    }
-
-    @Test
-    void words() {
-        final String result = text().uuid().upperCase().get();
+    void upperCase() {
+        final String result = spec().upperCase().get();
         assertThat(result).isUpperCase();
     }
 
     @Test
-    void paragraphs() {
-        final String result = text().uuid().withoutDashes().get();
+    void withoutDashes() {
+        final String result = spec().withoutDashes().get();
         assertThat(result).doesNotContain("-");
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/finance/CreditCardNumberGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/finance/CreditCardNumberGeneratorTest.java
@@ -40,13 +40,13 @@ class CreditCardNumberGeneratorTest {
 
     @Test
     void apiMethod() {
-        assertThat(generator.apiMethod()).isNull();
+        assertThat(generator.apiMethod()).isEqualTo("creditCard()");
     }
 
     @Test
     void generate() {
         for (int i = 0; i < Constants.SAMPLE_SIZE_DDD; i++) {
-            final CreditCardType cardType = Gen.oneOf(CreditCardType.values()).get();
+            final CCTypeImpl cardType = Gen.oneOf(CCTypeImpl.values()).get();
 
             final String[] prefixes = cardType.getPrefixes().stream()
                     .map(Object::toString)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/id/EanGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/id/EanGeneratorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.domain.id;
+
+import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.random.DefaultRandom;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EanGeneratorTest {
+    private final Random random = new DefaultRandom();
+    private final EanGenerator generator = new EanGenerator(
+            new GeneratorContext(Settings.defaults(), random));
+
+    @Test
+    void apiMethod() {
+        assertThat(generator.apiMethod()).isEqualTo("ean()");
+    }
+
+    @Test
+    void generate() {
+        final String result = generator.generate(random);
+        assertThat(result).hasSize(13); // default is EAN-13
+        // Actual validation is done in Hibernate bean validation tests
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/id/IsbnGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/id/IsbnGeneratorTest.java
@@ -30,7 +30,7 @@ class IsbnGeneratorTest {
 
     @Test
     void apiMethod() {
-        assertThat(generator.apiMethod()).isNull();
+        assertThat(generator.apiMethod()).isEqualTo("isbn()");
     }
 
     @Test

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/internet/EmailGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/domain/internet/EmailGeneratorTest.java
@@ -27,21 +27,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Gen.ints;
 
-class EmailAddressGeneratorTest {
-    private static final String ALLOWED_HASHTAGS_MESSAGE = String.format("%nAllowed hashtags:"
-            + "%n\t#a - alphanumeric character [a-z, A-Z, 0-9]"
-            + "%n\t#c - lower case character [a-z]"
-            + "%n\t#C - upper case character [A-Z]"
-            + "%n\t#d - digit [0-9]"
-            + "%n\t## - hash symbol escape%n");
-
+class EmailGeneratorTest {
     private static final Random random = new DefaultRandom();
     private final GeneratorContext context = new GeneratorContext(Settings.create(), random);
-    private final EmailAddressGenerator generator = new EmailAddressGenerator(context);
+    private final EmailGenerator generator = new EmailGenerator(context);
 
     @Test
     void apiMethod() {
-        assertThat(generator.apiMethod()).isNull();
+        assertThat(generator.apiMethod()).isEqualTo("email()");
     }
 
     @ValueSource(ints = {3, 4, 5, 6})
@@ -56,7 +49,7 @@ class EmailAddressGeneratorTest {
     @ValueSource(ints = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20})
     @ParameterizedTest
     void lengthGreaterThanSix(final int length) {
-        EmailAddressGenerator generator = new EmailAddressGenerator(context);
+        EmailGenerator generator = new EmailGenerator(context);
         generator.length(length);
         assertThat(generator.generate(random))
                 .hasSize(length)


### PR DESCRIPTION
- introduced specs for generators that are used for generating data based on Hibernate Validator annotations (e.g. EAN, ISBN, etc)

- factored out handling of nullable values

- refactored spec tests to use a common test template + misc cleanup