### PR TITLE
Added validation for Collection generator to reject `EnumSet`.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/GeneratorSupport.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratorSupport.java
@@ -52,7 +52,8 @@ final class GeneratorSupport {
             return EnumSet.class.isAssignableFrom(type);
         }
         if (generator instanceof CollectionGeneratorSpec) {
-            return Collection.class.isAssignableFrom(type) || type == Iterable.class;
+            return (Collection.class.isAssignableFrom(type) || type == Iterable.class)
+                    && type != EnumSet.class;
         }
         if (generator instanceof MapGeneratorSpec) {
             return Map.class.isAssignableFrom(type);
@@ -62,10 +63,10 @@ final class GeneratorSupport {
         }
         final Class<?> typeArg = TypeUtils.getGenericSuperclassTypeArgument(generator.getClass());
         if (typeArg != null) {
-            return type.isAssignableFrom(typeArg)
-                    || PrimitiveWrapperBiLookup.findEquivalent(typeArg)
-                    .filter(type::isAssignableFrom)
-                    .isPresent();
+            return type.isAssignableFrom(typeArg) ||
+                    PrimitiveWrapperBiLookup.findEquivalent(typeArg)
+                            .filter(type::isAssignableFrom)
+                            .isPresent();
         }
         // couldn't determine type arg ('this' is probably a lambda)
         return false;

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -73,7 +73,7 @@ public final class NodeFactory {
 
     /**
      * Creates children for the given node.
-     * Returned children will not have of their own.
+     * Returned children will not have children of their own.
      *
      * @param node to create children for
      * @return child nodes (without children), or an empty list if none.

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/BuiltInCollectionGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/BuiltInCollectionGeneratorTest.java
@@ -17,7 +17,9 @@ package org.instancio.test.features.generator;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.instancio.Instancio;
+import org.instancio.InstancioApi;
 import org.instancio.TypeToken;
+import org.instancio.exception.InstancioApiException;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
@@ -30,6 +32,7 @@ import org.instancio.test.support.pojo.collections.maps.TwoMapsOfIntegerItemStri
 import org.instancio.test.support.pojo.collections.sets.HashSetLong;
 import org.instancio.test.support.pojo.collections.sets.SetLong;
 import org.instancio.test.support.pojo.generics.basic.Item;
+import org.instancio.test.support.pojo.person.Gender;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.tags.NonDeterministicTag;
@@ -41,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +54,7 @@ import java.util.TreeMap;
 import java.util.Vector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.all;
 import static org.instancio.Select.field;
 import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
@@ -208,6 +213,24 @@ class BuiltInCollectionGeneratorTest {
             assertThat(list)
                     .hasSizeBetween(minSize, maxSize)
                     .allSatisfy(item -> assertThat(item.getValue()).isInstanceOf(String.class));
+        }
+    }
+
+    @Nested
+    class ValidationTest {
+
+        /**
+         * {@link EnumSet} os has a dedicated generator and
+         * is not supported by the collection generator.
+         */
+        @Test
+        void shouldRejectEnumSet() {
+            final InstancioApi<EnumSet<Gender>> api = Instancio.of(new TypeToken<EnumSet<Gender>>() {})
+                    .generate(all(EnumSet.class), gen -> gen.collection().size(1));
+
+            assertThatThrownBy(api::create)
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("Method 'collection()' cannot be used for type: java.util.EnumSet");
         }
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/IterableUsingCollectionGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/IterableUsingCollectionGeneratorTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
 import static org.instancio.Select.root;
 
 @FeatureTag(Feature.GENERATOR)
@@ -49,4 +50,20 @@ class IterableUsingCollectionGeneratorTest {
 
         assertThat(result).hasSize(10).hasOnlyElementsOfTypes(String.class);
     }
+
+    @Test
+    void assignCollectionToIterable() {
+        class IterableHolder {
+            Iterable<String> iterable;
+        }
+
+        final IterableHolder result = Instancio.of(IterableHolder.class)
+                .generate(field("iterable"), gen -> gen.collection().size(10))
+                .create();
+
+        assertThat(result.iterable)
+                .hasSize(10)
+                .allSatisfy(s -> assertThat(s).isNotBlank());
+    }
+
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/GeneratorSupportTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/GeneratorSupportTest.java
@@ -61,7 +61,8 @@ class GeneratorSupportTest {
         assertSupportsAll(integerGenerator, Object.class, int.class, Integer.class);
         assertSupportsAll(enumGenerator, Object.class, Gender.class);
         assertSupportsAll(enumSetGenerator, Object.class, EnumSet.class);
-        assertSupportsAll(collectionGenerator, Object.class, Collection.class, List.class, Set.class, SortedSet.class, HashSet.class);
+        assertSupportsAll(collectionGenerator, Object.class, Iterable.class, Collection.class,
+                List.class, Set.class, SortedSet.class, HashSet.class);
         assertSupportsAll(mapGenerator, Object.class, Map.class, TreeMap.class, HashMap.class);
         assertSupportsAll(stringGenerator, Object.class, CharSequence.class, String.class);
     }
@@ -71,7 +72,7 @@ class GeneratorSupportTest {
         assertSupportsNone(booleanGenerator, int.class, boolean[].class);
         assertSupportsNone(integerGenerator, long.class, Double.class);
         assertSupportsNone(enumGenerator, Integer.class);
-        assertSupportsNone(collectionGenerator, Map.class);
+        assertSupportsNone(collectionGenerator, Map.class, EnumSet.class); // EnumSet has a dedicated generator
         assertSupportsNone(enumSetGenerator, Foo.class, Gender.class, Collection.class);
         assertSupportsNone(mapGenerator, Collection.class);
         assertSupportsNone(stringGenerator, StringBuilder.class);


### PR DESCRIPTION
`EnumSet` has a dedicated generator and is not supported by collection generator.