### PR TITLE
Updated error message of method reference selector.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/selectors/MethodReferenceHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/MethodReferenceHelper.java
@@ -66,7 +66,7 @@ public final class MethodReferenceHelper {
     private static String getErrorMessage(final SerializedLambda lambda, final Class<?> targetClass) {
         final String at = Format.firstNonInstancioStackTraceLine(new Throwable());
         return new StringBuilder(1024).append(NL).append(NL)
-                .append("Unable to resolve field from method reference:").append(NL)
+                .append("Unable to resolve the field from method reference:").append(NL)
                 .append("-> ").append(Format.withoutPackage(targetClass)).append("::").append(lambda.getImplMethodName()).append(NL)
                 .append("   at ").append(at).append(NL)
                 .append(NL)
@@ -82,7 +82,19 @@ public final class MethodReferenceHelper {
                 .append("Possible solutions:").append(NL)
                 .append("-> Resolve the above issues, if applicable").append(NL)
                 .append("-> Specify the field name explicitly, e.g.").append(NL)
-                .append("   field(Example.class, \"someField\")")
+                .append("   field(Example.class, \"someField\")").append(NL)
+                .append("-> If using Kotlin, consider creating a 'KSelect' utility class, for example:").append(NL)
+                .append(NL)
+                .append("   class KSelect {").append(NL)
+                .append("       companion object {").append(NL)
+                .append("           fun <T, V> field(property: KProperty1<T, V>): TargetSelector {").append(NL)
+                .append("               val field = property.javaField!!").append(NL)
+                .append("               return Select.field(field.declaringClass, field.name)").append(NL)
+                .append("           }").append(NL)
+                .append("       }").append(NL)
+                .append("   }").append(NL)
+                .append(NL)
+                .append("   Usage: KSelect.field(SamplePojo::value)")
                 .toString();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/GetMethodSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/GetMethodSelectorTest.java
@@ -200,7 +200,7 @@ class GetMethodSelectorTest {
             assertThatThrownBy(() -> api.set(field(getValueMethod), "foo"))
                     .isExactlyInstanceOf(InstancioApiException.class)
                     .hasMessageContaining(String.format(
-                            "Unable to resolve field from method reference:%n" +
+                            "Unable to resolve the field from method reference:%n" +
                                     "-> ItemInterface::getValue"));
         }
 

--- a/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/MethodReferenceSelectorLambdaTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/MethodReferenceSelectorLambdaTest.java
@@ -36,7 +36,7 @@ class MethodReferenceSelectorLambdaTest {
 
         assertThatThrownBy(() -> api.ignore(field((StringHolder holder) -> holder.getValue())))
                 .isExactlyInstanceOf(InstancioApiException.class)
-                .hasMessageContainingAll("Unable to resolve field from method reference",
+                .hasMessageContainingAll("Unable to resolve the field from method reference",
                         "The method reference is expressed as a lambda function",
                         "Example:     field((SamplePojo pojo) -> pojo.getValue())",
                         "Instead of:  field(SamplePojo::getValue)");

--- a/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/MethodReferenceSelectorUnresolvedFieldTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/MethodReferenceSelectorUnresolvedFieldTest.java
@@ -36,9 +36,10 @@ class MethodReferenceSelectorUnresolvedFieldTest {
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessage(String.format("%n" +
                         "%n" +
-                        "Unable to resolve field from method reference:%n" +
+                        "Unable to resolve the field from method reference:%n" +
                         "-> NonMatchingGetter::getBar%n" +
-                        "   at org.other.test.features.mode.MethodReferenceSelectorUnresolvedFieldTest.lambda$resolvingFieldFails$0(MethodReferenceSelectorUnresolvedFieldTest.java:35)%n%n" +
+                        "   at org.other.test.features.mode.MethodReferenceSelectorUnresolvedFieldTest.lambda$resolvingFieldFails$0(MethodReferenceSelectorUnresolvedFieldTest.java:35)%n" +
+                        "%n" +
                         "Potential causes:%n" +
                         "-> The method and the corresponding field do not follow expected naming conventions%n" +
                         "   See: https://www.instancio.org/user-guide/#method-reference-selector%n" +
@@ -51,6 +52,18 @@ class MethodReferenceSelectorUnresolvedFieldTest {
                         "Possible solutions:%n" +
                         "-> Resolve the above issues, if applicable%n" +
                         "-> Specify the field name explicitly, e.g.%n" +
-                        "   field(Example.class, \"someField\")"));
+                        "   field(Example.class, \"someField\")%n" +
+                        "-> If using Kotlin, consider creating a 'KSelect' utility class, for example:%n" +
+                        "%n" +
+                        "   class KSelect {%n" +
+                        "       companion object {%n" +
+                        "           fun <T, V> field(property: KProperty1<T, V>): TargetSelector {%n" +
+                        "               val field = property.javaField!!%n" +
+                        "               return Select.field(field.declaringClass, field.name)%n" +
+                        "           }%n" +
+                        "       }%n" +
+                        "   }%n" +
+                        "%n" +
+                        "   Usage: KSelect.field(SamplePojo::value)"));
     }
 }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -238,6 +238,24 @@ For methods that follow other naming conventions, or situations where no method 
 !!! info "Regular selector definition"
     From here on, the definition of *regular selectors* also includes method reference selectors.
 
+##### Kotlin method reference selector
+
+Since Instancio does not include Kotlin dependencies,
+the method reference selector described above is only supported for Java classes.
+If you use Kotlin, a similar selector can be implemented as a simple utility class shown below.
+This sample assumes that the property has a non-null backing `javaField`:
+
+``` kotlin title="Sample implementation method reference selector for Kotlin" linenums="1"
+class KSelect {
+    companion object {
+        fun <T, V> field(property: KProperty1<T, V>): TargetSelector {
+            val field = property.javaField!!
+            return Select.field(field.declaringClass, field.name)
+        }
+    }
+}
+```
+
 #### Predicate selectors
 
 Predicate selectors allow for greater flexibility in matching fields and classes.


### PR DESCRIPTION
The method reference selector `field(Foo::getValue)` does not support Kotlin. Added a snippet to the message showing how to add a similar selector for Kotlin.