### PR TITLE
Updated `GeneratorProvider` to resolve generators based on a given `Node`.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Node.java
+++ b/instancio-core/src/main/java/org/instancio/Node.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+/**
+ * Represents a single {@code Node} of a node hierarchy
+ * created for a given {@link Type}. A node can represent:
+ *
+ * <ul>
+ *   <li>the root class</li>
+ *   <li>field of a class</li>
+ *   <li>an element of a collection, or in general, a generic type argument,
+ *       for example, the type of an {@link Optional} value</li>
+ * </ul>
+ *
+ * @since 2.11.0
+ */
+public interface Node {
+
+    /**
+     * Returns the target class of this node.
+     *
+     * <p>If this node represents a field, generally the target class
+     * will be the same as {@link Field#getType()}. However, there are
+     * cases where the target class may differ, for example:
+     *
+     * <ul>
+     *   <li>when a subtype is specified, <b>then</b>
+     *       the node's target class will represent the subtype.</li>
+     *   <li>when the node represents a generic type, <b>then</b>
+     *       the target class will represent the resolved type argument.</li>
+     * </ul>
+     *
+     * @return target class of this node, never {@code null}
+     * @since 2.11.0
+     */
+    Class<?> getTargetClass();
+
+    /**
+     * Returns the field of this node, if available.
+     *
+     * @return field of this node, or {@code null} if the node has no field
+     * @since 2.11.0
+     */
+    Field getField();
+
+}

--- a/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
@@ -19,7 +19,7 @@ import org.instancio.TypeTokenSupplier;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.generator.Generator;
 import org.instancio.internal.generator.AbstractGenerator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.Format;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.settings.SettingKey;
@@ -125,7 +125,7 @@ public final class ApiValidator {
         return collection;
     }
 
-    public static void validateGeneratorUsage(final Node node, final Generator<?> generator) {
+    public static void validateGeneratorUsage(final InternalNode node, final Generator<?> generator) {
         final AbstractGenerator<?> absGen = GeneratorSupport.unpackGenerator(generator);
         if (absGen == null) return;
 
@@ -136,7 +136,7 @@ public final class ApiValidator {
         }
     }
 
-    private static String generateMismatchErrorMessageTemplate(final Node node, final String apiMethodName) {
+    private static String generateMismatchErrorMessageTemplate(final InternalNode node, final String apiMethodName) {
         return "%nGenerator type mismatch:%n"
                 + "Method '" + apiMethodName + "' cannot be used for type: " + node.getTargetClass().getCanonicalName()
                 + (node.getField() == null ? "" : "%nField: " + node.getField());

--- a/instancio-core/src/main/java/org/instancio/internal/ArrayElementNodePopulationFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ArrayElementNodePopulationFilter.java
@@ -17,7 +17,7 @@ package org.instancio.internal;
 
 import org.instancio.generator.AfterGenerate;
 import org.instancio.internal.context.ModelContext;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.util.ReflectionUtils;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +31,7 @@ class ArrayElementNodePopulationFilter implements NodePopulationFilter {
     }
 
     @Override
-    public boolean shouldSkip(final Node elementNode,
+    public boolean shouldSkip(final InternalNode elementNode,
                               final AfterGenerate afterGenerate,
                               @Nullable final Object currentElementValue) {
 

--- a/instancio-core/src/main/java/org/instancio/internal/CallbackHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CallbackHandler.java
@@ -20,7 +20,7 @@ import org.instancio.exception.InstancioApiException;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResult;
 import org.instancio.internal.generator.InternalGeneratorHint;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,14 +33,14 @@ public class CallbackHandler implements GenerationListener {
     private static final Logger LOG = LoggerFactory.getLogger(CallbackHandler.class);
 
     private final ModelContext<?> context;
-    private final Map<Node, List<Object>> resultsForCallbacks = new IdentityHashMap<>();
+    private final Map<InternalNode, List<Object>> resultsForCallbacks = new IdentityHashMap<>();
 
     public CallbackHandler(final ModelContext<?> context) {
         this.context = context;
     }
 
     @Override
-    public void objectCreated(final Node node, final GeneratorResult result) {
+    public void objectCreated(final InternalNode node, final GeneratorResult result) {
         // callbacks are not invoked on null values
         if (result.getValue() == null) {
             return;
@@ -70,7 +70,7 @@ public class CallbackHandler implements GenerationListener {
         });
     }
 
-    private List<OnCompleteCallback<?>> getCallbacks(final Node node) {
+    private List<OnCompleteCallback<?>> getCallbacks(final InternalNode node) {
         return context.getCallbacks(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/FieldNodePopulationFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/FieldNodePopulationFilter.java
@@ -18,7 +18,7 @@ package org.instancio.internal;
 import org.instancio.exception.InstancioException;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.internal.context.ModelContext;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.util.ExceptionHandler;
 import org.instancio.internal.util.ReflectionUtils;
@@ -32,7 +32,7 @@ class FieldNodePopulationFilter implements NodePopulationFilter {
     }
 
     @Override
-    public boolean shouldSkip(final Node fieldNode,
+    public boolean shouldSkip(final InternalNode fieldNode,
                               final AfterGenerate afterGenerate,
                               final Object objectContainingField) {
 

--- a/instancio-core/src/main/java/org/instancio/internal/GeneratedNullValueListener.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratedNullValueListener.java
@@ -18,7 +18,7 @@ package org.instancio.internal;
 import org.instancio.Mode;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResult;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.settings.Keys;
 
 import java.util.ArrayDeque;
@@ -39,16 +39,16 @@ class GeneratedNullValueListener implements GenerationListener {
     }
 
     @Override
-    public void objectCreated(final Node node, final GeneratorResult result) {
+    public void objectCreated(final InternalNode node, final GeneratorResult result) {
         if (isLenientMode) {
             return;
         }
 
-        final Queue<Node> queue = new ArrayDeque<>();
+        final Queue<InternalNode> queue = new ArrayDeque<>();
         queue.add(node);
 
         while (!queue.isEmpty()) {
-            final Node current = queue.poll();
+            final InternalNode current = queue.poll();
 
             if (result.isIgnored()) {
                 context.isIgnored(current);

--- a/instancio-core/src/main/java/org/instancio/internal/GenerationListener.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GenerationListener.java
@@ -17,7 +17,7 @@ package org.instancio.internal;
 
 import org.instancio.documentation.InternalApi;
 import org.instancio.internal.generator.GeneratorResult;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 
 /**
  * Listener interface for classes interested in when an object has been created.
@@ -37,7 +37,7 @@ interface GenerationListener {
      *               be generated.
      * @since 1.3.3
      */
-    default void objectCreated(Node node, GeneratorResult result) {
+    default void objectCreated(InternalNode node, GeneratorResult result) {
         // no-op
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
@@ -30,7 +30,7 @@ import org.instancio.internal.handlers.NodeHandler;
 import org.instancio.internal.handlers.UserSuppliedGeneratorHandler;
 import org.instancio.internal.handlers.UsingGeneratorResolverHandler;
 import org.instancio.internal.instantiation.Instantiator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.settings.Keys;
 import org.slf4j.Logger;
@@ -76,11 +76,11 @@ class GeneratorFacade {
         return isEnabled ? new BeanValidationProcessor() : new NoopBeanValidationProvider();
     }
 
-    private boolean hasStaticField(final Node node) {
+    private boolean hasStaticField(final InternalNode node) {
         return node.getField() != null && Modifier.isStatic(node.getField().getModifiers());
     }
 
-    GeneratorResult generateNodeValue(final Node node) {
+    GeneratorResult generateNodeValue(final InternalNode node) {
         if (node.is(NodeKind.IGNORED) || hasStaticField(node)) {
             return GeneratorResult.ignoredResult();
         }
@@ -101,7 +101,7 @@ class GeneratorFacade {
         return generatorResult;
     }
 
-    private boolean shouldReturnNullForNullable(final Node node) {
+    private boolean shouldReturnNullForNullable(final InternalNode node) {
         final boolean precondition = context.isNullable(node);
         return random.diceRoll(precondition);
     }

--- a/instancio-core/src/main/java/org/instancio/internal/InternalModel.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InternalModel.java
@@ -17,14 +17,14 @@ package org.instancio.internal;
 
 import org.instancio.Model;
 import org.instancio.internal.context.ModelContext;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeContext;
 import org.instancio.internal.nodes.NodeFactory;
 
 final class InternalModel<T> implements Model<T> {
 
     private final ModelContext<T> modelContext;
-    private final Node rootNode;
+    private final InternalNode rootNode;
 
     InternalModel(ModelContext<T> modelContext) {
         this.modelContext = modelContext;
@@ -35,11 +35,11 @@ final class InternalModel<T> implements Model<T> {
         return modelContext;
     }
 
-    Node getRootNode() {
+    InternalNode getRootNode() {
         return rootNode;
     }
 
-    private Node createRootNode() {
+    private InternalNode createRootNode() {
         final NodeContext nodeContext = NodeContext.builder()
                 .maxDepth(modelContext.getMaxDepth())
                 .rootTypeMap(modelContext.getRootTypeMap())

--- a/instancio-core/src/main/java/org/instancio/internal/NodePopulationFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/NodePopulationFilter.java
@@ -17,7 +17,7 @@ package org.instancio.internal;
 
 import org.instancio.documentation.InternalApi;
 import org.instancio.generator.AfterGenerate;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 
 @InternalApi
 interface NodePopulationFilter {
@@ -30,6 +30,6 @@ interface NodePopulationFilter {
      * @param obj           what the object is varies depending on filter implementation
      * @return {@code true} if node should be skipped, {@code false} otherwise
      */
-    boolean shouldSkip(Node node, AfterGenerate afterGenerate, Object obj);
+    boolean shouldSkip(InternalNode node, AfterGenerate afterGenerate, Object obj);
 
 }

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/Assigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/Assigner.java
@@ -16,7 +16,7 @@
 package org.instancio.internal.assigners;
 
 import org.instancio.documentation.InternalApi;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -44,5 +44,5 @@ public interface Assigner {
      *               if the target field is a primitive,
      *               then {@code null} value is simply ignored.
      */
-    void assign(Node node, Object target, Object value);
+    void assign(InternalNode node, Object target, Object value);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/FieldAssigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/FieldAssigner.java
@@ -18,7 +18,7 @@ package org.instancio.internal.assigners;
 import org.instancio.assignment.AssignmentType;
 import org.instancio.assignment.OnSetFieldError;
 import org.instancio.exception.InstancioApiException;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.Format;
 import org.instancio.internal.util.Sonar;
 import org.instancio.settings.Keys;
@@ -42,7 +42,7 @@ public class FieldAssigner implements Assigner {
     }
 
     @Override
-    public void assign(final Node node, final Object target, final Object value) {
+    public void assign(final InternalNode node, final Object target, final Object value) {
         final Field field = node.getField();
 
         if (value != null) {

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
@@ -21,7 +21,7 @@ import org.instancio.assignment.OnSetMethodNotFound;
 import org.instancio.assignment.SetterStyle;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.exception.InstancioException;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.Format;
 import org.instancio.internal.util.Sonar;
 import org.instancio.settings.Keys;
@@ -69,7 +69,7 @@ public class MethodAssigner implements Assigner {
     }
 
     @Override
-    public void assign(final Node node, final Object target, final Object arg) {
+    public void assign(final InternalNode node, final Object target, final Object arg) {
         final Field field = node.getField();
         if (arg != null) {
             // can't use setters on final fields
@@ -84,7 +84,7 @@ public class MethodAssigner implements Assigner {
     }
 
     @SuppressWarnings(Sonar.ACCESSIBILITY_UPDATE_SHOULD_BE_REMOVED)
-    private void assignViaMethod(final Node node, final Object target, final Object arg) {
+    private void assignViaMethod(final InternalNode node, final Object target, final Object arg) {
         final String methodName = setterNameResolver.resolveFor(node.getField());
         final Optional<Method> methodOpt = resolveSetterMethod(methodName, node.getField());
 
@@ -104,7 +104,7 @@ public class MethodAssigner implements Assigner {
     }
 
     private void handleMethodInvocationError(
-            final Node node,
+            final InternalNode node,
             final Object target,
             final Object arg,
             final Method method,
@@ -126,7 +126,7 @@ public class MethodAssigner implements Assigner {
     }
 
     private void handleMethodNotFoundError(
-            final Node node,
+            final InternalNode node,
             final Object target,
             final Object arg,
             final String methodName) {

--- a/instancio-core/src/main/java/org/instancio/internal/context/BooleanSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/BooleanSelectorMap.java
@@ -16,7 +16,7 @@
 package org.instancio.internal.context;
 
 import org.instancio.TargetSelector;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.Flattener;
 
 import java.util.Collections;
@@ -40,7 +40,7 @@ public class BooleanSelectorMap {
         return targetSelectors;
     }
 
-    public boolean isTrue(final Node node) {
+    public boolean isTrue(final InternalNode node) {
         return Boolean.TRUE.equals(selectorMap.getValue(node).orElse(false));
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/GeneratorSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/GeneratorSelectorMap.java
@@ -24,7 +24,7 @@ import org.instancio.generators.Generators;
 import org.instancio.internal.generator.InternalGeneratorHint;
 import org.instancio.internal.generator.array.ArrayGenerator;
 import org.instancio.internal.generator.misc.GeneratorDecorator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.Flattener;
 import org.instancio.internal.selectors.SelectorImpl;
 import org.instancio.internal.util.Sonar;
@@ -77,7 +77,7 @@ class GeneratorSelectorMap {
         return Collections.unmodifiableMap(generatorSubtypeMap);
     }
 
-    Optional<Generator<?>> getGenerator(final Node node) {
+    Optional<Generator<?>> getGenerator(final InternalNode node) {
         return selectorMap.getValue(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -25,7 +25,7 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.RandomHelper;
 import org.instancio.internal.generator.misc.SupplierAdapter;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.spi.InternalContainerFactoryProvider;
 import org.instancio.internal.spi.Providers;
 import org.instancio.internal.util.CollectionUtils;
@@ -156,21 +156,21 @@ public final class ModelContext<T> {
         return maxDepth;
     }
 
-    public boolean isIgnored(final Node node) {
+    public boolean isIgnored(final InternalNode node) {
         return ignoredSelectorMap.isTrue(node);
     }
 
-    public boolean isNullable(final Node node) {
+    public boolean isNullable(final InternalNode node) {
         return nullableSelectorMap.isTrue(node);
     }
 
     @SuppressWarnings(Sonar.GENERIC_WILDCARD_IN_RETURN)
-    public Optional<Generator<?>> getGenerator(final Node node) {
+    public Optional<Generator<?>> getGenerator(final InternalNode node) {
         return generatorSelectorMap.getGenerator(node);
     }
 
     @SuppressWarnings(Sonar.GENERIC_WILDCARD_IN_RETURN)
-    public List<OnCompleteCallback<?>> getCallbacks(final Node node) {
+    public List<OnCompleteCallback<?>> getCallbacks(final InternalNode node) {
         return onCompleteCallbackSelectorMap.getCallbacks(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/OnCompleteCallbackSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/OnCompleteCallbackSelectorMap.java
@@ -17,7 +17,7 @@ package org.instancio.internal.context;
 
 import org.instancio.OnCompleteCallback;
 import org.instancio.TargetSelector;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.Flattener;
 
 import java.util.Collections;
@@ -42,7 +42,7 @@ class OnCompleteCallbackSelectorMap {
         return onCompleteCallbacks;
     }
 
-    List<OnCompleteCallback<?>> getCallbacks(final Node node) {
+    List<OnCompleteCallback<?>> getCallbacks(final InternalNode node) {
         return selectorMap.getValues(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
@@ -19,7 +19,7 @@ import org.instancio.PredicateSelector;
 import org.instancio.Scope;
 import org.instancio.TargetSelector;
 import org.instancio.internal.PrimitiveWrapperBiLookup;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.PredicateSelectorImpl;
 import org.instancio.internal.selectors.PrimitiveAndWrapperSelectorImpl;
 import org.instancio.internal.selectors.ScopeImpl;
@@ -122,7 +122,7 @@ final class SelectorMap<V> {
      * @param node for which to look up the value
      * @return value for given node, if present
      */
-    Optional<V> getValue(final Node node) {
+    Optional<V> getValue(final InternalNode node) {
         final List<SelectorImpl> withParent = getSelectorsWithParent(node, getCandidates(node), FIND_ONE_ONLY);
 
         if (!withParent.isEmpty()) {
@@ -134,7 +134,7 @@ final class SelectorMap<V> {
         return getPredicateSelectorMatch(node);
     }
 
-    private Optional<V> getPredicateSelectorMatch(final Node node) {
+    private Optional<V> getPredicateSelectorMatch(final InternalNode node) {
         PredicateSelectorEntry<V> classPredicate = null;
 
         // If there's a field predicate anywhere in the list, then return the last one found.
@@ -167,7 +167,7 @@ final class SelectorMap<V> {
      * @param node for which to look up the values
      * @return all values for given node, or an empty list if none found
      */
-    List<V> getValues(final Node node) {
+    List<V> getValues(final InternalNode node) {
         final List<SelectorImpl> selectorsWithParent = getSelectorsWithParent(node, getCandidates(node), !FIND_ONE_ONLY);
         final List<V> values = new ArrayList<>(selectorsWithParent.size() + predicateSelectors.size());
 
@@ -186,7 +186,7 @@ final class SelectorMap<V> {
         return values;
     }
 
-    private static boolean isPredicateMatch(final Node node, final PredicateSelectorEntry<?> entry) {
+    private static boolean isPredicateMatch(final InternalNode node, final PredicateSelectorEntry<?> entry) {
         return entry.predicateSelector.getSelectorTargetKind() == SelectorTargetKind.FIELD
                 ? entry.predicateSelector.getFieldPredicate().test(node.getField())
                 : entry.predicateSelector.getClassPredicate().test(node.getTargetClass());
@@ -212,7 +212,7 @@ final class SelectorMap<V> {
      * @param node to look up selectors for
      * @return list of selectors
      */
-    private List<SelectorImpl> getCandidates(final Node node) {
+    private List<SelectorImpl> getCandidates(final InternalNode node) {
         if (node.getParent() == null && scopelessSelectors.containsKey(SCOPELESS_ROOT)) {
             return Collections.singletonList(scopelessSelectors.get(SCOPELESS_ROOT).get(0));
         }
@@ -233,7 +233,7 @@ final class SelectorMap<V> {
     }
 
     private static List<SelectorImpl> getSelectorsWithParent(
-            final Node targetNode,
+            final InternalNode targetNode,
             final List<SelectorImpl> candidates,
             final boolean findOneOnly) {
 
@@ -258,13 +258,13 @@ final class SelectorMap<V> {
         return results;
     }
 
-    private static boolean selectorScopesMatchNodeHierarchy(final SelectorImpl candidate, final Node targetNode) {
+    private static boolean selectorScopesMatchNodeHierarchy(final SelectorImpl candidate, final InternalNode targetNode) {
         if (candidate.getScopes().isEmpty()) {
             return true;
         }
         final Deque<Scope> deq = new ArrayDeque<>(candidate.getScopes());
         ScopeImpl scope = (ScopeImpl) deq.removeLast();
-        Node node = targetNode;
+        InternalNode node = targetNode;
 
         while (node != null) {
             if (scope.isFieldScope()) {

--- a/instancio-core/src/main/java/org/instancio/internal/context/SubtypeSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SubtypeSelectorMap.java
@@ -16,7 +16,7 @@
 package org.instancio.internal.context;
 
 import org.instancio.TargetSelector;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.Flattener;
 
 import java.util.Collections;
@@ -41,7 +41,7 @@ public final class SubtypeSelectorMap {
         return selectorMap;
     }
 
-    public Optional<Class<?>> getSubtype(final Node node) {
+    public Optional<Class<?>> getSubtype(final InternalNode node) {
         return selectorMap.getValue(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorResolver.java
@@ -20,6 +20,7 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.SubtypeGeneratorSpec;
 import org.instancio.internal.generator.array.ArrayGenerator;
 import org.instancio.internal.generator.lang.EnumGenerator;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.spi.ProviderEntry;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.internal.util.ServiceLoaders;
@@ -66,9 +67,11 @@ public class GeneratorResolver {
     }
 
     @SuppressWarnings("all")
-    public Optional<Generator<?>> get(final Class<?> klass) {
+    public Optional<Generator<?>> get(final InternalNode node) {
+        final Class<?> klass = node.getTargetClass();
+
         // Generators provided by SPI take precedence over built-in generators
-        final Optional<Generator<?>> spiGenerator = generatorProviderFacade.getGenerator(klass);
+        final Optional<Generator<?>> spiGenerator = generatorProviderFacade.getGenerator(node);
         if (spiGenerator.isPresent()) {
             return spiGenerator;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/ArrayNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/ArrayNodeHandler.java
@@ -20,7 +20,7 @@ import org.instancio.internal.GeneratorSpecProcessor;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResolver;
 import org.instancio.internal.generator.GeneratorResult;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.jetbrains.annotations.NotNull;
 
 public class ArrayNodeHandler implements NodeHandler {
@@ -41,9 +41,9 @@ public class ArrayNodeHandler implements NodeHandler {
 
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
         if (node.getTargetClass().isArray()) {
-            final Generator<?> generator = generatorResolver.get(node.getTargetClass()).orElseThrow(
+            final Generator<?> generator = generatorResolver.get(node).orElseThrow(
                     () -> new IllegalStateException("Unable to get array generator for node: " + node));
 
             beanValidationProcessors.process(generator, node.getTargetClass(), node.getField());

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/CollectionNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/CollectionNodeHandler.java
@@ -20,7 +20,7 @@ import org.instancio.internal.GeneratorSpecProcessor;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResult;
 import org.instancio.internal.generator.util.CollectionGenerator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -40,7 +40,7 @@ public class CollectionNodeHandler implements NodeHandler {
 
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
         if (Collection.class.isAssignableFrom(node.getTargetClass())) {
             final CollectionGenerator<?> generator = new CollectionGenerator<>(
                     new GeneratorContext(context.getSettings(), context.getRandom()));

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/GeneratedValuePostProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/GeneratedValuePostProcessor.java
@@ -2,7 +2,7 @@ package org.instancio.internal.handlers;
 
 import org.instancio.documentation.InternalApi;
 import org.instancio.generator.Generator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 
 /**
  * Post-processor for generated values.
@@ -20,5 +20,5 @@ interface GeneratedValuePostProcessor {
      * @param generator that generated the value
      * @return processed value, or the same value if no processing was done
      */
-    Object process(Object value, Node node, Generator<?> generator);
+    Object process(Object value, InternalNode node, Generator<?> generator);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/InstantiatingHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/InstantiatingHandler.java
@@ -19,7 +19,7 @@ import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Hints;
 import org.instancio.internal.generator.GeneratorResult;
 import org.instancio.internal.instantiation.Instantiator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.ReflectionUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,7 +33,7 @@ public class InstantiatingHandler implements NodeHandler {
 
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
         final Class<?> targetClass = node.getTargetClass();
 
         if (ReflectionUtils.isArrayOrConcrete(targetClass)) {

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/MapNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/MapNodeHandler.java
@@ -20,7 +20,7 @@ import org.instancio.internal.GeneratorSpecProcessor;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResult;
 import org.instancio.internal.generator.util.MapGenerator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -40,7 +40,7 @@ public class MapNodeHandler implements NodeHandler {
 
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
         if (Map.class.isAssignableFrom(node.getTargetClass())) {
             final MapGenerator<?, ?> generator = new MapGenerator<>(
                     new GeneratorContext(context.getSettings(), context.getRandom()));

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/NodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/NodeHandler.java
@@ -17,13 +17,13 @@ package org.instancio.internal.handlers;
 
 import org.instancio.documentation.InternalApi;
 import org.instancio.internal.generator.GeneratorResult;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.jetbrains.annotations.NotNull;
 
 @InternalApi
 public interface NodeHandler {
 
     @NotNull
-    GeneratorResult getResult(@NotNull Node node);
+    GeneratorResult getResult(@NotNull InternalNode node);
 
 }

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/StringPrefixingPostProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/StringPrefixingPostProcessor.java
@@ -2,7 +2,7 @@ package org.instancio.internal.handlers;
 
 import org.instancio.generator.Generator;
 import org.instancio.internal.generator.lang.StringGenerator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.StringUtils;
 
 class StringPrefixingPostProcessor implements GeneratedValuePostProcessor {
@@ -14,7 +14,7 @@ class StringPrefixingPostProcessor implements GeneratedValuePostProcessor {
     }
 
     @Override
-    public Object process(final Object value, final Node node, final Generator<?> generator) {
+    public Object process(final Object value, final InternalNode node, final Generator<?> generator) {
         if (stringFieldPrefixEnabled
                 && node.getField() != null
                 && generator.getClass() == StringGenerator.class

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/UserSuppliedGeneratorHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/UserSuppliedGeneratorHandler.java
@@ -26,7 +26,7 @@ import org.instancio.internal.generator.InternalGeneratorHint;
 import org.instancio.internal.generator.misc.GeneratorDecorator;
 import org.instancio.internal.generator.misc.InstantiatingGenerator;
 import org.instancio.internal.instantiation.Instantiator;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -53,7 +53,7 @@ public class UserSuppliedGeneratorHandler implements NodeHandler {
      */
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
         return getUserSuppliedGenerator(node).map(generator -> {
             final Hints hints = generator.hints();
             final InternalGeneratorHint internalHint = hints.get(InternalGeneratorHint.class);
@@ -69,7 +69,7 @@ public class UserSuppliedGeneratorHandler implements NodeHandler {
     }
 
     @SuppressWarnings("PMD.AvoidDeeplyNestedIfStmts")
-    private Optional<Generator<?>> getUserSuppliedGenerator(final Node node) {
+    private Optional<Generator<?>> getUserSuppliedGenerator(final InternalNode node) {
         final Optional<Generator<?>> generatorOpt = modelContext.getGenerator(node);
 
         if (generatorOpt.isPresent()) {
@@ -81,7 +81,7 @@ public class UserSuppliedGeneratorHandler implements NodeHandler {
 
             if (internalHint != null && internalHint.isDelegating()) {
                 final Class<?> forClass = defaultIfNull(internalHint.targetClass(), node.getTargetClass());
-                final Generator<?> delegate = generatorResolver.get(forClass)
+                final Generator<?> delegate = generatorResolver.get(node)
                         .orElse(new InstantiatingGenerator(instantiator, forClass));
 
                 if (delegate instanceof AbstractGenerator<?>) {

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/UsingGeneratorResolverHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/UsingGeneratorResolverHandler.java
@@ -20,7 +20,7 @@ import org.instancio.internal.GeneratorSpecProcessor;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResolver;
 import org.instancio.internal.generator.GeneratorResult;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.settings.Keys;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -51,11 +51,12 @@ public class UsingGeneratorResolverHandler implements NodeHandler {
 
     @NotNull
     @Override
-    public GeneratorResult getResult(@NotNull final Node node) {
-        final Class<?> targetClass = node.getTargetClass();
-        final Optional<Generator<?>> generatorOpt = generatorResolver.get(targetClass);
+    public GeneratorResult getResult(@NotNull final InternalNode node) {
+        final Optional<Generator<?>> generatorOpt = generatorResolver.get(node);
 
         return generatorOpt.map(generator -> {
+            final Class<?> targetClass = node.getTargetClass();
+
             LOG.trace("Using '{}' generator to create '{}'", generator.getClass().getSimpleName(), targetClass.getName());
             beanValidationProcessors.process(generator, node.getTargetClass(), node.getField());
 

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/InternalNode.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/InternalNode.java
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public final class Node {
+public final class InternalNode {
 
-    private static final Node IGNORED_NODE = builder()
+    private static final InternalNode IGNORED_NODE = builder()
             .type(Object.class)
             .rawType(Object.class)
             .targetClass(Object.class)
@@ -42,13 +42,13 @@ public final class Node {
     private final Class<?> rawType;
     private final Class<?> targetClass;
     private final Field field;
-    private final Node parent;
+    private final InternalNode parent;
     private final TypeMap typeMap;
     private final NodeKind nodeKind;
     private final int depth;
-    private List<Node> children;
+    private List<InternalNode> children;
 
-    private Node(final Builder builder) {
+    private InternalNode(final Builder builder) {
         nodeContext = builder.nodeContext;
         type = Verify.notNull(builder.type, "null type");
         rawType = Verify.notNull(builder.rawType, "null rawType");
@@ -61,7 +61,7 @@ public final class Node {
         depth = parent == null ? 0 : parent.depth + 1;
     }
 
-    public static Node ignoredNode() {
+    public static InternalNode ignoredNode() {
         return IGNORED_NODE;
     }
 
@@ -142,7 +142,7 @@ public final class Node {
         return field;
     }
 
-    public Node getParent() {
+    public InternalNode getParent() {
         return parent;
     }
 
@@ -150,7 +150,7 @@ public final class Node {
         return typeMap;
     }
 
-    public Node getOnlyChild() {
+    public InternalNode getOnlyChild() {
         Verify.state(getChildren().size() == 1, "Expected one child, but were %s", getChildren().size());
         return getChildren().get(0);
     }
@@ -165,11 +165,11 @@ public final class Node {
      *
      * @return this node's children or an empty list if none
      */
-    public List<Node> getChildren() {
+    public List<InternalNode> getChildren() {
         return children;
     }
 
-    public void setChildren(final List<Node> children) {
+    public void setChildren(final List<InternalNode> children) {
         this.children = children;
     }
 
@@ -181,7 +181,7 @@ public final class Node {
      * {@code false} otherwise.
      */
     public boolean hasAncestorEqualToSelf() {
-        Node ancestor = parent;
+        InternalNode ancestor = parent;
 
         while (ancestor != null) {
             if (ancestor.equals(this)) {
@@ -209,7 +209,7 @@ public final class Node {
     public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        final Node other = (Node) o;
+        final InternalNode other = (InternalNode) o;
 
         return this.getTargetClass().equals(other.getTargetClass())
                 && Objects.equals(this.getType(), other.getType())
@@ -246,8 +246,8 @@ public final class Node {
         private Class<?> rawType;
         private Class<?> targetClass;
         private Field field;
-        private Node parent;
-        private List<Node> children;
+        private InternalNode parent;
+        private List<InternalNode> children;
         private NodeKind nodeKind;
         private Map<Type, Type> additionalTypeMap = Collections.emptyMap();
 
@@ -279,12 +279,12 @@ public final class Node {
             return this;
         }
 
-        public Builder parent(@Nullable final Node parent) {
+        public Builder parent(@Nullable final InternalNode parent) {
             this.parent = parent;
             return this;
         }
 
-        public Builder children(final List<Node> children) {
+        public Builder children(final List<InternalNode> children) {
             this.children = children;
             return this;
         }
@@ -299,8 +299,8 @@ public final class Node {
             return this;
         }
 
-        public Node build() {
-            return new Node(this);
+        public InternalNode build() {
+            return new InternalNode(this);
         }
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
@@ -70,7 +70,7 @@ public final class NodeContext {
      *   <li>a generator's {@code subtype()} method, e.g. {@code gen.collection().subtype()}</li>
      * </ol>
      */
-    Optional<Class<?>> getSubtype(@NotNull final Node node) {
+    Optional<Class<?>> getSubtype(@NotNull final InternalNode node) {
         final Optional<Class<?>> subtype = subtypeSelectorMap.getSubtype(node);
         if (subtype.isPresent()) {
             return subtype;
@@ -83,7 +83,7 @@ public final class NodeContext {
                 : Optional.of(subtypeFromSettings);
     }
 
-    boolean isIgnored(@NotNull final Node node) {
+    boolean isIgnored(@NotNull final InternalNode node) {
         return ignoredSelectorMap.isTrue(node);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.nodes;
+
+import org.instancio.Node;
+import org.instancio.internal.util.Verify;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+public final class NodeImpl implements Node {
+
+    private final Class<?> targetClass;
+    private final Field field;
+
+    public NodeImpl(final Class<?> targetClass, final Field field) {
+        this.targetClass = Verify.notNull(targetClass, "targetClass is null");
+        this.field = field;
+    }
+
+    @Override
+    public Class<?> getTargetClass() {
+        return targetClass;
+    }
+
+    @Override
+    public Field getField() {
+        return field;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NodeImpl)) return false;
+        final NodeImpl node = (NodeImpl) o;
+        return Objects.equals(targetClass, node.targetClass)
+                && Objects.equals(field, node.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetClass, field);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Node[targetClass=%s, field=%s]",
+                targetClass.getName(),
+                field == null ? null : field.getName());
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/TypeHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/TypeHelper.java
@@ -39,9 +39,9 @@ class TypeHelper {
         this.nodeContext = nodeContext;
     }
 
-    Type resolveTypeVariable(final TypeVariable<?> typeVar, @Nullable final Node parent) {
+    Type resolveTypeVariable(final TypeVariable<?> typeVar, @Nullable final InternalNode parent) {
         Type mappedType = parent == null ? typeVar : parent.getTypeMap().getOrDefault(typeVar, typeVar);
-        Node ancestor = parent;
+        InternalNode ancestor = parent;
 
         while ((mappedType == null || mappedType instanceof TypeVariable) && ancestor != null) {
             Type rootTypeMapping = nodeContext.getRootTypeMap().get(mappedType);

--- a/instancio-core/src/main/java/org/instancio/spi/InstancioServiceProvider.java
+++ b/instancio-core/src/main/java/org/instancio/spi/InstancioServiceProvider.java
@@ -16,9 +16,11 @@
 package org.instancio.spi;
 
 import org.instancio.InstancioApi;
+import org.instancio.Node;
 import org.instancio.TargetSelector;
 import org.instancio.generator.Generator;
-import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.GeneratorSpec;
+import org.instancio.generators.Generators;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 
@@ -43,6 +45,9 @@ import java.util.ServiceLoader;
  * {@code org.instancio.spi.InstancioServiceProvider} under
  * {@code /META-INF/services}. The file must contain the fully-qualified name
  * of the implementing class.
+ *
+ * <p><b>Note:</b> only {@link InstancioServiceProvider} (and not the interfaces
+ * defined within it) can be registered via the {@code ServiceLoader}.
  *
  * @since 2.11.0
  */
@@ -111,33 +116,20 @@ public interface InstancioServiceProvider {
     interface GeneratorProvider {
 
         /**
-         * Returns a generator class for the specified {@code type}.
-         * If the implementation does not define a generator for the given
-         * type, then a {@code null} can be returned.
+         * Returns a generator spec for the specified {@code node}.
+         * The returned spec must also implement the {@link Generator} interface.
          *
-         * <p>Instancio will attempt to instantiate the generator class
-         * using the following constructors (in order of precedence):
+         * <p>If the implementation does not define a generator for the given
+         * node, then a {@code null} can be returned.
          *
-         * <ol>
-         *   <li>constructor with a single parameter {@link GeneratorContext}</li>
-         *   <li>default (no-argument) constructor</li>
-         * </ol>
-         *
-         * <p>If the custom generator defines a constructor with
-         * {@code GeneratorContext} as the sole parameter, then this
-         * constructor will be invoked, and an instance of
-         * {@code GeneratorContext} will be provided to it.
-         * Otherwise, the default constructor will be used.
-         *
-         * @param type for which to return a generator
-         * @return generator class for the given {@code type},
-         * or {@code null} if no generator is defined
-         * @throws InstancioSpiException if the returned class
+         * @param generators provides access to built-in generators
+         * @param node       for which to return a generator
+         * @return generator spec for the given {@code node}, or {@code null}
+         * @throws InstancioSpiException if the returned generator spec
          *                               does not implement {@link Generator}
-         *                               or cannot be instantiated
          * @since 2.11.0
          */
-        Class<?> getGenerator(Class<?> type);
+        GeneratorSpec<?> getGenerator(Node node, Generators generators);
     }
 
     /**
@@ -213,5 +205,4 @@ public interface InstancioServiceProvider {
          */
         Object instantiate(Class<?> type);
     }
-
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/assignment/FieldAssignerTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/assignment/FieldAssignerTest.java
@@ -18,7 +18,7 @@ package org.instancio.internal.assignment;
 import org.instancio.assignment.OnSetFieldError;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.internal.assigners.FieldAssigner;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 import org.instancio.test.support.pojo.person.Person;
@@ -38,13 +38,13 @@ import static org.mockito.Mockito.when;
 class FieldAssignerTest {
     private static final Exception EXPECTED_ERROR = new RuntimeException("expected error");
 
-    private static Node getMockNode() {
+    private static InternalNode getMockNode() {
         final Field mockField = mock(Field.class);
         doReturn(Person.class).when(mockField).getDeclaringClass();
         doReturn(String.class).when(mockField).getType();
         doReturn("name").when(mockField).getName();
         doThrow(EXPECTED_ERROR).when(mockField).setAccessible(true);
-        return when(mock(Node.class).getField()).thenReturn(mockField).getMock();
+        return when(mock(InternalNode.class).getField()).thenReturn(mockField).getMock();
     }
 
     private static FieldAssigner createAssigner(final OnSetFieldError onSetFieldError) {
@@ -54,7 +54,7 @@ class FieldAssignerTest {
 
     @Test
     void ignoreError() throws IllegalAccessException {
-        final Node mockNode = getMockNode();
+        final InternalNode mockNode = getMockNode();
         final FieldAssigner assigner = createAssigner(OnSetFieldError.IGNORE);
         assigner.assign(mockNode, "any-target", "any-value");
 
@@ -65,7 +65,7 @@ class FieldAssignerTest {
     @Test
     void failOnError() {
         final FieldAssigner assigner = createAssigner(OnSetFieldError.FAIL);
-        final Node mockNode = getMockNode();
+        final InternalNode mockNode = getMockNode();
 
         assertThatThrownBy(() -> assigner.assign(mockNode, "any-target", "any-value"))
                 .isExactlyInstanceOf(InstancioApiException.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
@@ -31,7 +31,7 @@ import org.instancio.generator.specs.ArrayGeneratorSpec;
 import org.instancio.generators.Generators;
 import org.instancio.internal.generator.misc.GeneratorDecorator;
 import org.instancio.internal.generator.misc.SupplierAdapter;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
@@ -336,14 +336,14 @@ class ModelContextTest {
         return field(field.getDeclaringClass(), field.getName());
     }
 
-    private static Node mockNode(Class<?> targetClass, Field field) {
-        final Node node = mock(Node.class);
+    private static InternalNode mockNode(Class<?> targetClass, Field field) {
+        final InternalNode node = mock(InternalNode.class);
         doReturn(targetClass).when(node).getRawType();
         doReturn(field).when(node).getField();
         return node;
     }
 
-    private static Node mockNode(Class<?> targetClass) {
+    private static InternalNode mockNode(Class<?> targetClass) {
         return mockNode(targetClass, null);
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/SelectorMapTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/SelectorMapTest.java
@@ -19,7 +19,7 @@ import org.instancio.GroupableSelector;
 import org.instancio.Select;
 import org.instancio.Selector;
 import org.instancio.TargetSelector;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeContext;
 import org.instancio.internal.nodes.NodeFactory;
 import org.instancio.internal.selectors.SelectorImpl;
@@ -56,15 +56,15 @@ class SelectorMapTest {
 
     private final NodeFactory nodeFactory = new NodeFactory(nodeContext);
 
-    private final Node rootNode = nodeFactory.createRootNode(PersonHolder.class);
-    private final Node personNameNode = getNodeWithField(rootNode, Person.class, "name");
-    private final Node phoneNumberNode = getNodeWithField(rootNode, Phone.class, "number");
-    private final Node petNameNode = getNodeWithField(rootNode, Pet.class, "name");
+    private final InternalNode rootNode = nodeFactory.createRootNode(PersonHolder.class);
+    private final InternalNode personNameNode = getNodeWithField(rootNode, Person.class, "name");
+    private final InternalNode phoneNumberNode = getNodeWithField(rootNode, Phone.class, "number");
+    private final InternalNode petNameNode = getNodeWithField(rootNode, Pet.class, "name");
     // RichPerson.phone.number
-    private final Node richPersonPhoneFieldNumberFieldNode = getNodeWithField(
+    private final InternalNode richPersonPhoneFieldNumberFieldNode = getNodeWithField(
             getNodeWithField(rootNode, RichPerson.class, "phone"), Phone.class, "number");
     // RichPerson.address1.List<Phone>.number
-    private final Node richPersonListOfPhonesPhoneNumberFieldNode = getNodeWithField(
+    private final InternalNode richPersonListOfPhonesPhoneNumberFieldNode = getNodeWithField(
             getNodeWithField(rootNode, RichPerson.class, "address1"), Phone.class, "number");
 
     private final SelectorMap<String> selectorMap = new SelectorMap<>();
@@ -181,19 +181,19 @@ class SelectorMapTest {
         assertThat(selectorMap.getValue(personNameNode)).isEmpty();
         assertThat(selectorMap.getValue(phoneNumberNode)).isEmpty();
 
-        final Node stringNode = nodeFactory.createRootNode(String.class);
+        final InternalNode stringNode = nodeFactory.createRootNode(String.class);
         assertThat(selectorMap.getValue(stringNode)).isEmpty();
     }
 
-    private static Node getNodeWithField(final Node node, final Class<?> declaringClass, final String fieldName) {
+    private static InternalNode getNodeWithField(final InternalNode node, final Class<?> declaringClass, final String fieldName) {
         final Field field = ReflectionUtils.getField(declaringClass, fieldName);
         assertThat(field).as("null field").isNotNull();
         if (Objects.equals(node.getField(), field)) {
             return node;
         }
 
-        Node result = null;
-        for (Node child : node.getChildren()) {
+        InternalNode result = null;
+        for (InternalNode child : node.getChildren()) {
             result = getNodeWithField(child, declaringClass, fieldName);
             if (result != null) break;
         }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/InternalNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/InternalNodeTest.java
@@ -42,7 +42,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 import static org.instancio.testsupport.utils.NodeUtils.getChildNode;
 
 @NodeTag
-class NodeTest {
+class InternalNodeTest {
     private static final NodeContext NODE_CONTEXT = NodeContext.builder()
             .maxDepth(Integer.MAX_VALUE)
             .ignoredSelectorMap(new BooleanSelectorMap(Collections.emptySet()))
@@ -53,7 +53,7 @@ class NodeTest {
 
     @Test
     void ignoredNode() {
-        final Node node = Node.ignoredNode();
+        final InternalNode node = InternalNode.ignoredNode();
         assertNode(node)
                 .hasChildrenOfSize(0)
                 .isOfKind(NodeKind.IGNORED)
@@ -75,10 +75,10 @@ class NodeTest {
 
     @Test
     void toBuilder() {
-        final Node parent = createNode(Person.class, new TypeToken<Person>() {});
-        final List<Node> children = Collections.singletonList(createNode(String.class, new TypeToken<String>() {}));
+        final InternalNode parent = createNode(Person.class, new TypeToken<Person>() {});
+        final List<InternalNode> children = Collections.singletonList(createNode(String.class, new TypeToken<String>() {}));
 
-        final Node node = Node.builder()
+        final InternalNode node = InternalNode.builder()
                 .type(Types.LIST_STRING.get())
                 .rawType(List.class)
                 .targetClass(List.class)
@@ -89,7 +89,7 @@ class NodeTest {
                 .children(children)
                 .build();
 
-        final Node copy = node.toBuilder().build();
+        final InternalNode copy = node.toBuilder().build();
 
         assertThat(copy.getNodeContext()).isEqualTo(node.getNodeContext());
         assertThat(copy.getType()).isEqualTo(node.getType());
@@ -111,18 +111,20 @@ class NodeTest {
             TypeToken<?> typeBazInteger = new TypeToken<Baz<Integer>>() {};
             TypeToken<?> typeBazString = new TypeToken<Baz<String>>() {};
 
-            Node bazInteger = createNode(List.class, typeBazInteger);
-            Node bazString = createNode(List.class, typeBazString);
+            InternalNode bazInteger = createNode(List.class, typeBazInteger);
+            InternalNode bazString = createNode(List.class, typeBazString);
             NodeContext nodeContext = NodeContext.builder().build();
-            Node bazIntegerClassNode = Node.builder()
+            InternalNode bazIntegerClassNode = InternalNode.builder()
                     .nodeContext(nodeContext)
                     .type(typeBazInteger.get())
                     .rawType(Baz.class)
                     .targetClass(Baz.class)
                     .build();
 
-            assertThat(bazString).isEqualTo(bazString).hasSameHashCodeAs(bazString);
-            assertThat(bazString).isNotEqualTo(bazInteger).doesNotHaveSameHashCodeAs(bazInteger);
+            assertThat(bazString)
+                    .isEqualTo(bazString).hasSameHashCodeAs(bazString)
+                    .isNotEqualTo(bazInteger).doesNotHaveSameHashCodeAs(bazInteger);
+
             assertThat(bazInteger).isNotEqualTo(bazIntegerClassNode).doesNotHaveSameHashCodeAs(bazIntegerClassNode);
         }
     }
@@ -211,7 +213,7 @@ class NodeTest {
 
         @Test
         void verifyToString() {
-            final Node personNode = NODE_FACTORY.createRootNode(Person.class);
+            final InternalNode personNode = NODE_FACTORY.createRootNode(Person.class);
 
             assertThat(personNode)
                     .hasToString("Node[Person, depth=0, #chn=9, Person]");
@@ -234,13 +236,13 @@ class NodeTest {
 
         @Test
         void ignoredNode() {
-            assertThat(Node.ignoredNode()).hasToString("Node[IGNORED]");
+            assertThat(InternalNode.ignoredNode()).hasToString("Node[IGNORED]");
         }
     }
 
-    private static Node createNode(Class<?> klass, TypeToken<?> type) {
+    private static InternalNode createNode(Class<?> klass, TypeToken<?> type) {
         final NodeContext nodeContext = NodeContext.builder().build();
-        return Node.builder()
+        return InternalNode.builder()
                 .nodeContext(nodeContext)
                 .type(type.get())
                 .rawType(klass)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeImplTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.nodes;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.instancio.internal.util.ReflectionUtils;
+import org.instancio.test.support.pojo.generics.foobarbaz.Foo;
+import org.instancio.test.support.tags.NodeTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@NodeTag
+class NodeImplTest {
+
+    @Test
+    void verifyEqualsAndHashCode() {
+        EqualsVerifier.forClass(NodeImpl.class).verify();
+    }
+
+    @Test
+    void validation() {
+        assertThatThrownBy(() -> new NodeImpl(null, null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessage("targetClass is null");
+    }
+
+    @Test
+    void verifyToString() {
+        assertThat(new NodeImpl(Foo.class, ReflectionUtils.getField(Foo.class, "fooValue")))
+                .hasToString("Node[targetClass=org.instancio.test.support.pojo.generics.foobarbaz.Foo, field=fooValue]");
+
+        assertThat(new NodeImpl(Foo.class, null))
+                .hasToString("Node[targetClass=org.instancio.test.support.pojo.generics.foobarbaz.Foo, field=null]");
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/spi/ProviderEntryTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/spi/ProviderEntryTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ProviderEntryTest {
 
-    private static final GeneratorProvider NOOP_GENERATOR_PROVIDER = type -> null;
+    private static final GeneratorProvider NOOP_GENERATOR_PROVIDER = (node, generators) -> null;
     private static final TypeResolver NOOP_TYPE_RESOLVER = type -> null;
     private static final TypeInstantiator NOOP_TYPE_INSTANTIATOR = type -> null;
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ArrayLongNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ArrayLongNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.test.support.pojo.arrays.ArrayLong;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -26,8 +26,8 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ArrayLongNodeTest extends NodeTestTemplate<ArrayLong> {
 
     @Override
-    protected void verify(Node rootNode) {
-        final Node primitiveArray = assertNode(NodeUtils.getChildNode(rootNode, "primitive"))
+    protected void verify(InternalNode rootNode) {
+        final InternalNode primitiveArray = assertNode(NodeUtils.getChildNode(rootNode, "primitive"))
                 .isOfKind(NodeKind.ARRAY)
                 .hasTargetClass(long[].class)
                 .hasChildrenOfSize(1)
@@ -37,7 +37,7 @@ class ArrayLongNodeTest extends NodeTestTemplate<ArrayLong> {
                 .hasTargetClass(long.class)
                 .hasNullField();
 
-        final Node wrapperArray = assertNode(NodeUtils.getChildNode(rootNode, "wrapper"))
+        final InternalNode wrapperArray = assertNode(NodeUtils.getChildNode(rootNode, "wrapper"))
                 .hasTargetClass(Long[].class)
                 .hasChildrenOfSize(1)
                 .get();

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ArrayOfStringSuppliersNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ArrayOfStringSuppliersNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.arrayofsuppliers.ArrayOfStringSuppliers;
 import org.instancio.test.support.pojo.generics.arrayofsuppliers.GenericArrayHolder;
 import org.instancio.test.support.tags.GenericsTag;
@@ -29,7 +29,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ArrayOfStringSuppliersNodeTest extends NodeTestTemplate<ArrayOfStringSuppliers> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(ArrayOfStringSuppliers.class)
@@ -37,7 +37,7 @@ class ArrayOfStringSuppliersNodeTest extends NodeTestTemplate<ArrayOfStringSuppl
                 .hasTypeMapWithSize(1)
                 .hasChildrenOfSize(1);
 
-        final Node array = assertNode(rootNode.getOnlyChild())
+        final InternalNode array = assertNode(rootNode.getOnlyChild())
                 .hasDepth(1)
                 .hasFieldName("array")
                 .hasTargetClass(Supplier[].class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BaseClasSubClassInheritanceNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BaseClasSubClassInheritanceNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.inheritance.BaseClassSubClassInheritance;
 import org.instancio.test.support.pojo.inheritance.BaseClassSubClassInheritance.SubClass;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -26,13 +26,13 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class BaseClasSubClassInheritanceNodeTest extends NodeTestTemplate<BaseClassSubClassInheritance> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(BaseClassSubClassInheritance.class)
                 .hasChildrenOfSize(1);
 
-        final Node subClass = assertNode(rootNode.getOnlyChild())
+        final InternalNode subClass = assertNode(rootNode.getOnlyChild())
                 .hasDepth(1)
                 .hasTargetClass(SubClass.class)
                 .hasFieldName("subClass")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BidirectionalOneToOneNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BidirectionalOneToOneNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.cyclic.BidirectionalOneToOne;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -27,13 +27,13 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class BidirectionalOneToOneNodeTest extends NodeTestTemplate<BidirectionalOneToOne.Parent> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(BidirectionalOneToOne.Parent.class)
                 .hasChildrenOfSize(2);
 
-        final Node child = assertNode(NodeUtils.getChildNode(rootNode, "child"))
+        final InternalNode child = assertNode(NodeUtils.getChildNode(rootNode, "child"))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("child")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesABCWithCrossReferencesNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesABCWithCrossReferencesNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.cyclic.ClassesABCWithCrossReferences;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -32,7 +32,7 @@ class ClassesABCWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesABCW
     private static final int EXPECTED_MAX_DEPTH = 10;
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ClassesABCWithCrossReferences.class)
                 .hasChildrenOfSize(3);
@@ -73,7 +73,7 @@ class ClassesABCWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesABCW
         assertThat(stats.nodesAtDepth[10]).isEqualTo(216);
     }
 
-    private void assertNodeRecursively(final Node node, final int expectedDepth, final Stats stats) {
+    private void assertNodeRecursively(final InternalNode node, final int expectedDepth, final Stats stats) {
         if (node == null) return;
 
         stats.maxDepth = Math.max(stats.maxDepth, node.getDepth());

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesWithCrossReferencesNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesWithCrossReferencesNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.cyclic.ClassesWithCrossReferences;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -33,7 +33,7 @@ class ClassesWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesWithCro
     }
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode).isNotNull();
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/CyclicListNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/CyclicListNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.cyclic.CyclicList;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -24,7 +24,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class CyclicListNodeTest extends NodeTestTemplate<CyclicList> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(CyclicList.class)
                 .hasDepth(0)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/EnumSetOfGenderNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/EnumSetOfGenderNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.person.Gender;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -26,7 +26,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class EnumSetOfGenderNodeTest extends NodeTestTemplate<EnumSet<Gender>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(EnumSet.class)
                 .hasDepth(0)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/FooBarBazContainerNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/FooBarBazContainerNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.foobarbaz.Bar;
 import org.instancio.test.support.pojo.generics.foobarbaz.Baz;
 import org.instancio.test.support.pojo.generics.foobarbaz.Foo;
@@ -29,13 +29,13 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class FooBarBazContainerNodeTest extends NodeTestTemplate<FooBarBazContainer> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(FooBarBazContainer.class)
                 .hasDepth(0)
                 .hasChildrenOfSize(1);
 
-        final Node itemNode = CollectionUtils.getOnlyElement(rootNode.getChildren());
+        final InternalNode itemNode = CollectionUtils.getOnlyElement(rootNode.getChildren());
         assertNode(itemNode)
                 .hasDepth(1)
                 .hasTargetClass(Foo.class)
@@ -48,7 +48,7 @@ class FooBarBazContainerNodeTest extends NodeTestTemplate<FooBarBazContainer> {
                         "Baz<java.lang.String>>>")
                 .hasChildrenOfSize(2);
 
-        final Node fooValueNode = NodeUtils.getChildNode(itemNode, "fooValue");
+        final InternalNode fooValueNode = NodeUtils.getChildNode(itemNode, "fooValue");
         assertNode(fooValueNode)
                 .hasDepth(2)
                 .hasTargetClass(Bar.class)
@@ -64,7 +64,7 @@ class FooBarBazContainerNodeTest extends NodeTestTemplate<FooBarBazContainer> {
                 .hasTargetClass(Object.class)
                 .hasNoChildren();
 
-        final Node barValueNode = NodeUtils.getChildNode(fooValueNode, "barValue");
+        final InternalNode barValueNode = NodeUtils.getChildNode(fooValueNode, "barValue");
         assertNode(barValueNode)
                 .hasDepth(3)
                 .hasTargetClass(Baz.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericContainerStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericContainerStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.container.GenericContainer;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 import org.instancio.testsupport.utils.NodeUtils;
@@ -27,7 +27,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class GenericContainerStringNodeTest extends NodeTestTemplate<GenericContainer<String>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(GenericContainer.class)
@@ -43,7 +43,7 @@ class GenericContainerStringNodeTest extends NodeTestTemplate<GenericContainer<S
                 .hasNoChildren();
 
         // T[] array
-        final Node array = assertNode(NodeUtils.getChildNode(rootNode, "array"))
+        final InternalNode array = assertNode(NodeUtils.getChildNode(rootNode, "array"))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("array")
@@ -61,7 +61,7 @@ class GenericContainerStringNodeTest extends NodeTestTemplate<GenericContainer<S
                 .hasNoChildren();
 
         // List<T> list
-        final Node list = assertNode(NodeUtils.getChildNode(rootNode, "list"))
+        final InternalNode list = assertNode(NodeUtils.getChildNode(rootNode, "list"))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("list")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericItemHolderWithInheritanceNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericItemHolderWithInheritanceNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.pojo.generics.inheritance.GenericTypesWithInheritance.EntityWithId;
 import org.instancio.test.support.pojo.generics.inheritance.GenericTypesWithInheritance.GenericItemHolderWithInheritance;
@@ -32,7 +32,7 @@ class GenericItemHolderWithInheritanceNodeTest
         extends NodeTestTemplate<GenericItemHolderWithInheritance<PhoneWithType, Item<PhoneWithType>>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(GenericItemHolderWithInheritance.class)
@@ -47,7 +47,7 @@ class GenericItemHolderWithInheritanceNodeTest
         assertItem(rootNode);
     }
 
-    private static void assertId(final Node rootNode) {
+    private static void assertId(final InternalNode rootNode) {
         assertNode(NodeUtils.getChildNode(rootNode, "id"))
                 .hasDepth(1)
                 .hasParent(rootNode)
@@ -58,8 +58,8 @@ class GenericItemHolderWithInheritanceNodeTest
                 .get();
     }
 
-    private static void assertItem(final Node rootNode) {
-        final Node item = assertNode(NodeUtils.getChildNode(rootNode, "item"))
+    private static void assertItem(final InternalNode rootNode) {
+        final InternalNode item = assertNode(NodeUtils.getChildNode(rootNode, "item"))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("item")
@@ -67,7 +67,7 @@ class GenericItemHolderWithInheritanceNodeTest
                 .hasChildrenOfSize(1)
                 .get();
 
-        final Node phoneWithType = assertNode(NodeUtils.getChildNode(item, "value"))
+        final InternalNode phoneWithType = assertNode(NodeUtils.getChildNode(item, "value"))
                 .hasDepth(2)
                 .hasParent(item)
                 .hasTargetClass(PhoneWithType.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericPhoneHolderWithInheritanceNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/GenericPhoneHolderWithInheritanceNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.inheritance.GenericTypesWithInheritance.EntityWithId;
 import org.instancio.test.support.pojo.generics.inheritance.GenericTypesWithInheritance.GenericPhoneHolderWithInheritance;
 import org.instancio.test.support.pojo.person.PhoneType;
@@ -31,7 +31,7 @@ class GenericPhoneHolderWithInheritanceNodeTest
         extends NodeTestTemplate<GenericPhoneHolderWithInheritance<PhoneWithType>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(GenericPhoneHolderWithInheritance.class)
@@ -44,7 +44,7 @@ class GenericPhoneHolderWithInheritanceNodeTest
         assertPhone(rootNode);
     }
 
-    private static void assertId(final Node rootNode) {
+    private static void assertId(final InternalNode rootNode) {
         assertNode(NodeUtils.getChildNode(rootNode, "id"))
                 .hasDepth(1)
                 .hasParent(rootNode)
@@ -55,8 +55,8 @@ class GenericPhoneHolderWithInheritanceNodeTest
                 .get();
     }
 
-    private static void assertPhone(final Node rootNode) {
-        final Node phoneWithType = assertNode(NodeUtils.getChildNode(rootNode, "phone"))
+    private static void assertPhone(final InternalNode rootNode) {
+        final InternalNode phoneWithType = assertNode(NodeUtils.getChildNode(rootNode, "phone"))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("phone")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/IndirectCircularRefNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/IndirectCircularRefNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.cyclic.IndirectCircularRef;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.test.support.util.CollectionUtils;
@@ -27,27 +27,27 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class IndirectCircularRefNodeTest extends NodeTestTemplate<IndirectCircularRef> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(IndirectCircularRef.class)
                 .hasChildrenOfSize(1);
 
-        final Node startA = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
+        final InternalNode startA = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
                 .hasDepth(1)
                 .hasTargetClass(IndirectCircularRef.A.class)
                 .hasFieldName("startA")
                 .hasChildrenOfSize(1)
                 .get();
 
-        final Node b = assertNode(CollectionUtils.getOnlyElement(startA.getChildren()))
+        final InternalNode b = assertNode(CollectionUtils.getOnlyElement(startA.getChildren()))
                 .hasDepth(2)
                 .hasTargetClass(IndirectCircularRef.B.class)
                 .hasFieldName("b")
                 .hasChildrenOfSize(1)
                 .get();
 
-        final Node c = assertNode(CollectionUtils.getOnlyElement(b.getChildren()))
+        final InternalNode c = assertNode(CollectionUtils.getOnlyElement(b.getChildren()))
                 .hasDepth(3)
                 .hasTargetClass(IndirectCircularRef.C.class)
                 .hasFieldName("c")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ItemArrayStringIntegerContainerNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ItemArrayStringIntegerContainerNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.pojo.generics.container.ItemArrayContainer;
@@ -27,7 +27,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ItemArrayStringIntegerContainerNodeTest extends NodeTestTemplate<ItemArrayContainer<String, Integer>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ItemArrayContainer.class)
                 .isOfKind(NodeKind.DEFAULT)
@@ -40,9 +40,9 @@ class ItemArrayStringIntegerContainerNodeTest extends NodeTestTemplate<ItemArray
         assertItemArrayY(rootNode);
     }
 
-    private void assertItemArrayX(Node rootNode) {
+    private void assertItemArrayX(InternalNode rootNode) {
         final String itemArrayField = "itemArrayX";
-        final Node array = assertNode(NodeUtils.getChildNode(rootNode, itemArrayField))
+        final InternalNode array = assertNode(NodeUtils.getChildNode(rootNode, itemArrayField))
                 .hasFieldName(itemArrayField)
                 .hasTargetClass(Item[].class)
                 .hasTypeName("org.instancio.test.support.pojo.generics.basic.Item<X>[]")
@@ -53,9 +53,9 @@ class ItemArrayStringIntegerContainerNodeTest extends NodeTestTemplate<ItemArray
         assertElementNode(array, "X");
     }
 
-    private void assertItemArrayY(Node rootNode) {
+    private void assertItemArrayY(InternalNode rootNode) {
         final String itemArrayField = "itemArrayY";
-        final Node array = assertNode(NodeUtils.getChildNode(rootNode, itemArrayField))
+        final InternalNode array = assertNode(NodeUtils.getChildNode(rootNode, itemArrayField))
                 .hasFieldName(itemArrayField)
                 .hasTargetClass(Item[].class)
                 .hasTypeName("org.instancio.test.support.pojo.generics.basic.Item<Y>[]")
@@ -66,8 +66,8 @@ class ItemArrayStringIntegerContainerNodeTest extends NodeTestTemplate<ItemArray
         assertElementNode(array, "Y");
     }
 
-    private void assertElementNode(Node arrayNode, String expectedType) {
-        final Node elementNode = arrayNode.getOnlyChild();
+    private void assertElementNode(InternalNode arrayNode, String expectedType) {
+        final InternalNode elementNode = arrayNode.getOnlyChild();
         assertNode(elementNode)
                 .hasTargetClass(Item.class)
                 .hasNullField()

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ItemContainerStringLongNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ItemContainerStringLongNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.pojo.generics.container.ItemContainer;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -27,13 +27,13 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ItemContainerStringLongNodeTest extends NodeTestTemplate<ItemContainer<String, Long>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ItemContainer.class)
                 .hasChildrenOfSize(2);
 
         final String itemValueXField = "itemValueX";
-        final Node itemValueX = assertNode(NodeUtils.getChildNode(rootNode, itemValueXField))
+        final InternalNode itemValueX = assertNode(NodeUtils.getChildNode(rootNode, itemValueXField))
                 .hasParent(rootNode)
                 .hasFieldName(itemValueXField)
                 .hasTargetClass(Item.class)
@@ -49,7 +49,7 @@ class ItemContainerStringLongNodeTest extends NodeTestTemplate<ItemContainer<Str
                 .hasNoChildren();
 
         final String itemValueYField = "itemValueY";
-        final Node itemValueY = assertNode(NodeUtils.getChildNode(rootNode, itemValueYField))
+        final InternalNode itemValueY = assertNode(NodeUtils.getChildNode(rootNode, itemValueYField))
                 .hasParent(rootNode)
                 .hasFieldName(itemValueYField)
                 .hasTargetClass(Item.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/IterableStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/IterableStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -24,7 +24,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class IterableStringNodeTest extends NodeTestTemplate<Iterable<String>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(Iterable.class)
                 .hasChildrenOfSize(1);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListExtendsNumberNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListExtendsNumberNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.ListExtendsNumber;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -27,12 +27,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ListExtendsNumberNodeTest extends NodeTestTemplate<ListExtendsNumber> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ListExtendsNumber.class)
                 .hasChildrenOfSize(1);
 
-        final Node list = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
+        final InternalNode list = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
                 .hasFieldName("list")
                 .hasChildrenOfSize(1)
                 .hasTargetClass(List.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListListStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListListStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.collections.lists.ListListString;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.fixtures.Types;
@@ -28,20 +28,20 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ListListStringNodeTest extends NodeTestTemplate<ListListString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ListListString.class)
                 .hasChildrenOfSize(1);
 
         // List<List<String>>
-        final Node outerListNode = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
+        final InternalNode outerListNode = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
                 .hasChildrenOfSize(1)
                 .hasFieldName("nested")
                 .hasType(Types.LIST_LIST_STRING.get())
                 .get();
 
         // List<String>
-        final Node outerListElementNode = outerListNode.getOnlyChild();
+        final InternalNode outerListElementNode = outerListNode.getOnlyChild();
 
         assertNode(outerListElementNode)
                 .hasTargetClass(List.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListLocalDateTimeNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListLocalDateTimeNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
 import java.time.LocalDateTime;
@@ -26,8 +26,8 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 public class ListLocalDateTimeNodeTest extends NodeTestTemplate<List<LocalDateTime>> {
 
     @Override
-    protected void verify(final Node rootNode) {
-        final Node listNode = assertNode(rootNode)
+    protected void verify(final InternalNode rootNode) {
+        final InternalNode listNode = assertNode(rootNode)
                 .hasTargetClass(List.class)
                 .hasTypeMappedTo(List.class, "E", LocalDateTime.class)
                 .hasChildrenOfSize(1)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListOfOuterMidInnerStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListOfOuterMidInnerStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.outermidinner.Inner;
 import org.instancio.test.support.pojo.generics.outermidinner.ListOfOuterMidInnerString;
 import org.instancio.test.support.pojo.generics.outermidinner.Mid;
@@ -30,7 +30,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ListOfOuterMidInnerStringNodeTest extends NodeTestTemplate<ListOfOuterMidInnerString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasParent(null)
                 .hasNullField()
@@ -39,20 +39,20 @@ class ListOfOuterMidInnerStringNodeTest extends NodeTestTemplate<ListOfOuterMidI
                 .hasChildrenOfSize(1);
 
         //  List<Outer<Mid<Inner<String>>>>
-        final Node rootListElement = assertRootListAndItsElement(rootNode);
+        final InternalNode rootListElement = assertRootListAndItsElement(rootNode);
 
         // List<T> outerList
-        final Node outerElement = assertOuterList(rootListElement);
+        final InternalNode outerElement = assertOuterList(rootListElement);
 
         // List<T> midList
-        final Node midListElement = assertMidList(outerElement);
+        final InternalNode midListElement = assertMidList(outerElement);
 
         // List<T> innerList
         assertInnerList(midListElement);
     }
 
-    private Node assertRootListAndItsElement(Node rootNode) {
-        final Node rootList = assertNode(getOnlyElement(rootNode.getChildren()))
+    private InternalNode assertRootListAndItsElement(InternalNode rootNode) {
+        final InternalNode rootList = assertNode(getOnlyElement(rootNode.getChildren()))
                 .hasParent(rootNode)
                 .hasFieldName("rootList")
                 .hasTargetClass(List.class)
@@ -80,8 +80,8 @@ class ListOfOuterMidInnerStringNodeTest extends NodeTestTemplate<ListOfOuterMidI
         return rootList.getOnlyChild();
     }
 
-    private Node assertOuterList(Node rootListElement) {
-        final Node outerList = assertNode(getOnlyElement(rootListElement.getChildren()))
+    private InternalNode assertOuterList(InternalNode rootListElement) {
+        final InternalNode outerList = assertNode(getOnlyElement(rootListElement.getChildren()))
                 .hasParent(rootListElement)
                 .hasFieldName("outerList")
                 .hasTargetClass(List.class)
@@ -101,8 +101,8 @@ class ListOfOuterMidInnerStringNodeTest extends NodeTestTemplate<ListOfOuterMidI
         return outerList.getOnlyChild();
     }
 
-    private Node assertMidList(Node outerElement) {
-        final Node midList = assertNode(getOnlyElement(outerElement.getChildren()))
+    private InternalNode assertMidList(InternalNode outerElement) {
+        final InternalNode midList = assertNode(getOnlyElement(outerElement.getChildren()))
                 .hasParent(outerElement)
                 .hasFieldName("midList")
                 .hasTargetClass(List.class)
@@ -120,8 +120,8 @@ class ListOfOuterMidInnerStringNodeTest extends NodeTestTemplate<ListOfOuterMidI
         return midList.getOnlyChild();
     }
 
-    private void assertInnerList(Node midListElement) {
-        final Node innerList = assertNode(getOnlyElement(midListElement.getChildren()))
+    private void assertInnerList(InternalNode midListElement) {
+        final InternalNode innerList = assertNode(getOnlyElement(midListElement.getChildren()))
                 .hasParent(midListElement)
                 .hasFieldName("innerList")
                 .hasTargetClass(List.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListWithWildcardNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListWithWildcardNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.ListWithWildcard;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -27,12 +27,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ListWithWildcardNodeTest extends NodeTestTemplate<ListWithWildcard> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ListWithWildcard.class)
                 .hasChildrenOfSize(1);
 
-        final Node list = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
+        final InternalNode list = assertNode(CollectionUtils.getOnlyElement(rootNode.getChildren()))
                 .hasFieldName("list")
                 .hasChildrenOfSize(1)
                 .hasTargetClass(List.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListWithoutTypeNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ListWithoutTypeNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.ListWithoutType;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -25,7 +25,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class ListWithoutTypeNodeTest extends NodeTestTemplate<ListWithoutType> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(ListWithoutType.class)
                 .hasChildrenOfSize(1);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerArrayStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerArrayStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.collections.maps.MapIntegerArrayString;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -27,12 +27,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class MapIntegerArrayStringNodeTest extends NodeTestTemplate<MapIntegerArrayString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(MapIntegerArrayString.class)
                 .hasChildrenOfSize(1);
 
-        final Node map = assertNode(getOnlyElement(rootNode.getChildren()))
+        final InternalNode map = assertNode(getOnlyElement(rootNode.getChildren()))
                 .hasParent(rootNode)
                 .hasFieldName("map")
                 .hasTargetClass(Map.class)
@@ -47,7 +47,7 @@ class MapIntegerArrayStringNodeTest extends NodeTestTemplate<MapIntegerArrayStri
                 .hasTargetClass(Integer.class)
                 .hasNoChildren();
 
-        final Node array = assertNode(map.getChildren().get(1))
+        final InternalNode array = assertNode(map.getChildren().get(1))
                 .hasParent(map)
                 .hasNullField()
                 .hasTargetClass(String[].class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerItemOfStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerItemOfStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.collections.maps.MapIntegerItemOfString;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.testsupport.fixtures.Types;
@@ -29,12 +29,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class MapIntegerItemOfStringNodeTest extends NodeTestTemplate<MapIntegerItemOfString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(MapIntegerItemOfString.class)
                 .hasChildrenOfSize(1);
 
-        final Node outerMap = assertNode(getOnlyElement(rootNode.getChildren()))
+        final InternalNode outerMap = assertNode(getOnlyElement(rootNode.getChildren()))
                 .hasParent(rootNode)
                 .hasFieldName("map")
                 .hasTargetClass(Map.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerListStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerListStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.test.support.pojo.collections.maps.MapIntegerListString;
 import org.instancio.testsupport.fixtures.Types;
@@ -30,12 +30,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class MapIntegerListStringNodeTest extends NodeTestTemplate<MapIntegerListString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(MapIntegerListString.class)
                 .hasChildrenOfSize(1);
 
-        final Node map = assertNode(getOnlyElement(rootNode.getChildren()))
+        final InternalNode map = assertNode(getOnlyElement(rootNode.getChildren()))
                 .hasParent(rootNode)
                 .hasFieldName("map")
                 .isOfKind(NodeKind.MAP)
@@ -51,7 +51,7 @@ class MapIntegerListStringNodeTest extends NodeTestTemplate<MapIntegerListString
                 .hasTargetClass(Integer.class)
                 .hasNoChildren();
 
-        final Node list = assertNode(map.getChildren().get(1))
+        final InternalNode list = assertNode(map.getChildren().get(1))
                 .hasParent(map)
                 .hasNullField()
                 .isOfKind(NodeKind.COLLECTION)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapIntegerStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.test.support.pojo.collections.maps.MapIntegerString;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -28,13 +28,13 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class MapIntegerStringNodeTest extends NodeTestTemplate<MapIntegerString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasDepth(0)
                 .hasTargetClass(MapIntegerString.class)
                 .hasChildrenOfSize(1);
 
-        final Node map = assertNode(getOnlyElement(rootNode.getChildren()))
+        final InternalNode map = assertNode(getOnlyElement(rootNode.getChildren()))
                 .hasDepth(1)
                 .hasParent(rootNode)
                 .hasFieldName("map")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapWithoutTypesNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/MapWithoutTypesNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.MapWithoutTypes;
 import org.instancio.test.support.util.CollectionUtils;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -25,7 +25,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class MapWithoutTypesNodeTest extends NodeTestTemplate<MapWithoutTypes> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(MapWithoutTypes.class)
                 .hasChildrenOfSize(1);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NestedMapsNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NestedMapsNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.NestedMaps;
 import org.instancio.testsupport.fixtures.Types;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -28,16 +28,16 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class NestedMapsNodeTest extends NodeTestTemplate<NestedMaps<Long, String>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         map1(rootNode);
         map2(rootNode);
     }
 
-    private void map1(Node rootNode) {
+    private void map1(InternalNode rootNode) {
         // Map<Long, Map<String, Boolean>> map1
         final String fieldName = "map1";
 
-        final Node outerMap = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
+        final InternalNode outerMap = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
                 .hasParent(rootNode)
                 .hasFieldName(fieldName)
                 .hasTargetClass(Map.class)
@@ -50,11 +50,11 @@ class NestedMapsNodeTest extends NodeTestTemplate<NestedMaps<Long, String>> {
         assertNestedMap(outerMap);
     }
 
-    private void map2(Node rootNode) {
+    private void map2(InternalNode rootNode) {
         // Map<OKEY, Map<IKEY, Boolean>> map2
         final String fieldName = "map2";
 
-        final Node outerMap = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
+        final InternalNode outerMap = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
                 .hasParent(rootNode)
                 .hasFieldName(fieldName)
                 .hasTargetClass(Map.class)
@@ -67,14 +67,14 @@ class NestedMapsNodeTest extends NodeTestTemplate<NestedMaps<Long, String>> {
         assertNestedMap(outerMap);
     }
 
-    private void assertNestedMap(Node outerMap) {
+    private void assertNestedMap(InternalNode outerMap) {
         assertNode(outerMap.getChildren().get(0))
                 .hasParent(outerMap)
                 .hasNullField()
                 .hasTargetClass(Long.class)
                 .hasNoChildren();
 
-        final Node innerNode = assertNode(outerMap.getChildren().get(1))
+        final InternalNode innerNode = assertNode(outerMap.getChildren().get(1))
                 .hasParent(outerMap)
                 .hasNullField()
                 .hasTargetClass(Map.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NonGenericSubclassOfListNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NonGenericSubclassOfListNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.inheritance.NonGenericSubclassOfList;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -24,7 +24,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class NonGenericSubclassOfListNodeTest extends NodeTestTemplate<NonGenericSubclassOfList> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(NonGenericSubclassOfList.class)
                 .hasChildrenOfSize(1);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NonGenericSubclassOfMapNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/NonGenericSubclassOfMapNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.inheritance.NonGenericSubclassOfMap;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 
@@ -24,7 +24,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class NonGenericSubclassOfMapNodeTest extends NodeTestTemplate<NonGenericSubclassOfMap> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(NonGenericSubclassOfMap.class)
                 .hasChildrenOfSize(2);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/OneItemContainerItemNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/OneItemContainerItemNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.pojo.generics.container.OneItemContainer;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -27,14 +27,14 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class OneItemContainerItemNodeTest extends NodeTestTemplate<OneItemContainer<Item<String>>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(OneItemContainer.class)
                 .hasTypeMappedTo(OneItemContainer.class, "T", "org.instancio.test.support.pojo.generics.basic.Item<java.lang.String>")
                 .hasChildrenOfSize(1);
 
         final String itemField = "item";
-        final Node item = assertNode(NodeUtils.getChildNode(rootNode, itemField))
+        final InternalNode item = assertNode(NodeUtils.getChildNode(rootNode, itemField))
                 .hasParent(rootNode)
                 .hasFieldName(itemField)
                 .hasTargetClass(Item.class)
@@ -43,7 +43,7 @@ class OneItemContainerItemNodeTest extends NodeTestTemplate<OneItemContainer<Ite
                 .hasChildrenOfSize(1)
                 .get();
 
-        final Node nestedItem = assertNode(getOnlyElement(item.getChildren()))
+        final InternalNode nestedItem = assertNode(getOnlyElement(item.getChildren()))
                 .hasParent(item)
                 .hasFieldName("value")
                 .hasTargetClass(Item.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/OptionalStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/OptionalStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.test.support.pojo.misc.OptionalString;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -29,12 +29,12 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class OptionalStringNodeTest extends NodeTestTemplate<OptionalString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(OptionalString.class)
                 .hasChildrenOfSize(1);
 
-        final Node optionalNode = assertNode(NodeUtils.getChildNode(rootNode, "optional"))
+        final InternalNode optionalNode = assertNode(NodeUtils.getChildNode(rootNode, "optional"))
                 .hasParent(rootNode)
                 .hasFieldName("optional")
                 .isOfKind(NodeKind.CONTAINER)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairAStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairAStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.PairAString;
 import org.instancio.test.support.pojo.generics.basic.Pair;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -28,7 +28,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class PairAStringNodeTest extends NodeTestTemplate<PairAString<UUID>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(PairAString.class)
                 .hasChildrenOfSize(1);
@@ -36,7 +36,7 @@ class PairAStringNodeTest extends NodeTestTemplate<PairAString<UUID>> {
         // Pair<A, String>
         final String fieldName = "pairAString";
 
-        final Node pair = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
+        final InternalNode pair = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
                 .hasParent(rootNode)
                 .hasFieldName(fieldName)
                 .hasTargetClass(Pair.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairContainerIntegerStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairContainerIntegerStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.basic.Pair;
 import org.instancio.test.support.pojo.generics.container.PairContainer;
 import org.instancio.testsupport.templates.NodeTestTemplate;
@@ -26,14 +26,14 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class PairContainerIntegerStringNodeTest extends NodeTestTemplate<PairContainer<Integer, String>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(PairContainer.class)
                 .hasChildrenOfSize(1);
 
         // Pair<X, Y> pairValue;
         final String pairValueFieldName = "pairValue";
-        final Node pairValue = assertNode(NodeUtils.getChildNode(rootNode, pairValueFieldName))
+        final InternalNode pairValue = assertNode(NodeUtils.getChildNode(rootNode, pairValueFieldName))
                 .hasFieldName(pairValueFieldName)
                 .hasTargetClass(Pair.class)
                 .hasTypeName("org.instancio.test.support.pojo.generics.basic.Pair<X, Y>")

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairLongPairIntegerStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairLongPairIntegerStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.PairLongPairIntegerString;
 import org.instancio.test.support.pojo.generics.basic.Pair;
 import org.instancio.testsupport.fixtures.Types;
@@ -27,7 +27,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class PairLongPairIntegerStringNodeTest extends NodeTestTemplate<PairLongPairIntegerString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(PairLongPairIntegerString.class)
                 .hasChildrenOfSize(1);
@@ -35,7 +35,7 @@ class PairLongPairIntegerStringNodeTest extends NodeTestTemplate<PairLongPairInt
         // Pair<Long, Pair<Integer, String>>
         final String fieldName = "pairLongPairIntegerString";
 
-        final Node outerPair = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
+        final InternalNode outerPair = assertNode(NodeUtils.getChildNode(rootNode, fieldName))
                 .hasParent(rootNode)
                 .hasFieldName(fieldName)
                 .hasTargetClass(Pair.class)
@@ -51,7 +51,7 @@ class PairLongPairIntegerStringNodeTest extends NodeTestTemplate<PairLongPairInt
                 .hasTargetClass(Long.class)
                 .hasNoChildren();
 
-        final Node innerPair = assertNode(NodeUtils.getChildNode(outerPair, "right"))
+        final InternalNode innerPair = assertNode(NodeUtils.getChildNode(outerPair, "right"))
                 .hasFieldName("right")
                 .hasParent(outerPair)
                 .hasTargetClass(Pair.class)
@@ -64,7 +64,7 @@ class PairLongPairIntegerStringNodeTest extends NodeTestTemplate<PairLongPairInt
         assertInnerPair(innerPair);
     }
 
-    private void assertInnerPair(Node innerPair) {
+    private void assertInnerPair(InternalNode innerPair) {
         assertNode(NodeUtils.getChildNode(innerPair, "left"))
                 .hasFieldName("left")
                 .hasParent(innerPair)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairStringIntegerNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PairStringIntegerNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.basic.Pair;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 import org.instancio.testsupport.utils.NodeUtils;
@@ -25,7 +25,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class PairStringIntegerNodeTest extends NodeTestTemplate<Pair<String, Integer>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(Pair.class)
                 .hasTypeMappedTo(Pair.class, "L", String.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PartGenericSubclassOfMapNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/PartGenericSubclassOfMapNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.inheritance.PartGenericSubclassOfMap;
 import org.instancio.testsupport.templates.NodeTestTemplate;
 import org.junit.jupiter.api.Disabled;
@@ -26,7 +26,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class PartGenericSubclassOfMapNodeTest extends NodeTestTemplate<PartGenericSubclassOfMap<Long>> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(PartGenericSubclassOfMap.class)
                 .hasChildrenOfSize(2);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/TwoListsOfItemStringNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/TwoListsOfItemStringNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.collections.lists.TwoListsOfItemString;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.util.CollectionUtils;
@@ -31,7 +31,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class TwoListsOfItemStringNodeTest extends NodeTestTemplate<TwoListsOfItemString> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(TwoListsOfItemString.class)
                 .hasChildrenOfSize(2);
@@ -40,8 +40,8 @@ class TwoListsOfItemStringNodeTest extends NodeTestTemplate<TwoListsOfItemString
         assertListNode(rootNode, "list2");
     }
 
-    private void assertListNode(Node rootNode, String listField) {
-        final Node list = assertNode(NodeUtils.getChildNode(rootNode, listField))
+    private void assertListNode(InternalNode rootNode, String listField) {
+        final InternalNode list = assertNode(NodeUtils.getChildNode(rootNode, listField))
                 .hasChildrenOfSize(1)
                 .hasType(Types.LIST_ITEM_STRING.get())
                 .get();

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/WithGenericParentNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/WithGenericParentNodeTest.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.nodes;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.test.support.pojo.generics.inheritance.WithGenericParent;
 import org.instancio.test.support.pojo.generics.inheritance.WithGenericParent.GenericChild;
 import org.instancio.test.support.pojo.generics.inheritance.WithGenericParent.GenericGrandChild;
@@ -30,7 +30,7 @@ import static org.instancio.testsupport.asserts.NodeAssert.assertNode;
 class WithGenericParentNodeTest extends NodeTestTemplate<WithGenericParent> {
 
     @Override
-    protected void verify(Node rootNode) {
+    protected void verify(InternalNode rootNode) {
         assertNode(rootNode)
                 .hasTargetClass(WithGenericParent.class)
                 .hasEmptyTypeMap()
@@ -41,7 +41,7 @@ class WithGenericParentNodeTest extends NodeTestTemplate<WithGenericParent> {
         assertGenericGrandChild(NodeUtils.getChildNode(rootNode, "genericGrandChild"));
     }
 
-    private static void assertGenericParent(final Node node) {
+    private static void assertGenericParent(final InternalNode node) {
         assertNode(node)
                 .hasFieldName("genericParent")
                 .hasTargetClass(GenericParent.class)
@@ -54,7 +54,7 @@ class WithGenericParentNodeTest extends NodeTestTemplate<WithGenericParent> {
                 .hasNoChildren();
     }
 
-    private static void assertGenericChild(final Node node) {
+    private static void assertGenericChild(final InternalNode node) {
         assertNode(node)
                 .hasFieldName("genericChild")
                 .hasTargetClass(GenericChild.class)
@@ -72,7 +72,7 @@ class WithGenericParentNodeTest extends NodeTestTemplate<WithGenericParent> {
                 .hasNoChildren();
     }
 
-    private void assertGenericGrandChild(final Node node) {
+    private void assertGenericGrandChild(final InternalNode node) {
         assertNode(node)
                 .hasFieldName("genericGrandChild")
                 .hasTargetClass(GenericGrandChild.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/asserts/NodeAssert.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/asserts/NodeAssert.java
@@ -16,7 +16,7 @@
 package org.instancio.testsupport.asserts;
 
 import org.assertj.core.api.AbstractAssert;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeKind;
 import org.instancio.internal.nodes.TypeMap;
 
@@ -26,17 +26,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.testsupport.utils.TypeUtils.getTypeVar;
 
 @SuppressWarnings("UnusedReturnValue")
-public class NodeAssert extends AbstractAssert<NodeAssert, Node> {
+public class NodeAssert extends AbstractAssert<NodeAssert, InternalNode> {
 
-    private NodeAssert(Node actual) {
+    private NodeAssert(InternalNode actual) {
         super(actual, NodeAssert.class);
     }
 
-    public static NodeAssert assertNode(Node actual) {
+    public static NodeAssert assertNode(InternalNode actual) {
         return new NodeAssert(actual);
     }
 
-    public Node get() {
+    public InternalNode get() {
         return actual;
     }
 
@@ -136,7 +136,7 @@ public class NodeAssert extends AbstractAssert<NodeAssert, Node> {
         return this;
     }
 
-    public NodeAssert hasParent(Node expected) {
+    public NodeAssert hasParent(InternalNode expected) {
         isNotNull();
         assertThat(actual.getParent()).isSameAs(expected);
         return this;

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/templates/NodeTestTemplate.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/templates/NodeTestTemplate.java
@@ -18,7 +18,7 @@ package org.instancio.testsupport.templates;
 import org.instancio.TypeTokenSupplier;
 import org.instancio.internal.context.BooleanSelectorMap;
 import org.instancio.internal.context.SubtypeSelectorMap;
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.nodes.NodeContext;
 import org.instancio.internal.nodes.NodeFactory;
 import org.instancio.test.support.tags.NodeTag;
@@ -51,7 +51,7 @@ public abstract class NodeTestTemplate<T> {
                 .build();
         final NodeFactory nodeFactory = new NodeFactory(nodeContext);
         final TypeTokenSupplier<Type> typeSupplier = typeContext::getGenericType;
-        final Node rootNode = nodeFactory.createRootNode(typeSupplier.get());
+        final InternalNode rootNode = nodeFactory.createRootNode(typeSupplier.get());
         verify(rootNode);
     }
 
@@ -62,5 +62,5 @@ public abstract class NodeTestTemplate<T> {
     /**
      * A method for verifying created node.
      */
-    protected abstract void verify(Node rootNode);
+    protected abstract void verify(InternalNode rootNode);
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/utils/NodeUtils.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/utils/NodeUtils.java
@@ -15,7 +15,7 @@
  */
 package org.instancio.testsupport.utils;
 
-import org.instancio.internal.nodes.Node;
+import org.instancio.internal.nodes.InternalNode;
 
 public class NodeUtils {
 
@@ -23,7 +23,7 @@ public class NodeUtils {
         // non-instantiable
     }
 
-    public static Node getChildNode(Node parent, String fieldName) {
+    public static InternalNode getChildNode(InternalNode parent, String fieldName) {
         return parent.getChildren().stream()
                 .filter(it -> it.getField() != null && it.getField().getName().equals(fieldName))
                 .findAny()

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/person/PersonName.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/person/PersonName.java
@@ -26,4 +26,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PersonName {
+
+    int min() default -1;
+
+    int max() default -1;
 }


### PR DESCRIPTION
The original version of the `GeneratorProvider` resolved generators based on a given class. The new implementation makes the resolution using a given `Node`, which contains the target class _and_ field. This approach provides more flexibility, for example allowing generators to be resolved based on field annotations.

Issue #474