### PR TITLE
Modifed `SettingKey` interface to be parameterized.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
@@ -103,7 +103,7 @@ public final class ApiValidator {
                 "Invalid subtype mapping from '%s' to '%s'", to.getTypeName(), from.getTypeName()));
     }
 
-    public static void validateKeyValue(@Nullable final SettingKey key, @Nullable final Object value) {
+    public static void validateKeyValue(@Nullable final SettingKey<?> key, @Nullable final Object value) {
         isTrue(key != null, "Setting key must not be null");
         if (!key.allowsNullValue()) {
             isTrue(value != null, "Setting value for key '%s' must not be null", key);

--- a/instancio-core/src/main/java/org/instancio/internal/settings/AutoAdjustable.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/AutoAdjustable.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.settings;
+
+import org.instancio.documentation.InternalApi;
+import org.instancio.settings.Settings;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a setting that can be auto-adjusted based on the value
+ * of another related setting. An example would be auto-adjusting
+ * the {@code max} value of a range, when the new {@code min} value
+ * is greater than the current {@code max} value.
+ *
+ * @since 2.11.0
+ */
+@InternalApi
+public interface AutoAdjustable {
+
+    /**
+     * Auto-adjusts the {@link Settings} value for this key
+     * based on the value of another setting key.
+     *
+     * @param settings   to adjust
+     * @param otherValue value of the other setting to base the adjustment off
+     * @param <N>        a comparable number
+     * @since 2.11.0
+     */
+    <N extends Number & Comparable<N>> void autoAdjust(
+            @NotNull Settings settings,
+            @NotNull N otherValue);
+}

--- a/instancio-core/src/main/java/org/instancio/internal/settings/InternalKey.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/InternalKey.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-public final class InternalKey implements SettingKey {
+public final class InternalKey<T> implements SettingKey<T>, AutoAdjustable, Comparable<SettingKey<T>> {
 
     private final String propertyKey;
     private final Class<?> type;
@@ -50,13 +50,13 @@ public final class InternalKey implements SettingKey {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> Class<T> type() {
+    public Class<T> type() {
         return (Class<T>) type;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T defaultValue() {
+    public T defaultValue() {
         return (T) defaultValue;
     }
 
@@ -66,12 +66,14 @@ public final class InternalKey implements SettingKey {
     }
 
     @Override
-    public <T extends Number & Comparable<T>> void autoAdjust(
+    @SuppressWarnings("unchecked")
+    public <N extends Number & Comparable<N>> void autoAdjust(
             @NotNull final Settings settings,
-            @NotNull final T otherValue) {
+            @NotNull final N otherValue) {
 
         if (rangeAdjuster != null) {
-            rangeAdjuster.adjustRange(settings, this, otherValue);
+            final SettingKey<N> key = (SettingKey<N>) this;
+            rangeAdjuster.adjustRange(settings, key, otherValue);
         }
     }
 
@@ -79,7 +81,7 @@ public final class InternalKey implements SettingKey {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof InternalKey)) return false;
-        final InternalKey key = (InternalKey) o;
+        final InternalKey<?> key = (InternalKey<?>) o;
         return Objects.equals(propertyKey, key.propertyKey);
     }
 
@@ -89,7 +91,7 @@ public final class InternalKey implements SettingKey {
     }
 
     @Override
-    public int compareTo(final SettingKey o) {
+    public int compareTo(final SettingKey<T> o) {
         return propertyKey.compareTo(o.propertyKey());
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/settings/RangeAdjuster.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/RangeAdjuster.java
@@ -43,7 +43,7 @@ public interface RangeAdjuster {
      * @param otherValue based on which to update given setting key
      * @param <T>        numeric type
      */
-    <T extends Number & Comparable<T>> void adjustRange(Settings settings, SettingKey key, T otherValue);
+    <T extends Number & Comparable<T>> void adjustRange(Settings settings, SettingKey<T> key, T otherValue);
 
     /**
      * Adjusts the lower bound of a range given a new upper bound.
@@ -57,10 +57,10 @@ public interface RangeAdjuster {
 
         @Override
         public <T extends Number & Comparable<T>> void adjustRange(
-                final Settings settings, final SettingKey minSetting, final T newMax) {
+                final Settings settings, final SettingKey<T> minSetting, final T newMax) {
 
             final T curMin = settings.get(minSetting);
-            final Number newMin = NumberUtils.calculateNewMin(curMin, newMax, percentage);
+            final T newMin = NumberUtils.calculateNewMin(curMin, newMax, percentage);
             ((InternalSettings) settings).set(minSetting, newMin, false);
         }
     }
@@ -77,10 +77,10 @@ public interface RangeAdjuster {
 
         @Override
         public <T extends Number & Comparable<T>> void adjustRange(
-                final Settings settings, final SettingKey maxSetting, final T newMin) {
+                final Settings settings, final SettingKey<T> maxSetting, final T newMin) {
 
             final T curMax = settings.get(maxSetting);
-            final Number newMax = NumberUtils.calculateNewMax(curMax, newMin, percentage);
+            final T newMax = NumberUtils.calculateNewMax(curMax, newMin, percentage);
             ((InternalSettings) settings).set(maxSetting, newMax, false);
         }
     }

--- a/instancio-core/src/main/java/org/instancio/internal/settings/SettingsSupport.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/SettingsSupport.java
@@ -29,14 +29,15 @@ final class SettingsSupport {
 
     private static final Map<Class<?>, Function<String, Object>> VALUE_OF_FUNCTIONS = createValueOfFunctionsMap();
 
-    private static final Map<SettingKey, SettingKey> AUTO_ADJUSTABLE_MAP = getAutoAdjustableKeys();
+    private static final Map<SettingKey<?>, SettingKey<?>> AUTO_ADJUSTABLE_MAP = getAutoAdjustableKeys();
 
     static Function<String, Object> getFunction(final Class<?> type) {
         return VALUE_OF_FUNCTIONS.get(type);
     }
 
-    static Optional<SettingKey> getAutoAdjustable(final SettingKey key) {
-        return Optional.ofNullable(AUTO_ADJUSTABLE_MAP.get(key));
+    @SuppressWarnings("unchecked")
+    static <T> Optional<SettingKey<T>> getAutoAdjustable(final SettingKey<T> key) {
+        return Optional.ofNullable((SettingKey<T>) AUTO_ADJUSTABLE_MAP.get(key));
     }
 
     private static Map<Class<?>, Function<String, Object>> createValueOfFunctionsMap() {
@@ -52,8 +53,8 @@ final class SettingsSupport {
         return Collections.unmodifiableMap(fnMap);
     }
 
-    private static Map<SettingKey, SettingKey> getAutoAdjustableKeys() {
-        final Map<SettingKey, SettingKey> map = new HashMap<>();
+    private static Map<SettingKey<?>, SettingKey<?>> getAutoAdjustableKeys() {
+        final Map<SettingKey<?>, SettingKey<?>> map = new HashMap<>();
         map.put(Keys.ARRAY_MAX_LENGTH, Keys.ARRAY_MIN_LENGTH);
         map.put(Keys.ARRAY_MIN_LENGTH, Keys.ARRAY_MAX_LENGTH);
         map.put(Keys.BYTE_MAX, Keys.BYTE_MIN);

--- a/instancio-core/src/main/java/org/instancio/settings/Keys.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Keys.java
@@ -51,187 +51,187 @@ public final class Keys {
 
     private static final RangeAdjuster MIN_ADJUSTER = RangeAdjuster.MIN_ADJUSTER;
     private static final RangeAdjuster MAX_ADJUSTER = RangeAdjuster.MAX_ADJUSTER;
-    private static final List<SettingKey> ALL_KEYS = new ArrayList<>();
+    private static final List<SettingKey<Object>> ALL_KEYS = new ArrayList<>();
 
     /**
      * Specifies whether a {@code null} can be generated for array elements;
      * default is {@code false}; property name {@code array.elements.nullable}.
      */
-    public static final SettingKey ARRAY_ELEMENTS_NULLABLE = register(
+    public static final SettingKey<Boolean> ARRAY_ELEMENTS_NULLABLE = register(
             "array.elements.nullable", Boolean.class, false);
     /**
      * Specifies maximum length for arrays;
      * default is 6; property name {@code array.max.length}.
      */
-    public static final SettingKey ARRAY_MAX_LENGTH = register(
+    public static final SettingKey<Integer> ARRAY_MAX_LENGTH = register(
             "array.max.length", Integer.class, MAX_SIZE, MAX_ADJUSTER);
     /**
      * Specifies minimum length for arrays;
      * default is 2; property name {@code array.min.length}.
      */
-    public static final SettingKey ARRAY_MIN_LENGTH = register(
+    public static final SettingKey<Integer> ARRAY_MIN_LENGTH = register(
             "array.min.length", Integer.class, MIN_SIZE, MIN_ADJUSTER);
     /**
      * Specifies whether a null can be generated for arrays;
      * default is {@code false}; property name {@code array.nullable}.
      */
-    public static final SettingKey ARRAY_NULLABLE = register(
+    public static final SettingKey<Boolean> ARRAY_NULLABLE = register(
             "array.nullable", Boolean.class, false);
     /**
      * Specifies whether a {@code null} can be generated for Boolean type;
      * default is {@code false}; property name {@code boolean.nullable}.
      */
-    public static final SettingKey BOOLEAN_NULLABLE = register(
+    public static final SettingKey<Boolean> BOOLEAN_NULLABLE = register(
             "boolean.nullable", Boolean.class, false);
     /**
      * Specifies maximum value for bytes;
      * default is 127; property name {@code byte.max}.
      */
-    public static final SettingKey BYTE_MAX = register(
+    public static final SettingKey<Byte> BYTE_MAX = register(
             "byte.max", Byte.class, (byte) 127, MAX_ADJUSTER);
     /**
      * Specifies minimum value for bytes;
      * default is 1; property name {@code byte.min}.
      */
-    public static final SettingKey BYTE_MIN = register(
+    public static final SettingKey<Byte> BYTE_MIN = register(
             "byte.min", Byte.class, (byte) NUMERIC_MIN, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Byte type;
      * default is {@code false}; property name {@code byte.nullable}.
      */
-    public static final SettingKey BYTE_NULLABLE = register(
+    public static final SettingKey<Boolean> BYTE_NULLABLE = register(
             "byte.nullable", Boolean.class, false);
     /**
      * Specifies whether a {@code null} can be generated for Character type;
      * default is {@code false}; property name {@code character.nullable}.
      */
-    public static final SettingKey CHARACTER_NULLABLE = register(
+    public static final SettingKey<Boolean> CHARACTER_NULLABLE = register(
             "character.nullable", Boolean.class, false);
     /**
      * Specifies whether a {@code null} can be generated for collection elements;
      * default is {@code false}; property name {@code collection.elements.nullable}.
      */
-    public static final SettingKey COLLECTION_ELEMENTS_NULLABLE = register(
+    public static final SettingKey<Boolean> COLLECTION_ELEMENTS_NULLABLE = register(
             "collection.elements.nullable", Boolean.class, false);
     /**
      * Specifies maximum size for collections;
      * default is 6; property name {@code collection.max.size}.
      */
-    public static final SettingKey COLLECTION_MAX_SIZE = register(
+    public static final SettingKey<Integer> COLLECTION_MAX_SIZE = register(
             "collection.max.size", Integer.class, MAX_SIZE, MAX_ADJUSTER);
     /**
      * Specifies minimum size for collections;
      * default is 2; property name {@code collection.min.size}.
      */
-    public static final SettingKey COLLECTION_MIN_SIZE = register(
+    public static final SettingKey<Integer> COLLECTION_MIN_SIZE = register(
             "collection.min.size", Integer.class, MIN_SIZE, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for collections;
      * default is {@code false}; property name {@code collection.nullable}.
      */
-    public static final SettingKey COLLECTION_NULLABLE = register(
+    public static final SettingKey<Boolean> COLLECTION_NULLABLE = register(
             "collection.nullable", Boolean.class, false);
     /**
      * Specifies maximum value for doubles;
      * default is 10000; property name {@code double.max}.
      */
-    public static final SettingKey DOUBLE_MAX = register(
+    public static final SettingKey<Double> DOUBLE_MAX = register(
             "double.max", Double.class, (double) NUMERIC_MAX, MAX_ADJUSTER);
     /**
      * Specifies minimum value for doubles;
      * default is 1; property name {@code double.min}.
      */
-    public static final SettingKey DOUBLE_MIN = register(
+    public static final SettingKey<Double> DOUBLE_MIN = register(
             "double.min", Double.class, (double) NUMERIC_MIN, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Double type;
      * default is {@code false}; property name {@code double.nullable}.
      */
-    public static final SettingKey DOUBLE_NULLABLE = register(
+    public static final SettingKey<Boolean> DOUBLE_NULLABLE = register(
             "double.nullable", Boolean.class, false);
     /**
      * Specifies maximum value for floats;
      * default is 10000; property name {@code float.max}.
      */
-    public static final SettingKey FLOAT_MAX = register(
+    public static final SettingKey<Float> FLOAT_MAX = register(
             "float.max", Float.class, (float) NUMERIC_MAX, MAX_ADJUSTER);
     /**
      * Specifies minimum value for floats;
      * default is 1; property name {@code float.min}.
      */
-    public static final SettingKey FLOAT_MIN = register(
+    public static final SettingKey<Float> FLOAT_MIN = register(
             "float.min", Float.class, (float) NUMERIC_MIN, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Float type;
      * default is {@code false}; property name {@code float.nullable}.
      */
-    public static final SettingKey FLOAT_NULLABLE = register(
+    public static final SettingKey<Boolean> FLOAT_NULLABLE = register(
             "float.nullable", Boolean.class, false);
     /**
      * Specifies maximum value for integers;
      * default is 10000; property name {@code integer.max}.
      */
-    public static final SettingKey INTEGER_MAX = register(
+    public static final SettingKey<Integer> INTEGER_MAX = register(
             "integer.max", Integer.class, NUMERIC_MAX, MAX_ADJUSTER);
     /**
      * Specifies minimum value for integers;
      * default is 1; property name {@code integer.min}.
      */
-    public static final SettingKey INTEGER_MIN = register(
+    public static final SettingKey<Integer> INTEGER_MIN = register(
             "integer.min", Integer.class, NUMERIC_MIN, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Integer type;
      * default is {@code false}; property name {@code integer.nullable}.
      */
-    public static final SettingKey INTEGER_NULLABLE = register(
+    public static final SettingKey<Boolean> INTEGER_NULLABLE = register(
             "integer.nullable", Boolean.class, false);
     /**
      * Specifies maximum value for longs;
      * default is 10000; property name {@code long.max}.
      */
-    public static final SettingKey LONG_MAX = register(
+    public static final SettingKey<Long> LONG_MAX = register(
             "long.max", Long.class, (long) NUMERIC_MAX, MAX_ADJUSTER);
     /**
      * Specifies minimum value for longs;
      * default is 1; property name {@code long.min}.
      */
-    public static final SettingKey LONG_MIN = register(
+    public static final SettingKey<Long> LONG_MIN = register(
             "long.min", Long.class, (long) NUMERIC_MIN, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Long type;
      * default is {@code false}; property name {@code long.nullable}.
      */
-    public static final SettingKey LONG_NULLABLE = register(
+    public static final SettingKey<Boolean> LONG_NULLABLE = register(
             "long.nullable", Boolean.class, false);
     /**
      * Specifies whether a {@code null} can be generated for map keys;
      * default is {@code false}; property name {@code map.keys.nullable}.
      */
-    public static final SettingKey MAP_KEYS_NULLABLE = register(
+    public static final SettingKey<Boolean> MAP_KEYS_NULLABLE = register(
             "map.keys.nullable", Boolean.class, false);
     /**
      * Specifies maximum size for maps;
      * default is 6; property name {@code map.max.size}.
      */
-    public static final SettingKey MAP_MAX_SIZE = register(
+    public static final SettingKey<Integer> MAP_MAX_SIZE = register(
             "map.max.size", Integer.class, MAX_SIZE, MAX_ADJUSTER);
     /**
      * Specifies minimum size for maps;
      * default is 2; property name {@code map.min.size}.
      */
-    public static final SettingKey MAP_MIN_SIZE = register(
+    public static final SettingKey<Integer> MAP_MIN_SIZE = register(
             "map.min.size", Integer.class, MIN_SIZE, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for maps;
      * default is {@code false}; property name {@code map.nullable}.
      */
-    public static final SettingKey MAP_NULLABLE = register(
+    public static final SettingKey<Boolean> MAP_NULLABLE = register(
             "map.nullable", Boolean.class, false);
     /**
      * Specifies whether a {@code null} can be generated for map values;
      * default is {@code false}; property name {@code map.values.nullable}.
      */
-    public static final SettingKey MAP_VALUES_NULLABLE = register(
+    public static final SettingKey<Boolean> MAP_VALUES_NULLABLE = register(
             "map.values.nullable", Boolean.class, false);
     /**
      * Specifies the mode: strict (unused selectors will trigger an exception) or lenient;
@@ -240,7 +240,7 @@ public final class Keys {
      * @see Mode
      * @since 1.3.3
      */
-    public static final SettingKey MODE = register("mode", Mode.class, Mode.STRICT);
+    public static final SettingKey<Mode> MODE = register("mode", Mode.class, Mode.STRICT);
     /**
      * Specifies the default value of the {@link AfterGenerate} hint
      * supplied from custom generators to the engine;
@@ -250,7 +250,7 @@ public final class Keys {
      * @see AfterGenerate
      * @since 2.0.0
      */
-    public static final SettingKey AFTER_GENERATE_HINT = register(
+    public static final SettingKey<AfterGenerate> AFTER_GENERATE_HINT = register(
             "hint.after.generate", AfterGenerate.class, AfterGenerate.POPULATE_NULLS_AND_DEFAULT_PRIMITIVES);
     /**
      * Specifies whether initialised fields are allowed to be overwritten;
@@ -258,7 +258,7 @@ public final class Keys {
      *
      * @since 2.0.0
      */
-    public static final SettingKey OVERWRITE_EXISTING_VALUES = register(
+    public static final SettingKey<Boolean> OVERWRITE_EXISTING_VALUES = register(
             "overwrite.existing.values", Boolean.class, true);
     /**
      * Specifies how to assign values via reflection, using fields or methods;
@@ -268,7 +268,7 @@ public final class Keys {
      * @since 2.1.0
      */
     @ExperimentalApi
-    public static final SettingKey ASSIGNMENT_TYPE = register(
+    public static final SettingKey<AssignmentType> ASSIGNMENT_TYPE = register(
             "assignment.type", AssignmentType.class, AssignmentType.FIELD);
     /**
      * Specifies what should happen if an error occurs setting a field's value;
@@ -278,7 +278,7 @@ public final class Keys {
      * @since 2.1.0
      */
     @ExperimentalApi
-    public static final SettingKey ON_SET_FIELD_ERROR = register(
+    public static final SettingKey<OnSetFieldError> ON_SET_FIELD_ERROR = register(
             "on.set.field.error", OnSetFieldError.class, OnSetFieldError.IGNORE);
     /**
      * Specifies what should happen if an error occurs invoking a setter;
@@ -288,7 +288,7 @@ public final class Keys {
      * @since 2.1.0
      */
     @ExperimentalApi
-    public static final SettingKey ON_SET_METHOD_ERROR = register(
+    public static final SettingKey<OnSetMethodError> ON_SET_METHOD_ERROR = register(
             "on.set.method.error", OnSetMethodError.class, OnSetMethodError.ASSIGN_FIELD);
     /**
      * Specifies what should happen if a setter method for a field cannot be resolved;
@@ -298,7 +298,7 @@ public final class Keys {
      * @since 2.1.0
      */
     @ExperimentalApi
-    public static final SettingKey ON_SET_METHOD_NOT_FOUND = register(
+    public static final SettingKey<OnSetMethodNotFound> ON_SET_METHOD_NOT_FOUND = register(
             "on.set.method.not.found", OnSetMethodNotFound.class, OnSetMethodNotFound.ASSIGN_FIELD);
     /**
      * Indicates the naming convention of setter methods to use;
@@ -308,7 +308,7 @@ public final class Keys {
      * @since 2.1.0
      */
     @ExperimentalApi
-    public static final SettingKey SETTER_STYLE = register(
+    public static final SettingKey<SetterStyle> SETTER_STYLE = register(
             "setter.style", SetterStyle.class, SetterStyle.SET);
     /**
      * Specifies whether values should be generated based on
@@ -319,7 +319,7 @@ public final class Keys {
      * @since 2.7.0
      */
     @ExperimentalApi
-    public static final SettingKey BEAN_VALIDATION_ENABLED = register(
+    public static final SettingKey<Boolean> BEAN_VALIDATION_ENABLED = register(
             "bean.validation.enabled", Boolean.class, false);
     /**
      * Specifies the maximum depth of the generated object tree;
@@ -327,7 +327,7 @@ public final class Keys {
      *
      * @since 2.7.0
      */
-    public static final SettingKey MAX_DEPTH = register(
+    public static final SettingKey<Integer> MAX_DEPTH = register(
             "max.depth", Integer.class, 8);
     /**
      * Specifies the seed value;
@@ -335,48 +335,49 @@ public final class Keys {
      *
      * @since 1.5.1
      */
-    public static final SettingKey SEED = registerWithNullDefault("seed", Long.class);
+    public static final SettingKey<Long> SEED = register(
+            "seed", Long.class, null, null, true);
     /**
      * Specifies maximum value for shorts;
      * default is 10000; property name {@code short.max}.
      */
-    public static final SettingKey SHORT_MAX = register(
+    public static final SettingKey<Short> SHORT_MAX = register(
             "short.max", Short.class, (short) NUMERIC_MAX, MAX_ADJUSTER);
     /**
      * Specifies minimum value for shorts;
      * default is 1; property name {@code short.min}.
      */
-    public static final SettingKey SHORT_MIN = register(
+    public static final SettingKey<Short> SHORT_MIN = register(
             "short.min", Short.class, (short) 1, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for Short type;
      * default is {@code false}; property name {@code short.nullable}.
      */
-    public static final SettingKey SHORT_NULLABLE = register(
+    public static final SettingKey<Boolean> SHORT_NULLABLE = register(
             "short.nullable", Boolean.class, false);
     /**
      * Specifies whether an empty string can be generated;
      * default is {@code false}; property name {@code string.allow.empty}.
      */
-    public static final SettingKey STRING_ALLOW_EMPTY = register(
+    public static final SettingKey<Boolean> STRING_ALLOW_EMPTY = register(
             "string.allow.empty", Boolean.class, false);
     /**
      * Specifies maximum length of strings;
      * default is 10; property name {@code string.max.length}.
      */
-    public static final SettingKey STRING_MAX_LENGTH = register(
+    public static final SettingKey<Integer> STRING_MAX_LENGTH = register(
             "string.max.length", Integer.class, 10, MAX_ADJUSTER);
     /**
      * Specifies minimum length of strings;
      * default is 3; property name {@code string.min.length}.
      */
-    public static final SettingKey STRING_MIN_LENGTH = register(
+    public static final SettingKey<Integer> STRING_MIN_LENGTH = register(
             "string.min.length", Integer.class, 3, MIN_ADJUSTER);
     /**
      * Specifies whether a {@code null} can be generated for String type;
      * default is {@code false}; property name {@code string.nullable}.
      */
-    public static final SettingKey STRING_NULLABLE = register(
+    public static final SettingKey<Boolean> STRING_NULLABLE = register(
             "string.nullable", Boolean.class, false);
     /**
      * Specifies whether generated Strings should be prefixed with field names;
@@ -384,18 +385,26 @@ public final class Keys {
      *
      * @since 2.4.0
      */
-    public static final SettingKey STRING_FIELD_PREFIX_ENABLED = register(
+    public static final SettingKey<Boolean> STRING_FIELD_PREFIX_ENABLED = register(
             "string.field.prefix.enabled", Boolean.class, false);
 
     // Note: keys must be collected after all keys have been initialised
-    private static final Map<String, SettingKey> SETTING_KEY_MAP = Collections.unmodifiableMap(settingKeyMap());
+    private static final Map<String, SettingKey<?>> SETTING_KEY_MAP = Collections.unmodifiableMap(settingKeyMap());
+
+    private static Map<String, SettingKey<?>> settingKeyMap() {
+        final Map<String, SettingKey<?>> map = new HashMap<>();
+        for (SettingKey<?> key : ALL_KEYS) {
+            map.put(key.propertyKey(), key);
+        }
+        return map;
+    }
 
     /**
      * Returns all keys supported by Instancio.
      *
      * @return all keys
      */
-    public static List<SettingKey> all() {
+    public static List<SettingKey<Object>> all() {
         return Collections.unmodifiableList(ALL_KEYS);
     }
 
@@ -405,54 +414,42 @@ public final class Keys {
      * @param key to lookup
      * @return the setting key; an exception is thrown if the key is not found
      */
-    public static SettingKey get(@NotNull final String key) {
-        final SettingKey settingKey = SETTING_KEY_MAP.get(key);
+    @SuppressWarnings("unchecked")
+    public static <T> SettingKey<T> get(@NotNull final String key) {
+        final SettingKey<T> settingKey = (SettingKey<T>) SETTING_KEY_MAP.get(key);
         ApiValidator.isTrue(settingKey != null, "Invalid instancio property key: '%s'", key);
         return settingKey;
     }
 
-    private static SettingKey register(
+    private static <T> SettingKey<T> register(
             @NotNull final String propertyKey,
-            @NotNull final Class<?> type,
+            @NotNull final Class<T> type,
             @Nullable final Object defaultValue,
             @Nullable final RangeAdjuster rangeAdjuster,
             final boolean allowsNullValue) {
 
-        final SettingKey settingKey = new InternalKey(propertyKey, type, defaultValue, rangeAdjuster, allowsNullValue);
-        ALL_KEYS.add(settingKey);
+        final SettingKey<T> settingKey = new InternalKey<>(
+                propertyKey, type, defaultValue, rangeAdjuster, allowsNullValue);
+
+        ALL_KEYS.add((SettingKey<Object>) settingKey);
         return settingKey;
     }
 
-    private static SettingKey register(
+    private static <T> SettingKey<T> register(
             @NotNull final String propertyKey,
-            @NotNull final Class<?> type,
+            @NotNull final Class<T> type,
             @Nullable final Object defaultValue,
             @Nullable final RangeAdjuster rangeAdjuster) {
 
         return register(propertyKey, type, defaultValue, rangeAdjuster, false);
     }
 
-    private static SettingKey register(
+    private static <T> SettingKey<T> register(
             @NotNull final String key,
-            @NotNull final Class<?> type,
+            @NotNull final Class<T> type,
             @NotNull final Object defaultValue) {
 
         return register(key, type, defaultValue, null, false);
-    }
-
-    private static SettingKey registerWithNullDefault(
-            @NotNull final String key,
-            @NotNull final Class<?> type) {
-
-        return register(key, type, null, null, true);
-    }
-
-    private static Map<String, SettingKey> settingKeyMap() {
-        final Map<String, SettingKey> map = new HashMap<>();
-        for (SettingKey key : ALL_KEYS) {
-            map.put(key.propertyKey(), key);
-        }
-        return map;
     }
 
     private Keys() {

--- a/instancio-core/src/main/java/org/instancio/settings/SettingKey.java
+++ b/instancio-core/src/main/java/org/instancio/settings/SettingKey.java
@@ -15,8 +15,6 @@
  */
 package org.instancio.settings;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * A setting key represents a configuration item and has the following properties:
  *
@@ -25,11 +23,12 @@ import org.jetbrains.annotations.NotNull;
  *   <li>{@link #defaultValue()} - that will be used if there is no configuration file present</li>
  * </ul>
  *
+ * @param <T> type of the value
  * @see Keys
  * @see Settings
  * @since 1.0.1
  */
-public interface SettingKey extends Comparable<SettingKey> {
+public interface SettingKey<T> {
 
     /**
      * A property key that can be used to configure this setting in a properties file.
@@ -45,16 +44,15 @@ public interface SettingKey extends Comparable<SettingKey> {
      * @return value class
      * @since 1.0.1
      */
-    <T> Class<T> type();
+    Class<T> type();
 
     /**
      * Default value for this key.
      *
-     * @param <T> type of the value
      * @return default value
      * @since 1.0.1
      */
-    <T> T defaultValue();
+    T defaultValue();
 
     /**
      * Indicates whether the value for this key can be set to {@code null}.
@@ -64,14 +62,4 @@ public interface SettingKey extends Comparable<SettingKey> {
      */
     boolean allowsNullValue();
 
-    /**
-     * Auto-adjusts the {@link Settings} value for this key based on the value of another setting key.
-     *
-     * @param settings   to adjust
-     * @param otherValue value of the other setting to base the adjustment off
-     * @since 1.2.0
-     */
-    default <T extends Number & Comparable<T>> void autoAdjust(@NotNull Settings settings, @NotNull T otherValue) {
-        // no-op by default
-    }
 }

--- a/instancio-core/src/main/java/org/instancio/settings/Settings.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Settings.java
@@ -110,7 +110,7 @@ public interface Settings {
      * @param <T> setting value type
      * @return value for given key, or {@code null} if none.
      */
-    <T> T get(@NotNull SettingKey key);
+    <T> T get(@NotNull SettingKey<T> key);
 
     /**
      * Set the setting with the given key to the specified value.
@@ -124,7 +124,7 @@ public interface Settings {
      * @param value to set
      * @return this instance of settings
      */
-    Settings set(@NotNull SettingKey key, @Nullable Object value);
+    <T> Settings set(@NotNull SettingKey<T> key, @Nullable T value);
 
     /**
      * Maps the supertype {@code from} supertype to 'to' subtype.

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/ApiValidatorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/ApiValidatorTest.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.internal;
 
+import org.instancio.Mode;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.settings.Keys;
 import org.instancio.settings.SettingKey;
@@ -37,14 +38,14 @@ class ApiValidatorTest {
 
         @Test
         void nullAllowedForNullableValue() {
-            final SettingKey key = Keys.SEED;
+            final SettingKey<Long> key = Keys.SEED;
             assertThat(key.allowsNullValue()).isTrue();
             ApiValidator.validateKeyValue(key, null); // no error
         }
 
         @Test
         void nullNotAllowedForNonNullableValue() {
-            final SettingKey key = Keys.MODE;
+            final SettingKey<Mode> key = Keys.MODE;
             assertThat(key.allowsNullValue()).isFalse();
             assertThatThrownBy(() -> ApiValidator.validateKeyValue(key, null))
                     .isExactlyInstanceOf(InstancioApiException.class)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsAutoAdjustmentTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsAutoAdjustmentTest.java
@@ -61,7 +61,7 @@ class SettingsAutoAdjustmentTest {
                 .set(Keys.INTEGER_MAX, max)
                 .set(Keys.INTEGER_MIN, newMin);
 
-        assertThat((Object) settings.get(Keys.INTEGER_MAX)).isEqualTo(max);
+        assertThat(settings.get(Keys.INTEGER_MAX)).isEqualTo(max);
     }
 
     @Test
@@ -73,7 +73,7 @@ class SettingsAutoAdjustmentTest {
                 .set(Keys.ARRAY_MAX_LENGTH, max)
                 .set(Keys.ARRAY_MIN_LENGTH, newMin);
 
-        assertThat((Object) settings.get(Keys.ARRAY_MAX_LENGTH))
+        assertThat(settings.get(Keys.ARRAY_MAX_LENGTH))
                 .as("Expecting newMax value to be greater than newMin by %s%%", PERCENTAGE)
                 .isEqualTo((int) Math.round((newMin * (100 + PERCENTAGE)) / 100d));
     }
@@ -86,7 +86,7 @@ class SettingsAutoAdjustmentTest {
                 .set(Keys.INTEGER_MAX, 0)
                 .set(Keys.INTEGER_MIN, newMin);
 
-        assertThat((Object) settings.get(Keys.INTEGER_MAX)).isEqualTo(Integer.MAX_VALUE);
+        assertThat(settings.get(Keys.INTEGER_MAX)).isEqualTo(Integer.MAX_VALUE);
     }
 
     @ValueSource(longs = {Long.MIN_VALUE + 1})
@@ -97,7 +97,7 @@ class SettingsAutoAdjustmentTest {
                 .set(Keys.LONG_MIN, Long.MIN_VALUE + 100)
                 .set(Keys.LONG_MAX, newMax);
 
-        assertThat((Object) settings.get(Keys.LONG_MIN)).isEqualTo(Long.MIN_VALUE);
+        assertThat(settings.get(Keys.LONG_MIN)).isEqualTo(Long.MIN_VALUE);
     }
 
     @Test
@@ -105,7 +105,7 @@ class SettingsAutoAdjustmentTest {
     void newMaxIsNegativeAndIsLessThanMin() {
         settings.set(Keys.INTEGER_MAX, -100);
 
-        assertThat((Object) settings.get(Keys.INTEGER_MIN)).isEqualTo(-150);
+        assertThat(settings.get(Keys.INTEGER_MIN)).isEqualTo(-150);
     }
 
     @Test
@@ -115,25 +115,25 @@ class SettingsAutoAdjustmentTest {
                 .set(Keys.INTEGER_MAX, -120)
                 .set(Keys.INTEGER_MIN, -100);
 
-        assertThat((Object) settings.get(Keys.INTEGER_MAX)).isEqualTo(-50);
+        assertThat(settings.get(Keys.INTEGER_MAX)).isEqualTo(-50);
     }
 
     @Test
     @DisplayName("max is null: should set max")
     void setMaxIfNull() {
         final Settings settings = Settings.create();
-        assertThat((Object) settings.get(Keys.INTEGER_MAX)).isNull();
+        assertThat(settings.get(Keys.INTEGER_MAX)).isNull();
         settings.set(Keys.INTEGER_MIN, 100);
-        assertThat((Object) settings.get(Keys.INTEGER_MAX)).isEqualTo(150);
+        assertThat(settings.get(Keys.INTEGER_MAX)).isEqualTo(150);
     }
 
     @Test
     @DisplayName("min is null: should set min")
     void setMinIfNull() {
         final Settings settings = Settings.create();
-        assertThat((Object) settings.get(Keys.INTEGER_MIN)).isNull();
+        assertThat(settings.get(Keys.INTEGER_MIN)).isNull();
         settings.set(Keys.INTEGER_MAX, -100);
-        assertThat((Object) settings.get(Keys.INTEGER_MIN)).isEqualTo(-150);
+        assertThat(settings.get(Keys.INTEGER_MIN)).isEqualTo(-150);
     }
 
     @Nested
@@ -143,8 +143,8 @@ class SettingsAutoAdjustmentTest {
         @ParameterizedTest
         @MethodSource("minSettingKeys")
         @DisplayName("newMin > max: verify each settings updates its max to: newMin + PERCENTAGE")
-        void newMinIsGreaterThanMax(SettingKey minSetting) {
-            final Optional<SettingKey> maxSetting = SettingsSupport.getAutoAdjustable(minSetting);
+        void newMinIsGreaterThanMax(SettingKey<Number> minSetting) {
+            final Optional<SettingKey<Number>> maxSetting = SettingsSupport.getAutoAdjustable(minSetting);
             assertThat(maxSetting).isPresent();
 
             final Number max = NumberUtils.longConverter(minSetting.type()).apply(50L);
@@ -155,14 +155,14 @@ class SettingsAutoAdjustmentTest {
                     .set(maxSetting.get(), max)
                     .set(minSetting, newMin);
 
-            assertThat((Object) settings.get(maxSetting.get())).isEqualTo(expectedMax);
+            assertThat(settings.get(maxSetting.get())).isEqualTo(expectedMax);
         }
 
         @ParameterizedTest
         @MethodSource("maxSettingKeys")
         @DisplayName("newMax < min: verify each settings updates its min to: newMax - PERCENTAGE")
-        void newMaxIsLessThanMin(SettingKey maxSetting) {
-            final Optional<SettingKey> minSetting = SettingsSupport.getAutoAdjustable(maxSetting);
+        void newMaxIsLessThanMin(SettingKey<Number> maxSetting) {
+            final Optional<SettingKey<Number>> minSetting = SettingsSupport.getAutoAdjustable(maxSetting);
             assertThat(minSetting).isPresent();
 
             final Number min = NumberUtils.longConverter(maxSetting.type()).apply(120L);
@@ -173,7 +173,7 @@ class SettingsAutoAdjustmentTest {
                     .set(minSetting.get(), min)
                     .set(maxSetting, newMax);
 
-            assertThat((Object) settings.get(minSetting.get())).isEqualTo(expectedMin);
+            assertThat(settings.get(minSetting.get())).isEqualTo(expectedMin);
         }
 
         private Stream<Arguments> minSettingKeys() {

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsTest.java
@@ -48,7 +48,7 @@ class SettingsTest {
 
     @Test
     void defaults() {
-        for (SettingKey settingKey : Keys.all()) {
+        for (SettingKey<?> settingKey : Keys.all()) {
             final Object actual = DEFAULTS.get(settingKey);
             final Object expected = settingKey.defaultValue();
             assertThat(actual).isEqualTo(expected);
@@ -65,8 +65,8 @@ class SettingsTest {
 
         final Settings settings = Settings.from(map);
 
-        assertThat((Float) settings.get(Keys.FLOAT_MAX)).isEqualTo(9f);
-        assertThat((Boolean) settings.get(Keys.LONG_NULLABLE)).isTrue();
+        assertThat(settings.get(Keys.FLOAT_MAX)).isEqualTo(9f);
+        assertThat(settings.get(Keys.LONG_NULLABLE)).isTrue();
         assertThat(settings.getSubtypeMap())
                 .containsEntry(List.class, ArrayList.class)
                 .containsEntry(Set.class, HashSet.class);
@@ -87,9 +87,9 @@ class SettingsTest {
 
         final Settings merged = original.merge(overrides);
 
-        assertThat((Byte) merged.get(Keys.BYTE_MIN)).isEqualTo((byte) 99);
-        assertThat((Boolean) merged.get(Keys.ARRAY_NULLABLE)).isTrue();
-        assertThat((Long) merged.get(Keys.LONG_MAX))
+        assertThat(merged.get(Keys.BYTE_MIN)).isEqualTo((byte) 99);
+        assertThat(merged.get(Keys.ARRAY_NULLABLE)).isTrue();
+        assertThat(merged.get(Keys.LONG_MAX))
                 .as("Properties that were not overridden should retain their value")
                 .isEqualTo(originalLongMax);
 
@@ -98,17 +98,17 @@ class SettingsTest {
 
     @Test
     void getReturnsNullIfKeyHasNoValue() {
-        assertThat((Byte) Settings.create().get(Keys.BYTE_MIN)).isNull();
+        assertThat(Settings.create().get(Keys.BYTE_MIN)).isNull();
     }
 
     @Test
     void strictModeIsEnabledByDefault() {
-        assertThat((Mode) DEFAULTS.get(Keys.MODE)).isEqualTo(Mode.STRICT);
+        assertThat(DEFAULTS.get(Keys.MODE)).isEqualTo(Mode.STRICT);
     }
 
     @Test
-    void name() {
-        assertThat((AfterGenerate) DEFAULTS.get(Keys.AFTER_GENERATE_HINT))
+    void afterGenerateHintDefault() {
+        assertThat(DEFAULTS.get(Keys.AFTER_GENERATE_HINT))
                 .isEqualTo(AfterGenerate.POPULATE_NULLS_AND_DEFAULT_PRIMITIVES);
     }
 
@@ -123,16 +123,7 @@ class SettingsTest {
     @Test
     void getSetEnum() {
         final Settings settings = Settings.create().set(Keys.MODE, Mode.LENIENT);
-        assertThat((Mode) settings.get(Keys.MODE)).isEqualTo(Mode.LENIENT);
-    }
-
-    @Test
-    void setThrowsErrorIfGivenInvalidType() {
-        final Settings settings = Settings.create();
-        assertThatThrownBy(() -> settings.set(Keys.LONG_MAX, AUTO_ADJUST_DISABLED))
-                .isInstanceOf(InstancioApiException.class)
-                .hasMessage("The value 'false' is of unexpected type (Boolean) for key '%s' (expected: Long)",
-                        Keys.LONG_MAX.propertyKey());
+        assertThat(settings.get(Keys.MODE)).isEqualTo(Mode.LENIENT);
     }
 
     @Test
@@ -221,11 +212,11 @@ class SettingsTest {
                     .set(Keys.FLOAT_MIN, 3f)
                     .set(Keys.FLOAT_MAX, 3f);
 
-            assertThat((int) settings.get(Keys.COLLECTION_MIN_SIZE))
+            assertThat(settings.get(Keys.COLLECTION_MIN_SIZE))
                     .isEqualTo(settings.get(Keys.COLLECTION_MIN_SIZE))
                     .isEqualTo(2);
 
-            assertThat((float) settings.get(Keys.FLOAT_MIN))
+            assertThat(settings.get(Keys.FLOAT_MIN))
                     .isEqualTo(settings.get(Keys.FLOAT_MAX))
                     .isEqualTo(3f);
         }
@@ -242,8 +233,8 @@ class SettingsTest {
                     .merge(settings1)
                     .merge(settings2);
 
-            assertThat((Long) result.get(Keys.LONG_MIN)).isEqualTo(6);
-            assertThat((Long) result.get(Keys.LONG_MAX)).isEqualTo(11);
+            assertThat(result.get(Keys.LONG_MIN)).isEqualTo(6);
+            assertThat(result.get(Keys.LONG_MAX)).isEqualTo(11);
         }
 
         @Test


### PR DESCRIPTION
This provides better type-safety as it's no longer possible to call `Settings.set(key, value)` with the wrong type of value.

Factored out internal methods into separate interfaces.