### PR TITLE
Minor refactoring and additional tests for bean validation.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/BeanValidationProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/BeanValidationProcessor.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -52,7 +53,7 @@ public class BeanValidationProcessor implements GeneratorSpecProcessor {
     private static final String JAKARTA_VALIDATOR_CLASS = "jakarta.validation.Validation";
     private static final String HIBERNATE_VALIDATOR_CLASS = "org.hibernate.validator.HibernateValidator";
 
-    private final BeanValidationProvider[] validationProviders;
+    private final List<BeanValidationProvider> validationProviders;
 
     public BeanValidationProcessor() {
         validationProviders = initValidationProviders();
@@ -86,7 +87,7 @@ public class BeanValidationProcessor implements GeneratorSpecProcessor {
         }
     }
 
-    private static BeanValidationProvider[] initValidationProviders() {
+    private static List<BeanValidationProvider> initValidationProviders() {
         List<BeanValidationProvider> providers = new ArrayList<>();
         if (ReflectionUtils.loadClass(HIBERNATE_VALIDATOR_CLASS) != null) {
             providers.add(new HibernateBeanValidationProcessor());
@@ -97,6 +98,6 @@ public class BeanValidationProcessor implements GeneratorSpecProcessor {
         if (ReflectionUtils.loadClass(JAVAX_VALIDATOR_CLASS) != null) {
             providers.add(new JavaxBeanValidationProcessor());
         }
-        return providers.toArray(new BeanValidationProvider[0]);
+        return Collections.unmodifiableList(providers);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/CommonBeanValidationHandlerResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/CommonBeanValidationHandlerResolver.java
@@ -107,8 +107,7 @@ class CommonBeanValidationHandlerResolver implements AnnotationHandlerResolver {
                 numSpec.max(converter.apply(max));
                 BeanValidationUtils.setNonNullablePrimitive(spec, field);
 
-                // NOTE: currently fractions only supported for BigDecimal, and partially at that.
-                // See: https://github.com/instancio/instancio/issues/375
+                // Currently fractions are supported for BigDecimal, but not float/double
                 if (spec instanceof BigDecimalGeneratorSpec) {
                     ((BigDecimalGeneratorSpec) spec).scale(fraction);
                 }

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/HibernateBeanValidationHandlerResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/HibernateBeanValidationHandlerResolver.java
@@ -15,11 +15,6 @@
  */
 package org.instancio.internal.beanvalidation;
 
-import org.hibernate.validator.constraints.Length;
-import org.hibernate.validator.constraints.Range;
-import org.hibernate.validator.constraints.UniqueElements;
-import org.hibernate.validator.constraints.time.DurationMax;
-import org.hibernate.validator.constraints.time.DurationMin;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.generator.specs.DurationGeneratorSpec;
@@ -46,6 +41,11 @@ import static org.instancio.internal.util.ExceptionHandler.runIgnoringTheNoClass
 
 final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerResolver {
 
+    /*
+     * Note: this class should not import `org.hibernate.validator.constraints.*`
+     * to avoid class-not-found error if a constraint is not available on the classpath
+     */
+
     private final Map<Class<?>, FieldAnnotationHandler> handlerMap;
 
     private HibernateBeanValidationHandlerResolver() {
@@ -58,11 +58,16 @@ final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerR
 
     private static Map<Class<?>, FieldAnnotationHandler> initHandlers() {
         final Map<Class<?>, FieldAnnotationHandler> map = new HashMap<>();
-        runIgnoringTheNoClassDefFoundError(() -> map.put(DurationMin.class, new DurationMinHandler()));
-        runIgnoringTheNoClassDefFoundError(() -> map.put(DurationMax.class, new DurationMaxHandler()));
-        runIgnoringTheNoClassDefFoundError(() -> map.put(Length.class, new LengthHandler()));
-        runIgnoringTheNoClassDefFoundError(() -> map.put(Range.class, new RangeHandler()));
-        runIgnoringTheNoClassDefFoundError(() -> map.put(UniqueElements.class, new UniqueElementsHandler()));
+        runIgnoringTheNoClassDefFoundError(() -> map.put(
+                org.hibernate.validator.constraints.time.DurationMin.class, new DurationMinHandler()));
+        runIgnoringTheNoClassDefFoundError(() -> map.put(
+                org.hibernate.validator.constraints.time.DurationMax.class, new DurationMaxHandler()));
+        runIgnoringTheNoClassDefFoundError(() -> map.put(
+                org.hibernate.validator.constraints.Length.class, new LengthHandler()));
+        runIgnoringTheNoClassDefFoundError(() -> map.put(
+                org.hibernate.validator.constraints.Range.class, new RangeHandler()));
+        runIgnoringTheNoClassDefFoundError(() -> map.put(
+                org.hibernate.validator.constraints.UniqueElements.class, new UniqueElementsHandler()));
         return Collections.unmodifiableMap(map);
     }
 
@@ -79,7 +84,8 @@ final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerR
                             final Class<?> fieldType) {
 
             if (spec instanceof DurationGeneratorSpec) {
-                final DurationMin d = (DurationMin) annotation;
+                final org.hibernate.validator.constraints.time.DurationMin d =
+                        (org.hibernate.validator.constraints.time.DurationMin) annotation;
 
                 final Duration min = Duration
                         .ofDays(d.days())
@@ -103,7 +109,8 @@ final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerR
                             final Class<?> fieldType) {
 
             if (spec instanceof DurationGeneratorSpec) {
-                final DurationMax d = (DurationMax) annotation;
+                final org.hibernate.validator.constraints.time.DurationMax d =
+                        (org.hibernate.validator.constraints.time.DurationMax) annotation;
 
                 final Duration max = Duration
                         .ofDays(d.days())
@@ -127,7 +134,9 @@ final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerR
                             final Field field,
                             final Class<?> fieldType) {
 
-            final Length length = (Length) annotation;
+            final org.hibernate.validator.constraints.Length length =
+                    (org.hibernate.validator.constraints.Length) annotation;
+
             final IntRange range = BeanValidationUtils.calculateRange(
                     length.min(), length.max(), Keys.STRING_MAX_LENGTH.defaultValue());
 
@@ -149,7 +158,8 @@ final class HibernateBeanValidationHandlerResolver implements AnnotationHandlerR
                             final Field field,
                             final Class<?> fieldType) {
 
-            final Range range = (Range) annotation;
+            final org.hibernate.validator.constraints.Range range =
+                    (org.hibernate.validator.constraints.Range) annotation;
 
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final Function<Long, Number> fromLongConverter = NumberUtils.longConverter(fieldType);

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JakartaBeanValidationHandlerResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JakartaBeanValidationHandlerResolver.java
@@ -24,12 +24,17 @@ import static org.instancio.internal.util.ExceptionHandler.runIgnoringTheNoClass
 
 /**
  * Contain {@link FieldAnnotationHandler}s for non-primary annotations from
-{@code jakarta.validation.constraints} package.
+ * {@code jakarta.validation.constraints} package.
  *
  * <p>To get additional info about primary/non-primary annotations,
  * please read javadoc for {@link BeanValidationProcessor} class.
  */
 final class JakartaBeanValidationHandlerResolver extends CommonBeanValidationHandlerResolver {
+
+    /*
+     * Note: this class should not import `jakarta.validation.constraints.*`
+     * to avoid class-not-found error if a constraint is not available on the classpath
+     */
 
     static JakartaBeanValidationHandlerResolver getInstance() {
         return Holder.INSTANCE;

--- a/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JavaxBeanValidationHandlerResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/beanvalidation/JavaxBeanValidationHandlerResolver.java
@@ -31,6 +31,11 @@ import static org.instancio.internal.util.ExceptionHandler.runIgnoringTheNoClass
  */
 final class JavaxBeanValidationHandlerResolver extends CommonBeanValidationHandlerResolver {
 
+    /*
+     * Note: this class should not import `org.hibernate.validator.constraints.*`
+     * to avoid class-not-found error if a constraint is not available on the classpath
+     */
+
     static JavaxBeanValidationHandlerResolver getInstance() {
         return Holder.INSTANCE;
     }

--- a/instancio-tests/bean-validation-hibernate5-tests/README.md
+++ b/instancio-tests/bean-validation-hibernate5-tests/README.md
@@ -1,0 +1,6 @@
+### Hibernate 5 Validator tests
+
+Tests using version 5 of Hibernate Validator, which has a smaller set of constraints.
+
+This verifies that class-not-found error is not thrown if a constraint
+(e.g. `@UUID`) is not provided by the older version of the validator.

--- a/instancio-tests/bean-validation-hibernate5-tests/pom.xml
+++ b/instancio-tests/bean-validation-hibernate5-tests/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-tests</artifactId>
+        <version>2.10.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>bean-validation-hibernate5-tests</artifactId>
+    <packaging>jar</packaging>
+    <name>Instancio tests: Hibernate 5 Bean Validation Tests</name>
+
+    <properties>
+        <sonar.exclusions>**/test/pojo/beanvalidation/**/*</sonar.exclusions>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-test-support</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>5.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-junit</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/instancio-tests/bean-validation-hibernate5-tests/src/test/java/org/instancio/test/beanvalidation/hibernate5/Hibernate5PojoBVTest.java
+++ b/instancio-tests/bean-validation-hibernate5-tests/src/test/java/org/instancio/test/beanvalidation/hibernate5/Hibernate5PojoBVTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.beanvalidation.hibernate5;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.validator.constraints.CreditCardNumber;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.Range;
+import org.hibernate.validator.constraints.URL;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.beanvalidation.hibernate5.util.Hibernate5ValidatorUtil;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@FeatureTag(Feature.BEAN_VALIDATION)
+@ExtendWith(InstancioExtension.class)
+class Hibernate5PojoBVTest {
+
+    @Test
+    void hibernate5AndJavax() {
+        final Hibernate5PojoBV result = Instancio.of(Hibernate5PojoBV.class)
+                .withSettings(Settings.create().set(Keys.BEAN_VALIDATION_ENABLED, true))
+                .create();
+
+        Hibernate5ValidatorUtil.assertValid(result);
+    }
+
+    private static class Hibernate5PojoBV {
+
+        @NotNull
+        @Length(min = 1, max = 2)
+        private String length;
+
+        @Digits(integer = 5, fraction = 2)
+        private String digits;
+
+        @Range(min = 1, max = 10)
+        private int range;
+
+        @URL
+        @NotBlank
+        private String url;
+
+        @CreditCardNumber
+        private String creditCard;
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+        }
+    }
+}

--- a/instancio-tests/bean-validation-hibernate5-tests/src/test/java/org/instancio/test/beanvalidation/hibernate5/util/Hibernate5ValidatorUtil.java
+++ b/instancio-tests/bean-validation-hibernate5-tests/src/test/java/org/instancio/test/beanvalidation/hibernate5/util/Hibernate5ValidatorUtil.java
@@ -13,18 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.test.util;
+package org.instancio.test.beanvalidation.hibernate5.util;
 
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
-import jakarta.validation.ValidatorFactory;
-
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public final class HibernateValidatorUtil {
+public final class Hibernate5ValidatorUtil {
 
     public static void assertValid(final Object obj) {
         try (final ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
@@ -36,7 +35,7 @@ public final class HibernateValidatorUtil {
         }
     }
 
-    private HibernateValidatorUtil() {
+    private Hibernate5ValidatorUtil() {
         // non-instantiable
     }
 }

--- a/instancio-tests/bean-validation-hibernate5-tests/src/test/resources/logback-test.xml
+++ b/instancio-tests/bean-validation-hibernate5-tests/src/test/resources/logback-test.xml
@@ -35,8 +35,6 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
-    <logger name="org.instancio.internal.util.ExceptionHandler" level="info"/>
-
     <root level="warn">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/resources/logback-test.xml
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/resources/logback-test.xml
@@ -35,6 +35,8 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
+    <logger name="org.instancio.internal.util.ExceptionHandler" level="info"/>
+
     <root level="debug">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/instancio-tests/bean-validation-javax-tests/src/test/resources/logback-test.xml
+++ b/instancio-tests/bean-validation-javax-tests/src/test/resources/logback-test.xml
@@ -35,6 +35,8 @@
         <appender-ref ref="CONSOLE"/>
     </logger>
 
+    <logger name="org.instancio.internal.util.ExceptionHandler" level="info"/>
+
     <root level="debug">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/instancio-tests/instancio-core-tests/pom.xml
+++ b/instancio-tests/instancio-core-tests/pom.xml
@@ -10,6 +10,11 @@
     <packaging>jar</packaging>
     <name>Instancio tests: instancio-core Tests</name>
 
+    <!-- Note: core tests should NOT import any optional dependencies,
+         such as bean validation jars. This module contains tests
+         that verify the absence of class-not-found errors when
+         optional dependencies are absent.
+    -->
     <dependencies>
         <dependency>
             <groupId>org.instancio</groupId>

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/HibernateBeanValidationHandlerResolverTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/HibernateBeanValidationHandlerResolverTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.beanvalidation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HibernateBeanValidationHandlerResolverTest {
+
+    /**
+     * Verifies that class not found error is not thrown,
+     * even though the constraints are not on the classpath.
+     */
+    @Test
+    void shouldNotThrowClassNotFoundError() {
+        assertThat(HibernateBeanValidationHandlerResolver.getInstance()).isNotNull();
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/JakartaBeanValidationHandlerResolverTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/JakartaBeanValidationHandlerResolverTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.beanvalidation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JakartaBeanValidationHandlerResolverTest {
+
+    /**
+     * Verifies that class not found error is not thrown,
+     * even though the constraints are not on the classpath.
+     */
+    @Test
+    void shouldNotThrowClassNotFoundError() {
+        assertThat(JakartaBeanValidationHandlerResolver.getInstance()).isNotNull();
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/JavaxBeanValidationHandlerResolverTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/beanvalidation/JavaxBeanValidationHandlerResolverTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.beanvalidation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaxBeanValidationHandlerResolverTest {
+
+    /**
+     * Verifies that class not found error is not thrown,
+     * even though the constraints are not on the classpath.
+     */
+    @Test
+    void shouldNotThrowClassNotFoundError() {
+        assertThat(JavaxBeanValidationHandlerResolver.getInstance()).isNotNull();
+    }
+}

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -44,6 +44,7 @@
         <module>bean-validation-javax-tests</module>
         <module>bean-validation-jakarta-tests</module>
         <module>bean-validation-hibernate-tests</module>
+        <module>bean-validation-hibernate5-tests</module>
         <module>annotation-processor-with-lombok</module>
         <module>annotation-processor-with-gradle</module>
         <module>packaging-tests</module>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -76,7 +76,19 @@
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
+            <artifactId>bean-validation-javax-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
             <artifactId>bean-validation-hibernate-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>bean-validation-hibernate5-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
- avoid importing constraints to prevent class-not-found errors
- test module for Hibernate validator 5.0.0.Final
- tweak logging in bean validation test modules to reduce noise during the build