### PR TITLE
Reduced sample size of javax bean validation tests.

### DIFF
--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotNullBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotNullBVTest.java
@@ -25,6 +25,7 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.NotNullBv;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -65,6 +66,7 @@ class NotNullBVTest {
             .set(Keys.MAP_NULLABLE, true);
 
     @Test
+    @NonDeterministicTag
     void notNullWithNullablesViaSettings() {
         final List<NotNullBv> result = Instancio.of(NotNullBv.class)
                 .stream()
@@ -77,6 +79,7 @@ class NotNullBVTest {
     }
 
     @Test
+    @NonDeterministicTag
     void withNullableHasHigherPrecedenceThanBeanValidationAnnotations() {
         final TargetSelector nullables = Select.all(
                 allStrings(),

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
@@ -21,47 +21,46 @@ import org.instancio.settings.Keys;
 import org.instancio.test.pojo.beanvalidation.ArraySizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class ArraySizeBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSize() {
         final ArraySizeBV.WithMinSize result = Instancio.create(ArraySizeBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSizeZeo() {
         final ArraySizeBV.WithMinSizeZero result = Instancio.create(ArraySizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.ARRAY_MAX_LENGTH.defaultValue());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSize() {
         final ArraySizeBV.WithMaxSize result = Instancio.create(ArraySizeBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSizeZero() {
         final ArraySizeBV.WithMaxSizeZero result = Instancio.create(ArraySizeBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxSize() {
         final ArraySizeBV.WithMinMaxSize result = Instancio.create(ArraySizeBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxEqual() {
         final ArraySizeBV.WithMinMaxEqual result = Instancio.create(ArraySizeBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/BeanValidationDisabledBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/BeanValidationDisabledBVTest.java
@@ -23,11 +23,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.StringDigitsBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -40,7 +39,7 @@ class BeanValidationDisabledBVTest {
             .set(Keys.STRING_ALLOW_EMPTY, false)
             .set(Keys.STRING_NULLABLE, false);
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void shouldIgnoreBeanValidationAnnotationsWhenDisabledViaSettings() {
         final StringDigitsBV.OnString result = Instancio.create(StringDigitsBV.OnString.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionSizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionSizeBVTest.java
@@ -23,11 +23,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.CollectionSizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -38,37 +37,37 @@ class CollectionSizeBVTest {
             .set(Keys.STRING_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSize() {
         final CollectionSizeBV.WithMinSize result = Instancio.create(CollectionSizeBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSizeZeo() {
         final CollectionSizeBV.WithMinSizeZero result = Instancio.create(CollectionSizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSize() {
         final CollectionSizeBV.WithMaxSize result = Instancio.create(CollectionSizeBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSizeZero() {
         final CollectionSizeBV.WithMaxSizeZero result = Instancio.create(CollectionSizeBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxSize() {
         final CollectionSizeBV.WithMinMaxSize result = Instancio.create(CollectionSizeBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxEqual() {
         final CollectionSizeBV.WithMinMaxEqual result = Instancio.create(CollectionSizeBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/EmailBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/EmailBVTest.java
@@ -20,11 +20,10 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.EmailBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -34,7 +33,7 @@ class EmailBVTest {
     private static final int EMAIL_ADDRESS_MIN = 7;
     private static final int EMAIL_ADDRESS_MAX = 24;
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void onString() {
         final EmailBV.OnString result = Instancio.create(EmailBV.OnString.class);
         assertThat(result.getEmail())
@@ -42,7 +41,7 @@ class EmailBVTest {
                 .matches(DEFAULT_EMAIL_PATTERN);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void onCharSequence() {
         final EmailBV.OnCharSequence result = Instancio.create(EmailBV.OnCharSequence.class);
         assertThat(result.getEmail())

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/EmailComboBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/EmailComboBVTest.java
@@ -22,11 +22,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.EmailComboBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -34,7 +33,7 @@ class EmailComboBVTest {
 
     private static final String EMAIL_PATTERN = "\\w+@\\w+\\.\\p{Lower}{3}";
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void emailWithSize() {
         final EmailComboBV.EmailWithSize result = Instancio.create(EmailComboBV.EmailWithSize.class);
 
@@ -47,7 +46,7 @@ class EmailComboBVTest {
                 .hasSize(10);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void notNullEmailWithSize() {
         final EmailComboBV.NotNullEmailWithSize result = Instancio.of(EmailComboBV.NotNullEmailWithSize.class)
                 .withSettings(Settings.create().set(Keys.STRING_NULLABLE, true))

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/GenericFieldBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/GenericFieldBVTest.java
@@ -15,10 +15,6 @@
  */
 package org.instancio.test.beanvalidation;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.junit.InstancioExtension;
@@ -26,6 +22,11 @@ import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/InvalidAnnotationSpecTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/InvalidAnnotationSpecTest.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.test.beanvalidation;
 
-import javax.validation.constraints.Size;
 import org.instancio.Instancio;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.junit.InstancioExtension;
@@ -23,6 +22,8 @@ import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.validation.constraints.Size;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapSizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapSizeBVTest.java
@@ -23,11 +23,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.MapSizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -42,37 +41,37 @@ class MapSizeBVTest {
             .set(Keys.DOUBLE_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSize() {
         final MapSizeBV.WithMinSize result = Instancio.create(MapSizeBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSizeZeo() {
         final MapSizeBV.WithMinSizeZero result = Instancio.create(MapSizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSize() {
         final MapSizeBV.WithMaxSize result = Instancio.create(MapSizeBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSizeZero() {
         final MapSizeBV.WithMaxSizeZero result = Instancio.create(MapSizeBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxSize() {
         final MapSizeBV.WithMinMaxSize result = Instancio.create(MapSizeBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxEqual() {
         final MapSizeBV.WithMinMaxEqual result = Instancio.create(MapSizeBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DDD;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -46,11 +46,11 @@ class NotEmptyBVTest {
     void notEmptyWithEmptyAllowedViaSettings() {
         final List<NotEmptyBv> results = Instancio.of(NotEmptyBv.class)
                 .stream()
-                .limit(SAMPLE_SIZE_DDD)
+                .limit(SAMPLE_SIZE_D)
                 .collect(Collectors.toList());
 
         assertThat(results)
-                .hasSize(SAMPLE_SIZE_DDD)
+                .hasSize(SAMPLE_SIZE_D)
                 .allSatisfy(o -> {
                     assertThat(o.getString()).isNotEmpty();
                     assertThat(o.getArray()).isNotEmpty();

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotNullBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotNullBVTest.java
@@ -25,6 +25,7 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.NotNullBv;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -65,6 +66,7 @@ class NotNullBVTest {
             .set(Keys.MAP_NULLABLE, true);
 
     @Test
+    @NonDeterministicTag
     void notNullWithNullablesViaSettings() {
         final List<NotNullBv> result = Instancio.of(NotNullBv.class)
                 .stream()
@@ -77,6 +79,7 @@ class NotNullBVTest {
     }
 
     @Test
+    @NonDeterministicTag
     void withNullableHasHigherPrecedenceThanBeanValidationAnnotations() {
         final TargetSelector nullables = Select.all(
                 allStrings(),

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDecimalMinMaxNegativeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDecimalMinMaxNegativeBVTest.java
@@ -21,7 +21,7 @@ import org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxNegativeBV;
 import org.instancio.test.support.pojo.basic.Numbers;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,13 +29,12 @@ import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxNegativ
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxNegativeBV.MAX_ROUNDED;
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxNegativeBV.MIN;
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxNegativeBV.MIN_ROUNDED;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersDecimalMinMaxNegativeBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void decimalMinMax() {
         final Numbers result = Instancio.create(NumbersDecimalMinMaxNegativeBV.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDecimalMinMaxPositiveBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDecimalMinMaxPositiveBVTest.java
@@ -21,7 +21,7 @@ import org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxPositiveBV;
 import org.instancio.test.support.pojo.basic.Numbers;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,13 +29,12 @@ import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxPositiv
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxPositiveBV.MAX_ROUNDED;
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxPositiveBV.MIN;
 import static org.instancio.test.pojo.beanvalidation.NumbersDecimalMinMaxPositiveBV.MIN_ROUNDED;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersDecimalMinMaxPositiveBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void decimalMinMax() {
         final Numbers result = Instancio.create(NumbersDecimalMinMaxPositiveBV.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDigitsBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDigitsBVTest.java
@@ -20,20 +20,19 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.NumbersDigitsBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersDigitsBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void noFraction() {
         final NumbersDigitsBV.NoFraction result = Instancio.create(NumbersDigitsBV.NoFraction.class);
 
@@ -60,7 +59,7 @@ class NumbersDigitsBVTest {
                 new BigDecimal("999999999999"));
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withFraction() {
         final NumbersDigitsBV.WithFraction result = Instancio.create(NumbersDigitsBV.WithFraction.class);
 
@@ -77,7 +76,7 @@ class NumbersDigitsBVTest {
                 .hasScaleOf(20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withZeroInteger() {
         final NumbersDigitsBV.WithZeroInteger result = Instancio.create(NumbersDigitsBV.WithZeroInteger.class);
         assertThat(result.getPrimitiveFloat()).isBetween(0f, 0.999999f);

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersMinMaxNegativeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersMinMaxNegativeBVTest.java
@@ -22,16 +22,14 @@ import org.instancio.test.support.asserts.Asserts;
 import org.instancio.test.support.pojo.basic.Numbers;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersMinMaxNegativeBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void minMax() {
         final Numbers result = Instancio.create(NumbersMinMaxNegativeBV.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersMinMaxPositiveBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersMinMaxPositiveBVTest.java
@@ -21,16 +21,14 @@ import org.instancio.test.pojo.beanvalidation.NumbersMinMaxPositiveBV;
 import org.instancio.test.support.asserts.Asserts;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersMinMaxPositiveBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void minMax() {
         final NumbersMinMaxPositiveBV result = Instancio.create(NumbersMinMaxPositiveBV.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersNegativeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersNegativeBVTest.java
@@ -20,17 +20,16 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.NumbersNegativeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class NumbersNegativeBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void negative() {
         final NumbersNegativeBV.NegativeNumbers result = Instancio.create(NumbersNegativeBV.NegativeNumbers.class);
 
@@ -52,7 +51,7 @@ class NumbersNegativeBVTest {
         assertThat(result.getBigDecimal()).isNegative();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void negativeOrZero() {
         final NumbersNegativeBV.NegativeOrZeroNumbers result = Instancio.create(NumbersNegativeBV.NegativeOrZeroNumbers.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersPositiveBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NumbersPositiveBVTest.java
@@ -23,11 +23,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.NumbersPositiveBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -49,7 +48,7 @@ class NumbersPositiveBVTest {
             .set(Keys.FLOAT_MAX, -1f)
             .set(Keys.DOUBLE_MAX, -1d);
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void positive() {
         final NumbersPositiveBV.PositiveNumbers result = Instancio.create(NumbersPositiveBV.PositiveNumbers.class);
 
@@ -71,7 +70,7 @@ class NumbersPositiveBVTest {
         assertThat(result.getBigDecimal()).isPositive();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void positiveOrZero() {
         final NumbersPositiveBV.PositiveOrZeroNumbers result = Instancio.create(NumbersPositiveBV.PositiveOrZeroNumbers.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringBlanknessBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringBlanknessBVTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DDD;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -46,11 +46,11 @@ class StringBlanknessBVTest {
     @Test
     void notBlank() {
         final List<StringBlanknessBV.WithNotBlank> results = Instancio.ofList(StringBlanknessBV.WithNotBlank.class)
-                .size(SAMPLE_SIZE_DDD)
+                .size(SAMPLE_SIZE_D)
                 .create();
 
         assertThat(results)
-                .hasSize(SAMPLE_SIZE_DDD)
+                .hasSize(SAMPLE_SIZE_D)
                 .extracting(StringBlanknessBV.WithNotBlank::getValue)
                 .doesNotContain(null, "");
     }
@@ -58,11 +58,11 @@ class StringBlanknessBVTest {
     @Test
     void notEmpty() {
         final List<StringBlanknessBV.WithNotEmpty> results = Instancio.ofList(StringBlanknessBV.WithNotEmpty.class)
-                .size(SAMPLE_SIZE_DDD)
+                .size(SAMPLE_SIZE_D)
                 .create();
 
         assertThat(results)
-                .hasSize(SAMPLE_SIZE_DDD)
+                .hasSize(SAMPLE_SIZE_D)
                 .extracting(StringBlanknessBV.WithNotEmpty::getValue)
                 .doesNotContain(null, "");
     }
@@ -70,12 +70,12 @@ class StringBlanknessBVTest {
     @Test
     void notNull() {
         final List<StringBlanknessBV.WithNotNull> results = Instancio.ofList(StringBlanknessBV.WithNotNull.class)
-                .size(SAMPLE_SIZE_DDD)
+                .size(SAMPLE_SIZE_D)
                 .withSettings(Settings.create().set(Keys.STRING_NULLABLE, true))
                 .create();
 
         assertThat(results)
-                .hasSize(SAMPLE_SIZE_DDD)
+                .hasSize(SAMPLE_SIZE_D)
                 .extracting(StringBlanknessBV.WithNotNull::getValue)
                 .doesNotContainNull();
     }

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringDigitsBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringDigitsBVTest.java
@@ -20,17 +20,16 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.StringDigitsBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class StringDigitsBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void onString() {
         final StringDigitsBV.OnString result = Instancio.create(StringDigitsBV.OnString.class);
 
@@ -41,7 +40,7 @@ class StringDigitsBVTest {
         assertThat(result.getS4()).matches("\\d{15}\\.\\d{20}");
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void onCharSequence() {
         final StringDigitsBV.OnCharSequence result = Instancio.create(StringDigitsBV.OnCharSequence.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
@@ -23,12 +23,10 @@ import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.StringSizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
@@ -40,38 +38,38 @@ class StringSizeBVTest {
             .set(Keys.STRING_MIN_LENGTH, Keys.STRING_MIN_LENGTH.defaultValue())
             .set(Keys.STRING_MAX_LENGTH, Keys.STRING_MAX_LENGTH.defaultValue());
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMinSize() {
         final StringSizeBV.WithMinSize result = Instancio.create(StringSizeBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMinSizeZeo() {
         final StringSizeBV.WithMinSizeZero result = Instancio.create(StringSizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.STRING_MAX_LENGTH.defaultValue());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMaxSize() {
         final StringSizeBV.WithMaxSize result = Instancio.create(StringSizeBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
 
     }
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMaxSizeZero() {
         final StringSizeBV.WithMaxSizeZero result = Instancio.create(StringSizeBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMinMaxSize() {
         final StringSizeBV.WithMinMaxSize result = Instancio.create(StringSizeBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_D)
+    @Test
     void withMinMaxEqual() {
         final StringSizeBV.WithMinMaxEqual result = Instancio.create(StringSizeBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/TemporalPastFutureBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/TemporalPastFutureBVTest.java
@@ -20,7 +20,7 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.TemporalPastFutureBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.sql.Timestamp;
@@ -38,13 +38,12 @@ import java.util.Calendar;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class TemporalPastFutureBVTest {
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void past() {
         final TemporalPastFutureBV.WithPast result = Instancio.create(TemporalPastFutureBV.WithPast.class);
 
@@ -64,7 +63,7 @@ class TemporalPastFutureBVTest {
         assertThat(result.getCalendar()).isLessThan(Calendar.getInstance());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void pastOrPresent() {
         final TemporalPastFutureBV.WithPastOrPresent result = Instancio.create(TemporalPastFutureBV.WithPastOrPresent.class);
 
@@ -84,7 +83,7 @@ class TemporalPastFutureBVTest {
         assertThat(result.getCalendar()).isLessThan(Calendar.getInstance());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void future() {
         final TemporalPastFutureBV.WithFuture result = Instancio.create(TemporalPastFutureBV.WithFuture.class);
 
@@ -104,7 +103,7 @@ class TemporalPastFutureBVTest {
         assertThat(result.getCalendar()).isGreaterThan(Calendar.getInstance());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void futureOrPresent() {
         final TemporalPastFutureBV.WithFutureOrPresent result = Instancio.create(TemporalPastFutureBV.WithFutureOrPresent.class);
 

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/UnsupportedAnnotationBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/UnsupportedAnnotationBVTest.java
@@ -15,8 +15,6 @@
  */
 package org.instancio.test.beanvalidation;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.support.tags.Feature;
@@ -24,6 +22,8 @@ import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Jakarta and javax constraints are handled by the same logic. No need to test both with large sample sizes.