### PR TITLE
Bug fix: map generator adding `withEntries` to immutable map (#524)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -285,7 +285,9 @@ class InstancioEngine {
             }
         }
 
-        map.putAll(hint.withEntries());
+        if (!hint.withEntries().isEmpty()) {
+            map.putAll(hint.withEntries());
+        }
 
         final Optional<GeneratorResult> spiResult = substituteResult(node, generatorResult);
         return spiResult.orElse(generatorResult);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/collection/UnmodifiableCollectionGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/collection/UnmodifiableCollectionGeneratorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.custom.collection;
+
+import org.instancio.Instancio;
+import org.instancio.Random;
+import org.instancio.TypeToken;
+import org.instancio.generator.AfterGenerate;
+import org.instancio.generator.Generator;
+import org.instancio.generator.Hints;
+import org.instancio.generator.hints.CollectionHint;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+
+class UnmodifiableCollectionGeneratorTest {
+
+    private static final List<String> UNMODIFIABLE_LIST = Collections.emptyList();
+
+    @EnumSource(AfterGenerate.class)
+    @ParameterizedTest
+    void createUnmodifiableList(final AfterGenerate afterGenerate) {
+        final List<String> result = Instancio.of(new TypeToken<List<String>>() {})
+                .supply(all(List.class), new CustomListGenerator(afterGenerate))
+                .create();
+
+        assertThat(result).isSameAs(UNMODIFIABLE_LIST);
+    }
+
+    /**
+     * Since the hint does not specify {@link CollectionHint#generateElements()},
+     * none of the action types should try to add elements to the collection.
+     */
+    private static final class CustomListGenerator implements Generator<List<String>> {
+        private final AfterGenerate afterGenerate;
+
+        private CustomListGenerator(final AfterGenerate afterGenerate) {
+            this.afterGenerate = afterGenerate;
+        }
+
+        @Override
+        public List<String> generate(final Random random) {
+            return UNMODIFIABLE_LIST;
+        }
+
+        @Override
+        public Hints hints() {
+            return Hints.afterGenerate(afterGenerate);
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/map/UnmodifiableMapGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/map/UnmodifiableMapGeneratorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.custom.map;
+
+import org.instancio.Instancio;
+import org.instancio.Random;
+import org.instancio.TypeToken;
+import org.instancio.generator.AfterGenerate;
+import org.instancio.generator.Generator;
+import org.instancio.generator.Hints;
+import org.instancio.generator.hints.MapHint;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+
+class UnmodifiableMapGeneratorTest {
+
+    private static final Map<String, Integer> UNMODIFIABLE_MAP = Collections.emptyMap();
+
+    @EnumSource(AfterGenerate.class)
+    @ParameterizedTest
+    void createUnmodifiableMap(final AfterGenerate afterGenerate) {
+        final Map<String, Integer> result = Instancio.of(new TypeToken<Map<String, Integer>>() {})
+                .supply(all(Map.class), new CustomMapGenerator(afterGenerate))
+                .create();
+
+        assertThat(result).isSameAs(UNMODIFIABLE_MAP);
+    }
+
+    /**
+     * Since the hint does not specify {@link MapHint#generateEntries()},
+     * none of the action types should try to add entries to the map.
+     */
+    private static final class CustomMapGenerator implements Generator<Map<String, Integer>> {
+        private final AfterGenerate afterGenerate;
+
+        private CustomMapGenerator(final AfterGenerate afterGenerate) {
+            this.afterGenerate = afterGenerate;
+        }
+
+        @Override
+        public Map<String, Integer> generate(final Random random) {
+            return UNMODIFIABLE_MAP;
+        }
+
+        @Override
+        public Hints hints() {
+            return Hints.afterGenerate(afterGenerate);
+        }
+    }
+}

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -1233,7 +1233,13 @@ public Hints hints() {
 }
 ```
 
-The `AfterGenerate` enum defines the following values:
+In short, the `AfterGenerate` enum defines what should happen to an object returned by a generator.
+The exact semantics of `AfterGenerate` actions vary depending on the type of object.
+Different rules are applied to POJOs, arrays, collections, and records.
+For example, if a generator returns an instance of a `record`, the returned instance
+cannot be modified regardless of the `AfterGenerate` hint.
+
+The following describes the actions as they apply to POJOs:
 
 - **`DO_NOT_MODIFY`**
   
@@ -1252,7 +1258,6 @@ The `AfterGenerate` enum defines the following values:
     In addition, the object will be modifiable using selectors as described
     by above by `APPLY_SELECTORS`.
 
-
 - **`POPULATE_NULLS_AND_DEFAULT_PRIMITIVES`** **(default behaviour)**
 
     Indicates that primitive fields with default values declared by the object
@@ -1268,6 +1273,12 @@ The `AfterGenerate` enum defines the following values:
     Indicates that all fields should be populated, regardless of their initial values.
     This action will cause all the values to be overwritten with random data.
     This is the default mode the engine operates in when using internal generators.
+
+When defining custom array or collection generators, the following hints can also be used:
+
+- {{ArrayHint}}
+- {{CollectionHint}}
+- {{MapHint}}
 
 #### Custom Generator Example
 

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -57,6 +57,8 @@ nav:
 extra:
   # Core
   AfterGenerate:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/AfterGenerate.html" target="_blank">AfterGenerate</a>'
+  ArrayHint:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/hints/ArrayHint.html" target="_blank">ArrayHint</a>'
+  CollectionHint:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/hints/CollectionHint.html" target="_blank">CollectionHint</a>'
   Instancio:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/Instancio.html" target="_blank">Instancio</a>'
   InstancioApi:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/InstancioApi.html" target="_blank">InstancioApi</a>'
   InstancioServiceProvider:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/spi/InstancioServiceProvider.html" target="_blank">InstancioServiceProvider</a>'
@@ -65,6 +67,7 @@ extra:
   GeneratorProvider:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/spi/InstancioServiceProvider.GeneratorProvider.html" target="_blank">GeneratorProvider</a>'
   Generators:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generators/Generators.html" target="_blank">Generators</a>'
   Hints:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/Hints.html" target="_blank">Hints</a>'
+  MapHint:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/hints/MapHint.html" target="_blank">MapHint</a>'
   Mode:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/Mode.html" target="_blank">Mode</a>'
   Model:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/Model.html" target="_blank">Model</a>'
   OnCompleteCallback:  '<a href="https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/OnCompleteCallback.html" target="_blank">OnCompleteCallback</a>'


### PR DESCRIPTION
Check whether 'withEntries()' hint is not empty prior to adding given entries to a map. Unconditional addition causes an error when an empty collection is added to an unmodifiable map (unsupported operation exception).