### PR TITLE
Support for initialising custom generators via `init()` method.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/Generator.java
+++ b/instancio-core/src/main/java/org/instancio/generator/Generator.java
@@ -16,6 +16,7 @@
 package org.instancio.generator;
 
 import org.instancio.Random;
+import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.hints.ArrayHint;
 import org.instancio.generator.hints.CollectionHint;
 import org.instancio.generator.hints.MapHint;
@@ -30,6 +31,22 @@ import org.instancio.settings.Settings;
  */
 @FunctionalInterface
 public interface Generator<T> extends GeneratorSpec<T> {
+
+    /**
+     * An optional method for generators that need to initialise state before
+     * generating values.
+     *
+     * <p><b>Note:</b> this method is guaranteed to be called <b>before</b>
+     * {@link #generate(Random)}, however, there is no guarantee as to
+     * the number of times it will be invoked. It is possible for {@code init()}
+     * to be called multiple times for a given generator instance.
+     *
+     * @param context generator context
+     * @since 2.13.0
+     */
+    @ExperimentalApi
+    default void init(GeneratorContext context) {
+    }
 
     /**
      * Returns a generated value.

--- a/instancio-core/src/main/java/org/instancio/internal/context/GeneratorSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/GeneratorSelectorMap.java
@@ -108,6 +108,8 @@ class GeneratorSelectorMap {
     }
 
     private void putGenerator(final TargetSelector targetSelector, final Generator<?> g) {
+        g.init(context);
+
         final Generator<?> generator = GeneratorDecorator.decorate(g, defaultAfterGenerate);
         selectorMap.put(targetSelector, generator);
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorProviderFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorProviderFacade.java
@@ -36,6 +36,9 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Resolves generators provided by the SPI.
+ */
 class GeneratorProviderFacade {
 
     private static final Logger LOG = LoggerFactory.getLogger(GeneratorProviderFacade.class);
@@ -64,6 +67,7 @@ class GeneratorProviderFacade {
         if (result == null) {
             result = resolveViaDeprecatedSPI(node);
         }
+
         return Optional.ofNullable(result);
     }
 
@@ -74,6 +78,7 @@ class GeneratorProviderFacade {
             final Generator<?> generator = provider.getGenerators(context).get(forClass);
             if (generator != null) {
                 LOG.trace("Custom generator '{}' found for {}", generator.getClass().getName(), forClass);
+                generator.init(context);
                 return GeneratorDecorator.decorate(generator, afterGenerate);
             }
         }
@@ -92,6 +97,7 @@ class GeneratorProviderFacade {
 
                 final Generator<?> generator = (Generator<?>) spec;
                 LOG.trace("Custom generator '{}' found for {}", generator.getClass().getName(), node);
+                generator.init(context);
                 return GeneratorDecorator.decorate(generator, afterGenerate);
             }
         }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/CustomGeneratorSpecUseCaseTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/CustomGeneratorSpecUseCaseTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.custom;
+
+import org.instancio.Instancio;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.GeneratorSpec;
+import org.instancio.generator.Hints;
+import org.instancio.internal.util.ObjectUtils;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.SettingKey;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+
+/**
+ * Use case: support user-defined generator specs.
+ *
+ * <p>This test is a POC demonstrating a custom generator spec similar
+ * to the built-in specs. The custom spec supports randomised initial
+ * state and allows overriding generation parameters via spec methods.
+ */
+@FeatureTag({Feature.GENERATOR, Feature.SETTINGS})
+@ExtendWith(InstancioExtension.class)
+class CustomGeneratorSpecUseCaseTest {
+
+    /**
+     * Custom spec for a list of integers. Supports creating a list
+     * of a certain size comprised of either positive or negative integers.
+     */
+    private interface IntegerListSpec extends GeneratorSpec<List<Integer>> {
+
+        IntegerListSpec positive(int size);
+
+        IntegerListSpec negative(int size);
+    }
+
+    private static final SettingKey<Integer> KEY_MIN_SIZE = Keys.ofType(Integer.class).create();
+    private static final SettingKey<Integer> KEY_MAX_SIZE = Keys.ofType(Integer.class).create();
+
+    private static class IntegerListSpecImpl implements IntegerListSpec, Generator<List<Integer>> {
+
+        private Integer minSize;
+        private Integer maxSize;
+        private boolean isPositive = true;
+
+        private Random random;
+        private Settings settings;
+
+        @Override
+        public void init(final GeneratorContext context) {
+            random = context.random();
+            settings = context.getSettings();
+
+            // User may have invoked positive() or negative() method,
+            // which would initialise the size. If that's the case,
+            // the size should not be overwritten with Setting values.
+            minSize = ObjectUtils.defaultIfNull(minSize, settings.get(KEY_MIN_SIZE));
+            maxSize = ObjectUtils.defaultIfNull(maxSize, settings.get(KEY_MAX_SIZE));
+        }
+
+        @Override
+        public List<Integer> generate(final Random random) {
+            final int size = random.intRange(minSize, maxSize);
+            final List<Integer> list = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                final int n = isPositive
+                        ? random.intRange(1, 100)
+                        : random.intRange(-100, -1);
+
+                list.add(n);
+            }
+            return list;
+        }
+
+        @Override
+        public IntegerListSpec positive(final int size) {
+            this.minSize = size;
+            this.maxSize = size;
+            this.isPositive = true;
+            return this;
+        }
+
+        @Override
+        public IntegerListSpec negative(final int size) {
+            this.minSize = size;
+            this.maxSize = size;
+            this.isPositive = false;
+            return this;
+        }
+
+        @Override
+        public Hints hints() {
+            // Ensure Random and Settings are not null
+            // when hints() is invoked by the engine
+            // (i.e. init() must be called before hints())
+            assertThat(random).isNotNull();
+            assertThat(settings).isNotNull();
+
+            return null; // no hints required
+        }
+    }
+
+    private static final class ListHolder {
+        private List<Integer> list1;
+        private List<Integer> list2;
+    }
+
+    private static IntegerListSpec integerList() {
+        return new IntegerListSpecImpl();
+    }
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(KEY_MIN_SIZE, Constants.MIN_SIZE)
+            .set(KEY_MAX_SIZE, Constants.MAX_SIZE)
+            .lock();
+
+    @Test
+    void customGenerator() {
+        final ListHolder result = Instancio.of(ListHolder.class)
+                .generate(all(List.class), integerList())
+                .create();
+
+        final int expectedMin = settings.get(KEY_MIN_SIZE);
+        final int expectedMax = settings.get(KEY_MAX_SIZE);
+
+        assertThat(result.list1).hasSizeBetween(expectedMin, expectedMax);
+        assertThat(result.list2).hasSizeBetween(expectedMin, expectedMax);
+    }
+
+    @Test
+    void withSettingsOverride() {
+        final int size = 10;
+        final ListHolder result = Instancio.of(ListHolder.class)
+                .generate(all(List.class), integerList())
+                .withSettings(Settings.create()
+                        .set(KEY_MIN_SIZE, size)
+                        .set(KEY_MAX_SIZE, size))
+                .create();
+
+        assertThat(result.list1)
+                .hasSameSizeAs(result.list2)
+                .hasSize(size);
+    }
+
+    @Test
+    void customiseValuesViaSpecMethods() {
+        final ListHolder result = Instancio.of(ListHolder.class)
+                .generate(field("list1"), integerList().positive(1))
+                .generate(field("list2"), integerList().negative(2))
+                .create();
+
+        assertThat(result.list1).hasSize(1).allMatch(n -> n > 0);
+        assertThat(result.list2).hasSize(2).allMatch(n -> n < 0);
+    }
+}

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
@@ -16,9 +16,11 @@
 package org.instancio.junit.internal;
 
 import org.instancio.Random;
-import org.instancio.support.DefaultRandom;
 import org.instancio.junit.InstancioSource;
+import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,11 +60,18 @@ class InstancioArgumentsProviderTest {
         assertThat(stream).isEmpty();
     }
 
+    @NonDeterministicTag("Small chance of duplicate values being generated")
     @MethodSource("types")
     @ParameterizedTest
     void createObjectsGroupingByType(final Class<?>[] types) {
         final Random random = new DefaultRandom();
-        final Settings settings = Settings.create();
+        final Settings settings = Settings.create()
+                .set(Keys.STRING_MIN_LENGTH, 20)
+                .set(Keys.INTEGER_MIN, Integer.MIN_VALUE)
+                .set(Keys.INTEGER_MAX, Integer.MAX_VALUE)
+                .set(Keys.LONG_MIN, Long.MIN_VALUE)
+                .set(Keys.LONG_MAX, Long.MAX_VALUE);
+
         final Object[] results = InstancioArgumentsProvider.createObjectsGroupingByType(types, random, settings);
 
         assertThat(results).hasExactlyElementsOfTypes(types);

--- a/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomGeneratorProvider.java
+++ b/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomGeneratorProvider.java
@@ -22,6 +22,7 @@ import org.instancio.Node;
 import org.instancio.Random;
 import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.Hints;
 import org.instancio.generators.Generators;
@@ -45,6 +46,17 @@ public class CustomGeneratorProvider implements InstancioServiceProvider {
     public static final String FOO_RECORD_VALUE = "expected-foo-value";
     public static final Pattern PATTERN_GENERATOR_VALUE = Pattern.compile("baz");
 
+    /**
+     * A static generator instance for verifying {@link Generator#init(GeneratorContext)}
+     * invocation counts. Should only be used by {@code SpiGeneratorInitTest}.
+     */
+    public static final InitCountingPojoGenerator INIT_COUNTING_GENERATOR = new InitCountingPojoGenerator();
+
+    public static class InitCountingPojo {
+        // empty
+    }
+
+
     private static final Map<Class<?>, GeneratorSpec<?>> GENERATOR_MAP = new HashMap<>() {{
         put(String.class, new StringGeneratorFromSpi());
         put(Pattern.class, new PatternGeneratorFromSpi());
@@ -53,6 +65,7 @@ public class CustomGeneratorProvider implements InstancioServiceProvider {
         put(Address.class, new CustomAddressGenerator());
         put(Phone.class, new CustomPhoneGenerator());
         put(FooRecord.class, (Generator<?>) random -> new FooRecord(FOO_RECORD_VALUE));
+        put(InitCountingPojo.class, INIT_COUNTING_GENERATOR);
 
         // Error-handling: generator spec does not implement the Generator interface
         put(Float.class, new CustomFloatSpec());
@@ -153,4 +166,23 @@ public class CustomGeneratorProvider implements InstancioServiceProvider {
     }
 
     public static class CustomFloatSpec implements GeneratorSpec<Float> {}
+
+    public static class InitCountingPojoGenerator implements Generator<InitCountingPojo> {
+
+        private int initCount;
+
+        public int getInitCount() {
+            return initCount;
+        }
+
+        @Override
+        public void init(final GeneratorContext context) {
+            initCount++;
+        }
+
+        @Override
+        public InitCountingPojo generate(final Random random) {
+            return new InitCountingPojo();
+        }
+    }
 }

--- a/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/SpiGeneratorInitTest.java
+++ b/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/SpiGeneratorInitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.spi.tests;
+
+import org.example.spi.CustomGeneratorProvider;
+import org.example.spi.CustomGeneratorProvider.InitCountingPojo;
+import org.instancio.Instancio;
+import org.instancio.generator.Generator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+/**
+ * Tests for number of {@link Generator#init} invocations.
+ *
+ * @see CustomGeneratorProvider#INIT_COUNTING_GENERATOR
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SpiGeneratorInitTest {
+
+    private static final class InitCountingPojoCollections {
+        List<InitCountingPojo> holder1;
+        List<InitCountingPojo> holder2;
+    }
+
+    private static final class InitCountingPojoContainer {
+        InitCountingPojo holder1;
+        InitCountingPojo holder2;
+    }
+
+    /**
+     * This is a bit of a hack. Since the generator we're interested in
+     * is also loaded when other tests are run, its init count will not be zero.
+     * For this reason, initialise the count to the current init count.
+     */
+    private static int count = CustomGeneratorProvider.INIT_COUNTING_GENERATOR.getInitCount();
+
+    @Test
+    @Order(1)
+    @DisplayName("Generator.init() once per collection element")
+    void initCountWithCollectionElements() {
+        final InitCountingPojoCollections result = Instancio.of(InitCountingPojoCollections.class)
+                .generate(field("holder1"), gen -> gen.collection().size(1))
+                .generate(field("holder2"), gen -> gen.collection().size(2))
+                .create();
+
+        count += 3;
+
+        assertThat(result.holder1).hasSize(1);
+        assertThat(result.holder2).hasSize(2);
+        assertThat(CustomGeneratorProvider.INIT_COUNTING_GENERATOR.getInitCount()).isEqualTo(count);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Generator.init() once per field")
+    void initCountWithFields() {
+        final InitCountingPojoContainer result = Instancio.create(InitCountingPojoContainer.class);
+
+        count += 2;
+
+        assertThat(result.holder1).isNotNull();
+        assertThat(result.holder2).isNotNull();
+        assertThat(CustomGeneratorProvider.INIT_COUNTING_GENERATOR.getInitCount()).isEqualTo(count);
+    }
+}


### PR DESCRIPTION
This method was added previously and then subsequently removed in ddd1bb3a21 without being released. This commit adds the `init()` method again. The motivation is to allow more flexibility in custom generator implementations by providing the `GeneratorContext` via the `init()` method.