### PR TITLE
Disable gradle daemon

### DIFF
--- a/instancio-tests/annotation-processor-with-gradle/gradle-module/gradle.properties
+++ b/instancio-tests/annotation-processor-with-gradle/gradle-module/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
Hi, i was thinkering with the project to study it so i was running `mvn verify` over and over.

I noticed after some time lots of left over gradle daemon processes that were taking over my notebook lol

The problem is the module `annotation-processor-with-gradle` that is launching a gradle daemon, you can see it with the `jps` command.

I added a file that will suppress the daemon from being started.

From my point of view it is more logical that a build process that is based on maven shouldn't collaterally launch a daemon of another build tool. Moreover the module itself is very small and i didn't see much of a difference in terms of performance with or without the daemon.

Let me know what you think.

Bye!