### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -1,18 +1,17 @@
 name: "Deploy Snapshots"
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches:
+      - main
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - run: echo "PR merged, deploying snapshots"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 17
           server-id: sonatype-snapshots
           server-username: MAVEN_USERNAME
@@ -26,10 +25,11 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Run tests with JDK 8 using deployed snapshots"
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: 8
       # exclude test modules that require versions higher than 8
       - run: cd instancio-tests && mvn -v && mvn -B -pl '!java16-tests,!java17-tests,!spi-tests,!bean-validation-hibernate-tests' install


### PR DESCRIPTION
I changed the trigger of the deploy workflow so that external merged PR now can successfully deploy without errors.

I took the liberty of updating the actions too bumping the checkout to v3 and the setup-java to v3. I followed this guide for the latter https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md. (i will update the other workflow too in a separate PR).

Now the distribution is a mandatory field and i chose temurin because it's the most widely used openjdk distribution and it's vendor independent https://whichjdk.com/. If you prefer another one I'll change it accordingly of course.

I can't test it for obvious reason, so i hope i didn't mess up something :D 