### PR TITLE
Restructure build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,40 +1,29 @@
-name: "Build"
+name: 'Build'
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
+      - uses: actions/checkout@v3
 
-      - name: "Cache Maven packages"
-        uses: actions/cache@v2
+      - name: 'Build and analyse with JDK 17'
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: "Cache SonarCloud packages"
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: "Build and analyse with JDK 17"
-        uses: actions/setup-java@v1
-        with:
+          distribution: temurin
           java-version: 17
-      - run: mvn -v && mvn -B clean install sonar:sonar -Dsonar.projectKey=instancio_instancio
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          cache: maven
+
+      - run: mvn -v && mvn -B clean install
+
+      - name: 'Upload test coverage'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage
+          path: instancio-tests/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,69 @@
+name: 'Sonar'
+on:
+  workflow_run:
+    workflows: [ Build ]
+    types:
+      - completed
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
+
+      - name: 'Download test coverage'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "test-coverage"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/test-coverage.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip test coverage'
+        run: |
+          unzip test-coverage.zip
+          mkdir -p instancio-tests/report-aggregate/target/site/jacoco-aggregate
+          mv jacoco.xml instancio-tests/report-aggregate/target/site/jacoco-aggregate
+
+      - name: 'Cache SonarCloud packages'
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - run: >
+          mvn -B sonar:sonar -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} 
+          -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }} 
+          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }} 
+          -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.enforcer.require.java.version>[17,)</maven.enforcer.require.java.version>
         <sonar.organization>instancio</sonar.organization>
+        <sonar.projectKey>instancio_instancio</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>


### PR DESCRIPTION
Hi, after a not so funny journey to find a solution for the sonar problem i came up with this PR.

The idea is to split the current Build workflow in two workflows:

- Build: This workflow will trigger for every push on main and for every PR. It will build the project as usual but without the sonar scan because in this stage the `SONAR_TOKEN` isn't visible. After that the workflow will upload the jacoco test coverage as an artifact.
- Sonar: This workflow will trigger after the previous workflow completes its execution. It will checkout the project from the repository that triggered the PR (this should be safe because no build is triggered and the code is used only for the sonar analysis). It will download the test coverage generated in the previous step (thanks github for making this as convoluted as possible) and launch the sonar scan. This time the SONAR_SECRET is visible and the scan should reach the holy server of SonarCloud.

As a final fun fact i have no idea if this PR will trigger the old workflow or the new ones, but I guess we'll found out soon enough lol.

Let me know what you think of this!

Bye!