### PR TITLE
Support for Guava (#525)

### DIFF
--- a/instancio-guava/pom.xml
+++ b/instancio-guava/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-parent</artifactId>
+        <version>2.12.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>instancio-guava</artifactId>
+    <packaging>jar</packaging>
+    <name>Instancio Guava Support</name>
+    <description>Instancio support for Guava classes</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.instancio.guava</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${version.guava}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/instancio-guava/src/main/java/org/instancio/guava/GenGuava.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/GenGuava.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava;
+
+import org.instancio.documentation.ExperimentalApi;
+import org.instancio.guava.generator.specs.MultimapGeneratorSpec;
+import org.instancio.guava.generator.specs.TableGeneratorSpec;
+import org.instancio.guava.internal.generator.GuavaArrayListMultimapGenerator;
+import org.instancio.guava.internal.generator.GuavaHashBasedTableGenerator;
+
+/**
+ * Provides access to generators for Guava classes.
+ *
+ * @since 2.13.0
+ */
+@ExperimentalApi
+public final class GenGuava {
+
+    /**
+     * Generator spec for multimaps.
+     *
+     * @param <K> the type of the key
+     * @param <V> the type of the mapped values
+     * @return generator spec
+     * @since 2.13.0
+     */
+    public static <K, V> MultimapGeneratorSpec<K, V> multimap() {
+        return new GuavaArrayListMultimapGenerator<>();
+    }
+
+    /**
+     * Generator spec for tables.
+     *
+     * @param <R> the type of the table row keys
+     * @param <C> the type of the table column keys
+     * @param <V> the type of the mapped values
+     * @return generator spec
+     * @since 2.13.0
+     */
+    public static <R, C, V> TableGeneratorSpec<R, C, V> table() {
+        return new GuavaHashBasedTableGenerator<>();
+    }
+
+    private GenGuava() {
+        // non-instantiable
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/generator/specs/MultimapGeneratorSpec.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/generator/specs/MultimapGeneratorSpec.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.generator.specs;
+
+import com.google.common.collect.Multimap;
+import org.instancio.documentation.ExperimentalApi;
+import org.instancio.generator.specs.SizeGeneratorSpec;
+
+/**
+ * Generator spec for {@link Multimap Multimaps}.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the mapped values
+ * @since 2.13.0
+ */
+@ExperimentalApi
+public interface MultimapGeneratorSpec<K, V> extends SizeGeneratorSpec<Multimap<K, V>> {
+
+    @Override
+    MultimapGeneratorSpec<K, V> size(int size);
+
+    @Override
+    MultimapGeneratorSpec<K, V> minSize(int size);
+
+    @Override
+    MultimapGeneratorSpec<K, V> maxSize(int size);
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/generator/specs/TableGeneratorSpec.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/generator/specs/TableGeneratorSpec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.generator.specs;
+
+import com.google.common.collect.Table;
+import org.instancio.documentation.ExperimentalApi;
+import org.instancio.generator.specs.SizeGeneratorSpec;
+
+/**
+ * Generator spec for {@link Table Tables}.
+ *
+ * @param <R> the type of the table row keys
+ * @param <C> the type of the table column keys
+ * @param <V> the type of the mapped values
+ * @since 2.13.0
+ */
+@ExperimentalApi
+public interface TableGeneratorSpec<R, C, V> extends SizeGeneratorSpec<Table<R, C, V>> {
+
+    @Override
+    TableGeneratorSpec<R, C, V> size(int size);
+
+    @Override
+    TableGeneratorSpec<R, C, V> minSize(int size);
+
+    @Override
+    TableGeneratorSpec<R, C, V> maxSize(int size);
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/generator/specs/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/generator/specs/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Defines generator specs for Guava classes.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava.generator.specs;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaArrayListMultimapGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaArrayListMultimapGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.generator;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.Hints;
+import org.instancio.guava.generator.specs.MultimapGeneratorSpec;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.InternalContainerHint;
+import org.instancio.internal.util.Constants;
+import org.instancio.internal.util.NumberUtils;
+
+public class GuavaArrayListMultimapGenerator<K, V>
+        implements Generator<Multimap<K, V>>, MultimapGeneratorSpec<K, V> {
+
+    private GeneratorContext context;
+    private int minSize = Constants.MIN_SIZE;
+    private int maxSize = Constants.MAX_SIZE;
+
+    @Override
+    public void init(final GeneratorContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public MultimapGeneratorSpec<K, V> size(final int size) {
+        this.minSize = ApiValidator.validateSize(size);
+        this.maxSize = size;
+        return this;
+    }
+
+    @Override
+    public MultimapGeneratorSpec<K, V> minSize(final int size) {
+        this.minSize = ApiValidator.validateSize(size);
+        this.maxSize = NumberUtils.calculateNewMaxSize(maxSize, minSize);
+        return this;
+    }
+
+    @Override
+    public MultimapGeneratorSpec<K, V> maxSize(final int size) {
+        this.maxSize = ApiValidator.validateSize(size);
+        this.minSize = NumberUtils.calculateNewMinSize(minSize, maxSize);
+        return this;
+    }
+
+    @Override
+    public Multimap<K, V> generate(final Random random) {
+        return ArrayListMultimap.create();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Hints hints() {
+        final int generateEntries = context.random().intRange(minSize, maxSize);
+
+        return Hints.builder()
+                .with(InternalContainerHint.builder()
+                        .generateEntries(generateEntries)
+                        .addFunction((Multimap<K, V> map, Object... args) ->
+                                map.put(
+                                        (K) args[0],
+                                        (V) args[1]))
+                        .build())
+                .build();
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHashBasedTableGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHashBasedTableGenerator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.generator;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.Hints;
+import org.instancio.guava.generator.specs.TableGeneratorSpec;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.InternalContainerHint;
+import org.instancio.internal.util.Constants;
+import org.instancio.internal.util.NumberUtils;
+
+public class GuavaHashBasedTableGenerator<R, C, V>
+        implements Generator<Table<R, C, V>>, TableGeneratorSpec<R, C, V> {
+
+    private GeneratorContext context;
+    private int minSize = Constants.MIN_SIZE;
+    private int maxSize = Constants.MAX_SIZE;
+
+    @Override
+    public void init(final GeneratorContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public GuavaHashBasedTableGenerator<R, C, V> size(final int size) {
+        this.minSize = ApiValidator.validateSize(size);
+        this.maxSize = size;
+        return this;
+    }
+
+    @Override
+    public GuavaHashBasedTableGenerator<R, C, V> minSize(final int size) {
+        this.minSize = ApiValidator.validateSize(size);
+        this.maxSize = NumberUtils.calculateNewMaxSize(maxSize, minSize);
+        return this;
+    }
+
+    @Override
+    public GuavaHashBasedTableGenerator<R, C, V> maxSize(final int size) {
+        this.maxSize = ApiValidator.validateSize(size);
+        this.minSize = NumberUtils.calculateNewMinSize(minSize, maxSize);
+        return this;
+    }
+
+    @Override
+    public Table<R, C, V> generate(final Random random) {
+        return HashBasedTable.create();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Hints hints() {
+        final int generateEntries = context.random().intRange(minSize, maxSize);
+
+        return Hints.builder()
+                .with(InternalContainerHint.builder()
+                        .generateEntries(generateEntries)
+                        .addFunction((Table<R, C, V> table, Object... args) ->
+                                table.put(
+                                        (R) args[0],
+                                        (C) args[1],
+                                        (V) args[2]))
+                        .build())
+                .build();
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHostAndPortGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHostAndPortGenerator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.generator;
+
+import com.google.common.net.HostAndPort;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.generator.domain.internet.Ip4Generator;
+
+public class GuavaHostAndPortGenerator implements Generator<HostAndPort> {
+
+    private static final int MIN_PORT = 0;
+    private static final int MAX_PORT = 65_535;
+
+    private Ip4Generator ip4Generator;
+
+    @Override
+    public void init(final GeneratorContext context) {
+        ip4Generator = new Ip4Generator(context);
+    }
+
+    @Override
+    public HostAndPort generate(final Random random) {
+        final String host = ip4Generator.generate(random);
+        final int port = random.intRange(MIN_PORT, MAX_PORT);
+        return HostAndPort.fromParts(host, port);
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaInternetDomainNameGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaInternetDomainNameGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.generator;
+
+import com.google.common.net.InternetDomainName;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+
+public class GuavaInternetDomainNameGenerator implements Generator<InternetDomainName> {
+
+    @Override
+    public InternetDomainName generate(final Random random) {
+        final int length = random.intRange(2, 10);
+        final String tld = random.oneOf(".com", ".net", ".org");
+        final String domain = random.lowerCaseAlphabetic(length) + tld;
+        return InternetDomainName.from(domain);
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaRangeGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaRangeGenerator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.generator;
+
+import com.google.common.collect.Range;
+import org.instancio.Random;
+import org.instancio.generator.Generator;
+
+public class GuavaRangeGenerator<C extends Comparable<C>>
+        implements Generator<Range<C>> {
+
+
+    @Override
+    public Range<C> generate(final Random random) {
+        return Range.all();
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains Guava generator implementations.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava.internal.generator;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains internal implementation classes.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava.internal;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/spi/GuavaContainerFactory.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/spi/GuavaContainerFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.spi;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.TreeMultiset;
+import org.instancio.internal.spi.InternalContainerFactoryProvider;
+import org.instancio.internal.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.instancio.guava.internal.util.GuavaFunctions.fromCollection;
+import static org.instancio.guava.internal.util.GuavaFunctions.fromMap;
+import static org.instancio.guava.internal.util.GuavaFunctions.fromMultimap;
+import static org.instancio.guava.internal.util.GuavaFunctions.fromTable;
+
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveImports"})
+public class GuavaContainerFactory implements InternalContainerFactoryProvider {
+    private static final Map<Class<?>, Function<?, ?>> MAPPING_FUNCTIONS = getMappingFunctions();
+    private static final Set<Class<?>> CONTAINER_CLASSES = getContainerClasses();
+
+    private static Map<Class<?>, Function<?, ?>> getMappingFunctions() {
+        final Map<Class<?>, Function<?, ?>> map = new HashMap<>();
+
+        // Collections
+        map.put(ConcurrentHashMultiset.class, fromCollection(ConcurrentHashMultiset::create));
+        map.put(HashMultiset.class, fromCollection(HashMultiset::create));
+        map.put(ImmutableList.class, fromCollection(ImmutableList::copyOf));
+        map.put(ImmutableMultiset.class, fromCollection(ImmutableMultiset::copyOf));
+        map.put(ImmutableSet.class, fromCollection(ImmutableSet::copyOf));
+        map.put(ImmutableSortedMultiset.class, fromCollection(ImmutableSortedMultiset::copyOf));
+        map.put(ImmutableSortedSet.class, fromCollection(ImmutableSortedSet::copyOf));
+        map.put(LinkedHashMultiset.class, fromCollection(LinkedHashMultiset::create));
+        map.put(Multiset.class, fromCollection(HashMultiset::create));
+        map.put(SortedMultiset.class, fromCollection(TreeMultiset::create));
+        map.put(TreeMultiset.class, fromCollection(TreeMultiset::create));
+
+        // Maps
+        map.put(BiMap.class, fromMap(HashBiMap::create));
+        map.put(HashBiMap.class, fromMap(HashBiMap::create));
+        map.put(ImmutableBiMap.class, fromMap(ImmutableBiMap::copyOf));
+        map.put(ImmutableMap.class, fromMap(ImmutableMap::copyOf));
+        map.put(ImmutableSortedMap.class, fromMap(ImmutableSortedMap::copyOf));
+
+        // Multimaps
+        map.put(HashMultimap.class, fromMultimap(HashMultimap::create));
+        map.put(ImmutableListMultimap.class, fromMultimap(ImmutableListMultimap::copyOf));
+        map.put(ImmutableMultimap.class, fromMultimap(ImmutableMultimap::copyOf));
+        map.put(ImmutableSetMultimap.class, fromMultimap(ImmutableSetMultimap::copyOf));
+        map.put(LinkedHashMultimap.class, fromMultimap(LinkedHashMultimap::create));
+        map.put(LinkedListMultimap.class, fromMultimap(LinkedListMultimap::create));
+        map.put(SetMultimap.class, fromMultimap(HashMultimap::create));
+        map.put(SortedSetMultimap.class, fromMultimap(TreeMultimap::create));
+        map.put(TreeMultimap.class, fromMultimap(TreeMultimap::create));
+
+        // Tables
+        map.put(ImmutableTable.class, fromTable(ImmutableTable::copyOf));
+
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static Set<Class<?>> getContainerClasses() {
+        return Collections.unmodifiableSet(CollectionUtils.asSet(
+                ArrayListMultimap.class,
+                HashMultimap.class,
+                ImmutableListMultimap.class,
+                ImmutableMultimap.class,
+                ImmutableSetMultimap.class,
+                ImmutableTable.class,
+                LinkedHashMultimap.class,
+                LinkedListMultimap.class,
+                ListMultimap.class,
+                SetMultimap.class,
+                SortedSetMultimap.class,
+                Table.class,
+                TreeMultimap.class
+        ));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T, R> Function<T, R> getMappingFunction(Class<R> type, List<Class<?>> typeArguments) {
+        return (Function<T, R>) MAPPING_FUNCTIONS.get(type);
+    }
+
+    @Override
+    public boolean isContainer(final Class<?> type) {
+        return CONTAINER_CLASSES.contains(type);
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/spi/GuavaProvider.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/spi/GuavaProvider.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.spi;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.TreeMultiset;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InternetDomainName;
+import org.instancio.Node;
+import org.instancio.generator.Generator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generators.Generators;
+import org.instancio.guava.internal.generator.GuavaArrayListMultimapGenerator;
+import org.instancio.guava.internal.generator.GuavaHashBasedTableGenerator;
+import org.instancio.guava.internal.generator.GuavaHostAndPortGenerator;
+import org.instancio.guava.internal.generator.GuavaInternetDomainNameGenerator;
+import org.instancio.guava.internal.generator.GuavaRangeGenerator;
+import org.instancio.internal.generator.util.CollectionGenerator;
+import org.instancio.internal.generator.util.MapGenerator;
+import org.instancio.spi.InstancioServiceProvider;
+import org.instancio.spi.ServiceProviderContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.ExcessiveImports"})
+public class GuavaProvider implements InstancioServiceProvider {
+
+    private GeneratorContext generatorContext;
+
+    @Override
+    public void init(final ServiceProviderContext providerContext) {
+        this.generatorContext = new GeneratorContext(
+                providerContext.getSettings(),
+                providerContext.random());
+    }
+
+    @Override
+    public GeneratorProvider getGeneratorProvider() {
+        final Map<Class<?>, Generator<?>> generators = new HashMap<>();
+
+        // Collections
+        final Generator<?> collectionGenerator = new CollectionGenerator<>(generatorContext);
+        generators.put(ConcurrentHashMultiset.class, collectionGenerator);
+        generators.put(HashMultiset.class, collectionGenerator);
+        generators.put(ImmutableList.class, collectionGenerator);
+        generators.put(ImmutableMultiset.class, collectionGenerator);
+        generators.put(ImmutableSet.class, collectionGenerator);
+        generators.put(ImmutableSortedMultiset.class, collectionGenerator);
+        generators.put(ImmutableSortedSet.class, collectionGenerator);
+        generators.put(LinkedHashMultiset.class, collectionGenerator);
+        generators.put(Multiset.class, collectionGenerator);
+        generators.put(SortedMultiset.class, collectionGenerator);
+        generators.put(TreeMultiset.class, collectionGenerator);
+
+        // Maps
+        final Generator<?> mapGenerator = new MapGenerator<>(generatorContext);
+        generators.put(BiMap.class, mapGenerator);
+        generators.put(HashBiMap.class, mapGenerator);
+        generators.put(ImmutableBiMap.class, mapGenerator);
+        generators.put(ImmutableMap.class, mapGenerator);
+        generators.put(ImmutableSortedMap.class, mapGenerator);
+
+        // Multimaps
+        final Generator<?> multimapGenerator = new GuavaArrayListMultimapGenerator<>();
+        generators.put(ArrayListMultimap.class, multimapGenerator);
+        generators.put(HashMultimap.class, multimapGenerator);
+        generators.put(ImmutableListMultimap.class, multimapGenerator);
+        generators.put(ImmutableMultimap.class, multimapGenerator);
+        generators.put(ImmutableSetMultimap.class, multimapGenerator);
+        generators.put(LinkedHashMultimap.class, multimapGenerator);
+        generators.put(LinkedListMultimap.class, multimapGenerator);
+        generators.put(ListMultimap.class, multimapGenerator);
+        generators.put(Multimap.class, multimapGenerator);
+        generators.put(SetMultimap.class, multimapGenerator);
+        generators.put(SortedSetMultimap.class, multimapGenerator);
+        generators.put(TreeMultimap.class, multimapGenerator);
+
+        // Tables
+        final Generator<?> tableGenerator = new GuavaHashBasedTableGenerator<>();
+        generators.put(ImmutableTable.class, tableGenerator);
+        generators.put(Table.class, tableGenerator);
+
+        // Net
+        generators.put(InternetDomainName.class, new GuavaInternetDomainNameGenerator());
+        generators.put(HostAndPort.class, new GuavaHostAndPortGenerator());
+
+        // Range
+        generators.put(Range.class, new GuavaRangeGenerator<>());
+
+        return (Node node, Generators gen) -> generators.get(node.getTargetClass());
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/spi/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/spi/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains Instancio SPI implementation.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava.internal.spi;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/util/GuavaFunctions.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/util/GuavaFunctions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.guava.internal.util;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class GuavaFunctions {
+
+    @SuppressWarnings("rawtypes")
+    public static <R> Function<Collection, R> fromCollection(Function<Collection, R> fn) {
+        return fn;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static <R> Function<Map, R> fromMap(Function<Map, R> fn) {
+        return fn;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static <R> Function<Multimap, R> fromMultimap(Function<Multimap, R> fn) {
+        return fn;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static <R> Function<Table, R> fromTable(Function<Table, R> fn) {
+        return fn;
+    }
+
+    private GuavaFunctions() {
+        // non-instantiable
+    }
+}

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/util/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/util/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains internal utility classes.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava.internal.util;

--- a/instancio-guava/src/main/java/org/instancio/guava/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Provides support for Guava.
+ *
+ * @since 2.13.0
+ */
+package org.instancio.guava;

--- a/instancio-guava/src/main/resources/META-INF/services/org.instancio.internal.spi.InternalContainerFactoryProvider
+++ b/instancio-guava/src/main/resources/META-INF/services/org.instancio.internal.spi.InternalContainerFactoryProvider
@@ -1,0 +1,1 @@
+org.instancio.guava.internal.spi.GuavaContainerFactory

--- a/instancio-guava/src/main/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
+++ b/instancio-guava/src/main/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
@@ -1,0 +1,1 @@
+org.instancio.guava.internal.spi.GuavaProvider

--- a/instancio-tests/instancio-guava-tests/pom.xml
+++ b/instancio-tests/instancio-guava-tests/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-tests</artifactId>
+        <version>2.12.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>instancio-guava-tests</artifactId>
+    <packaging>jar</packaging>
+    <name>Instancio tests: instancio-guava Tests</name>
+
+    <properties>
+        <sonar.exclusions>**/test/pojo/guava/**/*</sonar.exclusions>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${version.lombok}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${version.guava}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-guava</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-junit</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-test-support</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/instancio-tests/instancio-guava-tests/src/main/java/org/instancio/test/pojo/guava/AllSupportedGuavaTypes.java
+++ b/instancio-tests/instancio-guava-tests/src/main/java/org/instancio/test/pojo/guava/AllSupportedGuavaTypes.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.pojo.guava;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Range;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.Table;
+import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.TreeMultiset;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.InternetDomainName;
+import lombok.Value;
+
+import java.util.UUID;
+
+@Value
+public class AllSupportedGuavaTypes {
+
+    // Collect
+    ArrayListMultimap<UUID, String> arrayListMultimap;
+    BiMap<UUID, String> biMap;
+    HashBiMap<UUID, String> hashBiMap;
+    HashMultimap<UUID, String> hashMultimap;
+    HashMultiset<UUID> hashMultiset;
+    ImmutableBiMap<UUID, String> immutableBiMap;
+    ImmutableList<UUID> immutableList;
+    ImmutableListMultimap<UUID, String> immutableListMultimap;
+    ImmutableMap<UUID, String> immutableMap;
+    ImmutableMultimap<UUID, String> immutableMultimap;
+    ImmutableMultiset<UUID> immutableMultiset;
+    ImmutableSet<UUID> immutableSet;
+    ImmutableSetMultimap<UUID, String> immutableSetMultimap;
+    ImmutableSortedMap<UUID, String> immutableSortedMap;
+    ImmutableSortedMultiset<UUID> immutableSortedMultiset;
+    ImmutableSortedSet<UUID> immutableSortedSet;
+    ImmutableTable<String, Integer, Long> immutableTable;
+    LinkedHashMultimap<UUID, String> linkedHashMultimap;
+    LinkedHashMultiset<UUID> linkedHashMultiset;
+    LinkedListMultimap<UUID, String> linkedListMultimap;
+    ListMultimap<UUID, String> listMultimap;
+    Multiset<UUID> multiset;
+    Range<Integer> range;
+    SetMultimap<UUID, String> setMultimap;
+    SortedMultiset<UUID> sortedMultiset;
+    SortedSetMultimap<UUID, String> sortedSetMultimap;
+    Table<String, Integer, Long> table;
+    TreeMultimap<UUID, String> treeMultimap;
+    TreeMultiset<UUID> treeMultiset;
+    ConcurrentHashMultiset<UUID> concurrentHashMultiset;
+
+    // Net
+    HostAndPort hostAndPort;
+    InternetDomainName internetDomainName;
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/GuavaRepeatabilityTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/GuavaRepeatabilityTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.guava;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.Seed;
+import org.instancio.test.pojo.guava.AllSupportedGuavaTypes;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(InstancioExtension.class)
+class GuavaRepeatabilityTest {
+
+    private static final long SEED = 12345L;
+
+    private static AllSupportedGuavaTypes first;
+
+    @Seed(SEED)
+    @Order(1)
+    @Test
+    void first() {
+        first = Instancio.create(AllSupportedGuavaTypes.class);
+
+        assertThat(first).hasNoNullFieldsOrProperties();
+    }
+
+    @Seed(SEED)
+    @Order(2)
+    @Test
+    void second() {
+        AllSupportedGuavaTypes second = Instancio.create(AllSupportedGuavaTypes.class);
+
+        assertThat(second)
+                .usingRecursiveComparison()
+                .isEqualTo(first);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaImmutableListTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaImmutableListTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.ImmutableList;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.types;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaImmutableListTest {
+
+    private static final int EXPECTED_SIZE = 10;
+
+    private static class Holder {
+        private List<String> List;
+    }
+
+    @Test
+    void createViaTypeToken() {
+        final List<String> result = Instancio.create(new TypeToken<ImmutableList<String>>() {});
+
+        assertThat(result)
+                .isInstanceOf(ImmutableList.class)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+    }
+
+    @Test
+    void generatorSpecSize() {
+        final List<String> result = Instancio.of(new TypeToken<ImmutableList<String>>() {})
+                .generate(types().of(List.class), gen -> gen.collection().size(EXPECTED_SIZE))
+                .create();
+
+        assertImmutableList(result);
+    }
+
+    @Test
+    void generatorSpecSubtype() {
+        final Holder result = Instancio.of(Holder.class)
+                .generate(all(List.class), gen -> gen.collection().size(EXPECTED_SIZE).subtype(ImmutableList.class))
+                .create();
+
+        assertImmutableList(result.List);
+    }
+
+    @Test
+    void subtype() {
+        final Holder result = Instancio.of(Holder.class)
+                .subtype(all(List.class), ImmutableList.class)
+                .generate(all(List.class), gen -> gen.collection().size(EXPECTED_SIZE))
+                .create();
+
+        assertImmutableList(result.List);
+    }
+
+    private static void assertImmutableList(final List<String> result) {
+        assertThat(result)
+                .isInstanceOf(ImmutableList.class)
+                .hasSize(EXPECTED_SIZE)
+                .doesNotContainNull();
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaImmutableMapTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaImmutableMapTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.ImmutableMap;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.types;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaImmutableMapTest {
+
+    private static final int EXPECTED_SIZE = 10;
+
+    private static class Holder {
+        private Map<String, Long> map;
+    }
+
+    @Test
+    void createViaTypeToken() {
+        final Map<String, Long> result = Instancio.create(new TypeToken<ImmutableMap<String, Long>>() {});
+
+        assertThat(result)
+                .isInstanceOf(ImmutableMap.class)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+    }
+
+    @Test
+    void generatorSpecSize() {
+        final Map<String, Long> result = Instancio.of(new TypeToken<ImmutableMap<String, Long>>() {})
+                .generate(types().of(Map.class), gen -> gen.map().size(EXPECTED_SIZE))
+                .create();
+
+        assertImmutableMap(result);
+    }
+
+    @Test
+    void generatorSpecSubtype() {
+        final Holder result = Instancio.of(Holder.class)
+                .generate(all(Map.class), gen -> gen.map().size(EXPECTED_SIZE).subtype(ImmutableMap.class))
+                .create();
+
+        assertImmutableMap(result.map);
+    }
+
+    @Test
+    void subtype() {
+        final Holder result = Instancio.of(Holder.class)
+                .subtype(all(Map.class), ImmutableMap.class)
+                .generate(all(Map.class), gen -> gen.map().size(EXPECTED_SIZE))
+                .create();
+
+        assertImmutableMap(result.map);
+    }
+
+    private static void assertImmutableMap(final Map<String, Long> result) {
+        assertThat(result)
+                .isInstanceOf(ImmutableMap.class)
+                .hasSize(EXPECTED_SIZE)
+                .doesNotContainKey(null)
+                .doesNotContainValue(null);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaMultimapTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaMultimapTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Table;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.guava.GenGuava;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.types;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaMultimapTest {
+
+    @Test
+    void createViaTypeToken() {
+        final Multimap<String, Long> result = Instancio.create(
+                new TypeToken<ImmutableListMultimap<String, Long>>() {});
+
+        assertThat(result).isExactlyInstanceOf(ImmutableListMultimap.class);
+        assertThat(result.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+        assertThat(result.keySet()).doesNotContainNull();
+        assertThat(result.values()).doesNotContainNull();
+    }
+
+    @Test
+    void createViaTypeTokenWithNestedTable() {
+        final Multimap<String, Table<Integer, String, Long>> result =
+                Instancio.create(new TypeToken<ListMultimap<String, Table<Integer, String, Long>>>() {});
+
+        assertThat(result).isExactlyInstanceOf(ArrayListMultimap.class);
+        assertThat(result.isEmpty()).isFalse();
+        assertThat(result.values()).doesNotContainNull()
+                .allSatisfy(table -> {
+                    assertThat(table).isInstanceOf(Table.class);
+                    assertThat(table.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+                    assertThat(table.values()).doesNotContainNull();
+                });
+    }
+
+    @Test
+    void generatorSpecMinMaxSize() {
+        final Multimap<String, Long> result = Instancio.of(new TypeToken<ImmutableListMultimap<String, Long>>() {})
+                .generate(types().of(Multimap.class), GenGuava.multimap().minSize(7).maxSize(8))
+                .create();
+
+        assertThat(result.size()).isBetween(7, 8);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedCollectionsTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedCollectionsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.LinkedHashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.SortedMultiset;
+import com.google.common.collect.TreeMultiset;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaSupportedCollectionsTest {
+
+    private static Stream<Arguments> args() {
+        return Stream.of(
+                Arguments.of(new TypeToken<ConcurrentHashMultiset<UUID>>() {}, ConcurrentHashMultiset.class),
+                Arguments.of(new TypeToken<HashMultiset<UUID>>() {}, HashMultiset.class),
+                Arguments.of(new TypeToken<ImmutableList<UUID>>() {}, ImmutableList.class),
+                Arguments.of(new TypeToken<ImmutableMultiset<UUID>>() {}, ImmutableMultiset.class),
+                Arguments.of(new TypeToken<ImmutableSet<UUID>>() {}, ImmutableSet.class),
+                Arguments.of(new TypeToken<ImmutableSortedMultiset<UUID>>() {}, ImmutableSortedMultiset.class),
+                Arguments.of(new TypeToken<ImmutableSortedSet<UUID>>() {}, ImmutableSortedSet.class),
+                Arguments.of(new TypeToken<LinkedHashMultiset<UUID>>() {}, LinkedHashMultiset.class),
+                Arguments.of(new TypeToken<Multiset<UUID>>() {}, HashMultiset.class),
+                Arguments.of(new TypeToken<SortedMultiset<UUID>>() {}, SortedMultiset.class),
+                Arguments.of(new TypeToken<TreeMultiset<UUID>>() {}, TreeMultiset.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    <C extends Collection<UUID>> void verify(final TypeToken<C> type, final Class<?> expectedSubtype) {
+        verifyCreate(type, expectedSubtype);
+        verifyCreateWithSize(type, expectedSubtype);
+    }
+
+    private static <C extends Collection<UUID>> void verifyCreate(final TypeToken<C> type, final Class<?> expectedSubtype) {
+        final Collection<UUID> result = Instancio.create(type);
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
+                .isInstanceOf(expectedSubtype);
+    }
+
+    private static <C extends Collection<UUID>> void verifyCreateWithSize(final TypeToken<C> type, final Class<?> expectedSubtype) {
+        final int size = 5;
+        final UUID expected = Instancio.create(UUID.class);
+        final Collection<UUID> result = Instancio.of(type)
+                .generate(root(), gen -> gen.collection().size(size).with(expected))
+                .create();
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .hasSize(size + 1) // plus expected element
+                .contains(expected)
+                .isInstanceOf(expectedSubtype);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedMapsTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedMapsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaSupportedMapsTest {
+
+    private static Stream<Arguments> args() {
+        return Stream.of(
+                Arguments.of(new TypeToken<BiMap<UUID, String>>() {}, HashBiMap.class),
+                Arguments.of(new TypeToken<HashBiMap<UUID, String>>() {}, HashBiMap.class),
+                Arguments.of(new TypeToken<ImmutableBiMap<UUID, String>>() {}, ImmutableBiMap.class),
+                Arguments.of(new TypeToken<ImmutableMap<UUID, String>>() {}, ImmutableMap.class),
+                Arguments.of(new TypeToken<ImmutableSortedMap<UUID, String>>() {}, ImmutableSortedMap.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    <M extends Map<UUID, String>> void verify(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        verifyCreate(type, expectedSubtype);
+        verifyCreateWithSize(type, expectedSubtype);
+    }
+
+    private static <M extends Map<UUID, String>> void verifyCreate(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        final Map<UUID, String> result = Instancio.create(type);
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
+                .isInstanceOf(expectedSubtype);
+    }
+
+    private static <M extends Map<UUID, String>> void verifyCreateWithSize(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        final int size = 5;
+        final UUID expectedKey = Instancio.create(UUID.class);
+        final String expectedValue = Instancio.create(String.class);
+        final Map<UUID, String> result = Instancio.of(type)
+                .generate(root(), gen -> gen.map().size(size).with(expectedKey, expectedValue))
+                .create();
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .hasSize(size + 1) // plus expected entry
+                .containsEntry(expectedKey, expectedValue)
+                .isInstanceOf(expectedSubtype);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedMultimapsTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedMultimapsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.SortedSetMultimap;
+import com.google.common.collect.TreeMultimap;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.guava.GenGuava;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaSupportedMultimapsTest {
+
+    private static Stream<Arguments> args() {
+        return Stream.of(
+                Arguments.of(new TypeToken<ArrayListMultimap<UUID, String>>() {}, ArrayListMultimap.class),
+                Arguments.of(new TypeToken<HashMultimap<UUID, String>>() {}, HashMultimap.class),
+                Arguments.of(new TypeToken<ImmutableListMultimap<UUID, String>>() {}, ImmutableListMultimap.class),
+                Arguments.of(new TypeToken<ImmutableMultimap<UUID, String>>() {}, ImmutableMultimap.class),
+                Arguments.of(new TypeToken<ImmutableSetMultimap<UUID, String>>() {}, ImmutableSetMultimap.class),
+                Arguments.of(new TypeToken<LinkedHashMultimap<UUID, String>>() {}, LinkedHashMultimap.class),
+                Arguments.of(new TypeToken<LinkedListMultimap<UUID, String>>() {}, LinkedListMultimap.class),
+                Arguments.of(new TypeToken<ListMultimap<UUID, String>>() {}, ArrayListMultimap.class),
+                Arguments.of(new TypeToken<SortedSetMultimap<UUID, String>>() {}, TreeMultimap.class),
+                Arguments.of(new TypeToken<SetMultimap<UUID, String>>() {}, HashMultimap.class),
+                Arguments.of(new TypeToken<TreeMultimap<UUID, String>>() {}, TreeMultimap.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    <M extends Multimap<UUID, String>> void verify(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        verifyCreate(type, expectedSubtype);
+        verifyCreateWithSize(type, expectedSubtype);
+    }
+
+    private static <M extends Multimap<UUID, String>> void verifyCreate(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        final Multimap<UUID, String> result = Instancio.create(type);
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .isInstanceOf(expectedSubtype);
+
+        assertThat(result.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+    }
+
+    private static <M extends Multimap<UUID, String>> void verifyCreateWithSize(final TypeToken<M> type, final Class<?> expectedSubtype) {
+        final int size = 5;
+        final Multimap<UUID, String> result = Instancio.of(type)
+                .generate(root(), GenGuava.multimap().size(size))
+                .create();
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .isInstanceOf(expectedSubtype);
+
+        assertThat(result.size()).isEqualTo(size);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedTablesTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/collect/GuavaSupportedTablesTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.collect;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.guava.GenGuava;
+import org.instancio.internal.util.Constants;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaSupportedTablesTest {
+
+    private static Stream<Arguments> args() {
+        return Stream.of(
+                Arguments.of(new TypeToken<Table<UUID, String, Long>>() {}, HashBasedTable.class),
+                Arguments.of(new TypeToken<ImmutableTable<UUID, String, Long>>() {}, ImmutableTable.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("args")
+    <T extends Table<UUID, String, Long>> void verify(final TypeToken<T> type, final Class<?> expectedSubtype) {
+        verifyCreate(type, expectedSubtype);
+        verifyCreateWithSize(type, expectedSubtype);
+    }
+
+    private static <T extends Table<UUID, String, Long>> void verifyCreate(final TypeToken<T> type, final Class<?> expectedSubtype) {
+        final Table<UUID, String, Long> result = Instancio.create(type);
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .isInstanceOf(expectedSubtype);
+
+        assertThat(result.size()).isBetween(Constants.MIN_SIZE, Constants.MAX_SIZE);
+    }
+
+    private static <T extends Table<UUID, String, Long>> void verifyCreateWithSize(final TypeToken<T> type, final Class<?> expectedSubtype) {
+        final int size = 5;
+        final Table<UUID, String, Long> result = Instancio.of(type)
+                .generate(root(), GenGuava.table().size(size))
+                .create();
+
+        assertThat(result)
+                .as("Failed type: %s, expected subtype: %s", type.get(), expectedSubtype)
+                .isInstanceOf(expectedSubtype);
+
+        assertThat(result.size()).isEqualTo(size);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/net/GuavaHostAndPortTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/net/GuavaHostAndPortTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.net;
+
+import com.google.common.net.HostAndPort;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaHostAndPortTest {
+
+    private static final String IP4_REGEX = "\\d{1,3}\\.\\d{1,3}.\\d{1,3}.\\d{1,3}";
+
+    @Test
+    void create() {
+        final HostAndPort result = Instancio.create(HostAndPort.class);
+
+        assertThat(result.getHost()).matches(IP4_REGEX);
+        assertThat(result.getPort()).isBetween(0, 65535);
+    }
+}

--- a/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/net/GuavaInternetDomainNameTest.java
+++ b/instancio-tests/instancio-guava-tests/src/test/java/org/instancio/test/guava/net/GuavaInternetDomainNameTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.guava.net;
+
+import com.google.common.net.InternetDomainName;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class GuavaInternetDomainNameTest {
+
+    private static final String DOMAIN_NAME_REGEX = "[a-z]{2,10}\\.[a-z]{2,3}";
+
+    @RepeatedTest(100)
+    void create() {
+        final InternetDomainName result = Instancio.create(InternetDomainName.class);
+
+        assertThat(result.toString()).matches(DOMAIN_NAME_REGEX);
+    }
+}

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -31,6 +31,7 @@
         <module>instancio-core-tests</module>
         <module>instancio-junit-tests</module>
         <module>instancio-processor-tests</module>
+        <module>instancio-guava-tests</module>
         <module>feature-tests</module>
         <module>default-package-tests</module>
         <module>global-seed-tests</module>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
+            <artifactId>instancio-guava</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
             <artifactId>instancio-core-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -59,6 +64,12 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-processor-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-guava-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
             ${maven.multiModuleProjectDirectory}/instancio-tests/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <latest.release.version>2.12.1</latest.release.version>
+        <version.guava>31.1-jre</version.guava>
         <version.jakarta.validation>3.0.2</version.jakarta.validation>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.hibernate.validator>8.0.0.Final</version.hibernate.validator>
@@ -74,6 +75,7 @@
         <module>instancio-core</module>
         <module>instancio-junit</module>
         <module>instancio-processor</module>
+        <module>instancio-guava</module>
         <module>instancio-tests</module>
     </modules>
 
@@ -84,6 +86,7 @@
                 <module>instancio-core</module>
                 <module>instancio-junit</module>
                 <module>instancio-processor</module>
+                <module>instancio-guava</module>
             </modules>
             <build>
                 <plugins>


### PR DESCRIPTION
`instancio-guava` module that provides (experimental) support for Guava. Using the Guava module requires the following dependecies on the classpath:

- `instancio-core` **or** `instancio-junit`
- `com.google.guava:guava` (supported versions: `23.1-jre` or higher)

The `instancio-guava` module is packaged as a `jar` (usage in an OSGi container is currently not supported).

- JPMS module name `org.instancio.guava`.
- Supported classes listed below.
- Minimal generator specs (to specify size) are available for tables and multimaps, e.g.

```java
class GuavaPojo {
    Table<String, Character, Integer> table;
    Multimap<Integer, Long> multimap;
    // snip...
}

GuavaPojo result = Instancio.of(GuavaPojo.class)
    .generate(field(GuavaPojo::getTable), GenGuava.table().minSize(1).maxSize(3))
    .generate(field(GuavaPojo::getMultimap), GenGuava.multimap().size(10))
    .create();

assertThat(result.getTable().size()).isBetween(1, 3);
assertThat(result.getMultimap().size()).isEqualTo(10);
```


### Collections

- [x] ArrayListMultimap
- [x] BiMap
- [x] HashBiMap
- [x] HashMultimap
- [x] HashMultiset
- [x] ImmutableBiMap
- [x] ImmutableList
- [x] ImmutableListMultimap
- [x] ImmutableMap
- [x] ImmutableMultimap
- [x] ImmutableMultiset
- [x] ImmutableSet
- [x] ImmutableSetMultimap
- [x] ImmutableSortedMap
- [x] ImmutableSortedMultiset
- [x] ImmutableSortedSet
- [x] ImmutableTable
- [x] LinkedHashMultimap
- [x] LinkedHashMultiset
- [x] LinkedListMultimap
- [x] ListMultimap
- [x] Multiset
- [x] Range
- [x] SetMultimap
- [x] SortedMultiset
- [x] SortedSetMultimap
- [x] Table
- [x] TreeMultimap
- [x] TreeMultiset
- [x] ConcurrentHashMultiset

### Net

- [x] HostAndPort
- [x] InternetDomainName

