### PR TITLE
Fix sonar workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build"
+name: 'Build'
 on:
   push:
     branches:
@@ -8,33 +8,41 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
+      - uses: actions/checkout@v3
 
-      - name: "Cache Maven packages"
-        uses: actions/cache@v2
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: "Cache SonarCloud packages"
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: "Build and analyse with JDK 17"
-        uses: actions/setup-java@v1
-        with:
+          distribution: temurin
           java-version: 17
-      - run: mvn -v && mvn -B clean install sonar:sonar -Dsonar.projectKey=instancio_instancio
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          cache: maven
+
+      - name: 'Build project'
+        run: mvn -v && mvn -B clean install
+
+      - name: 'Prepare target artifact'
+        run: |
+          find -iname "*target" -type d -exec tar -rf target.tar {} \+
+          zstd -q -T0 target.tar
+
+      - name: 'Upload target artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: target-artifact
+          path: target.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: 'Prepare repository artifact'
+        run: |
+          cd ~/.m2/repository/org
+          tar --zstd -cf repository.tar.zst instancio
+
+      - name: 'Upload repository artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: repository-artifact
+          path: ~/.m2/repository/org/repository.tar.zst
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,105 @@
+name: 'Sonar'
+on:
+  workflow_run:
+    workflows: [ Build ]
+    types:
+      - completed
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: write
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of Sonar analysis
+
+      - name: 'Download target artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "target-artifact"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/target-artifact.zip`, Buffer.from(download.data));
+            await github.rest.actions.deleteArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+            });
+
+      - name: 'Download repository artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "repository-artifact"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/repository-artifact.zip`, Buffer.from(download.data));
+            await github.rest.actions.deleteArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+            });
+
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: 'Extract artifacts'
+        run: |
+          unzip target-artifact.zip
+          tar -xf target.tar.zst
+          unzip repository-artifact.zip
+          rm -rf ~/.m2/repository/org/instancio
+          mkdir -p ~/.m2/repository/org
+          tar -xf repository.tar.zst -C ~/.m2/repository/org
+
+      - name: 'Cache SonarCloud packages'
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: 'Sonar analysis'
+        run: >
+          mvn -B sonar:sonar -Dsonar.projectKey=instancio_instancio
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }} 
+          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }} 
+          -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Ok this is it, I can feel it :D

I made the following improvements from the previous attempt: 

- Uploading every target directory instead of just the test coverage. It's a zstandard compressed archive to save storage space, it cuts down almost 90% of the size this way.
- Installing every module in the local maven repository. I personally tested that even with the .class files sonar still complains about the lack of modules installed inside the .m2 folder. I don't know if it's a deal breaker for the analysis but to be extra safe about it i installed every module to shut it up. It should be safe to do so because no maven life cycle is started, it's just an explicit goal invocation of a very precise plugin. It shouldn't be possible to sneak some malicious plugin this way.
- Deleting the artifact after downloading it. This should avoid an unnecessary clutter of the storage space.
- This time i actually tested it in my forked environment lol https://github.com/EvaristeGalois11/instancio/actions It seems to reach the SONAR_TOKEN problem without any other weird errors