### PR TITLE
Exclude `byte-buddy` from `junit-platform-testkit`.

### DIFF
--- a/instancio-tests/instancio-junit-tests/pom.xml
+++ b/instancio-tests/instancio-junit-tests/pom.xml
@@ -34,6 +34,12 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-testkit</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
AssertJ has a dependency on a different version of `byte-buddy`. This resolves Maven enforcer dependency convergence error.