### PR TITLE
Add generics capabilities to InstancioSource annotation

### DIFF
--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
@@ -17,6 +17,11 @@ package org.instancio.junit;
 
 import org.junit.jupiter.params.ParameterizedTest;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class InstancioSourceTest {
@@ -42,6 +47,28 @@ class InstancioSourceTest {
         assertThat(second.bar).isNotBlank();
     }
 
+    @InstancioSource
+    @ParameterizedTest
+    void list(final List<String> list) {
+        assertThat(list).isNotEmpty().allSatisfy(s -> assertThat(s).isNotBlank());
+    }
+
+    @InstancioSource
+    @ParameterizedTest
+    void map(final Map<String, Integer> map) {
+        assertThat(map).isNotEmpty();
+        assertThat(map.keySet()).allSatisfy(s -> assertThat(s).isNotBlank());
+        assertThat(map.values()).allSatisfy(i -> assertThat(i).isNotZero());
+    }
+
+    @InstancioSource
+    @ParameterizedTest
+    void customGeneric(final Generic<String, UUID> arg) {
+        assertThat(arg).isNotNull();
+        assertThat(arg.first).isNotBlank();
+        assertThat(arg.second).isNotEmpty().doesNotContainNull();
+    }
+
     static class First {
         String foo;
 
@@ -55,6 +82,19 @@ class InstancioSourceTest {
 
         void setBar(final String bar) {
             this.bar = bar;
+        }
+    }
+
+    static class Generic<T, E> {
+        T first;
+        List<E> second;
+
+        public void setFirst(final T first) {
+            this.first = first;
+        }
+
+        public void setSecond(final List<E> second) {
+            this.second = second;
         }
     }
 }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2307,6 +2307,3 @@ It should be noted that using `@InstancioSource` has a couple of important limit
 The biggest limitation is that the generated objects cannot be customised.
 The only option is to customise generated values using [settings injection](#settings-injection).
 However, it is not possible to customise values on a per-field basis, as you would with the builder API.
-
-The second limitation is that it does not support parameterized types.
-For instance, it is not possible to specify that `@InstancioSource(List.class)` should be of type `List<String>`.


### PR DESCRIPTION
I really like the `@InstancioSource` annotation, but not supporting generics was a big limitation for me.

It turns out that all the right pieces were already there, I just rewired a bit the `ArgumentsProvider` :D