### PR TITLE
Refactor Luhn generator

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/CreditCardNumberGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/CreditCardNumberGenerator.java
@@ -70,11 +70,8 @@ public class CreditCardNumberGenerator extends AbstractGenerator<String>
                 : cardType;
 
         final String prefix = random.oneOf(type.getPrefixes()).toString();
-        final int lengthWithoutCheckDigit = type.getLength() - prefix.length();
+        final int lengthWithoutCheckDigit = type.getLength() - prefix.length() - 1;
         final String withoutCheckDigit = prefix + random.digits(lengthWithoutCheckDigit);
-        final char[] payload = withoutCheckDigit.toCharArray();
-        final int checkDigit = LuhnUtils.getCheckDigit(payload);
-        payload[payload.length - 1] = (char) (checkDigit + '0');
-        return new String(payload);
+        return withoutCheckDigit + LuhnUtils.getCheckDigit(withoutCheckDigit);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/LuhnGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/LuhnGenerator.java
@@ -99,26 +99,19 @@ public class LuhnGenerator extends AbstractGenerator<String>
         final int size = random.intRange(minSize, maxSize);
         final int start = Math.max(0, startIndex);
         final int end = endIndex == -1 ? size - 1 : endIndex;
-        final int actualSize = Math.max(size, endIndex);
         final int check = checkDigitIndex == -1 ? end : checkDigitIndex;
-        final int payloadSize = end - start + 1;
+        final int actualEnd = end == check ? end - 1 : end;
+        final int actualSize = Math.max(Math.max(size, actualEnd + 1), check + 1);
+        final int payloadSize = actualEnd - start + 1;
         final String digits = random.digits(payloadSize);
-        final char[] payloadChars = digits.toCharArray();
-        final int checkDigit = LuhnUtils.getCheckDigit(payloadChars);
+        final int checkDigit = LuhnUtils.getCheckDigit(digits);
 
-        String result = new String(payloadChars);
-
-        if (start > 0) {
-            final String prefix = random.digits(start);
-            result = prefix + result;
-        }
-        if (end < actualSize) {
-            final String suffix = random.digits(actualSize - end - 1);
-            result += suffix;
-        }
-
-        final char[] resultChars = result.toCharArray();
-        resultChars[check] = (char) (checkDigit + '0');
-        return new String(resultChars);
+        final StringBuilder result = new StringBuilder(digits);
+        final String prefix = random.digits(start);
+        result.insert(0, prefix);
+        final String suffix = random.digits(actualSize - result.length());
+        result.append(suffix);
+        result.setCharAt(check, (char) (checkDigit + '0'));
+        return result.toString();
     }
 }

--- a/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckAndLengthBV.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckAndLengthBV.java
@@ -47,12 +47,25 @@ public class LuhnCheckAndLengthBV {
     public static class WithStartEndAndCheckDigitIndices {
         @NotNull
         @Length(min = 17)
-        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 7)
+        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 8)
         private String value0;
 
         @NotNull
         @Length(max = 20) // min = 0
         @LuhnCheck(startIndex = 5, endIndex = 10, checkDigitIndex = 3)
+        private String value1;
+    }
+
+    @Data
+    public static class WithEndAndCheckDigitIndicesEqual {
+        @NotNull
+        @Length(min = 17)
+        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 7)
+        private String value0;
+
+        @NotNull
+        @Length(max = 20) // min = 0
+        @LuhnCheck(startIndex = 5, endIndex = 10, checkDigitIndex = 10)
         private String value1;
     }
 }

--- a/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckBV.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/main/java/org/instancio/test/pojo/beanvalidation/LuhnCheckBV.java
@@ -40,11 +40,23 @@ public class LuhnCheckBV {
 
     @Data
     public static class WithStartEndAndCheckDigitIndices {
-        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 7)
+        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 8)
         private String value0;
         @LuhnCheck(startIndex = 5, endIndex = 10, checkDigitIndex = 3)
         private String value1;
         @LuhnCheck(startIndex = 1, endIndex = 21, checkDigitIndex = 0)
+        private String value2;
+        @LuhnCheck(startIndex = 100, endIndex = 105, checkDigitIndex = 150)
+        private String value3;
+    }
+
+    @Data
+    public static class WithEndAndCheckDigitIndicesEqual {
+        @LuhnCheck(startIndex = 0, endIndex = 7, checkDigitIndex = 7)
+        private String value0;
+        @LuhnCheck(startIndex = 5, endIndex = 10, checkDigitIndex = 10)
+        private String value1;
+        @LuhnCheck(startIndex = 1, endIndex = 21, checkDigitIndex = 21)
         private String value2;
         @LuhnCheck(startIndex = 100, endIndex = 105, checkDigitIndex = 105)
         private String value3;

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckAndLengthBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckAndLengthBVTest.java
@@ -20,6 +20,7 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckAndLengthBV.WithDefaults;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckAndLengthBV.WithStartEndAndCheckDigitIndices;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckAndLengthBV.WithStartEndIndices;
+import org.instancio.test.pojo.beanvalidation.LuhnCheckAndLengthBV.WithEndAndCheckDigitIndicesEqual;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.util.HibernateValidatorUtil;
@@ -61,11 +62,23 @@ class LuhnCheckAndLengthBVTest {
         });
     }
 
-    // TODO broken test
     @Test
-    @Disabled("FIXME")
     void withStartEndAndCheckDigitIndices() {
         final Stream<WithStartEndAndCheckDigitIndices> results = Instancio.of(WithStartEndAndCheckDigitIndices.class)
+                .stream()
+                .limit(SAMPLE_SIZE_DDD);
+
+        assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(result -> {
+            HibernateValidatorUtil.assertValid(result);
+            assertThat(result.getValue0()).hasSizeBetween(17, 25);
+            assertThat(result.getValue1()).hasSizeBetween(11, 20);
+        });
+    }
+
+    @Disabled("https://hibernate.atlassian.net/browse/HV-1945")
+    @Test
+    void withEndAndCheckDigitIndicesEqual() {
+        final Stream<WithEndAndCheckDigitIndicesEqual> results = Instancio.of(WithEndAndCheckDigitIndicesEqual.class)
                 .stream()
                 .limit(SAMPLE_SIZE_DDD);
 

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckBVTest.java
@@ -19,6 +19,7 @@ import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithDefaults;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithStartEndAndCheckDigitIndices;
+import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithEndAndCheckDigitIndicesEqual;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithStartEndIndices;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -54,11 +55,19 @@ class LuhnCheckBVTest {
         assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
     }
 
-    // TODO broken test
     @Test
-    @Disabled("FIXME")
     void withStartEndAndCheckDigitIndices() {
         final Stream<WithStartEndAndCheckDigitIndices> results = Instancio.of(WithStartEndAndCheckDigitIndices.class)
+                .stream()
+                .limit(SAMPLE_SIZE_DDD);
+
+        assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+    }
+
+    @Disabled("https://hibernate.atlassian.net/browse/HV-1945")
+    @Test
+    void withEndAndCheckDigitIndicesEqual() {
+        final Stream<WithEndAndCheckDigitIndicesEqual> results = Instancio.of(WithEndAndCheckDigitIndicesEqual.class)
                 .stream()
                 .limit(SAMPLE_SIZE_DDD);
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/LuhnUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/LuhnUtilsTest.java
@@ -58,7 +58,7 @@ class LuhnUtilsTest {
 
     @Test
     void validWithIndexCheckDigitOutsidePayload() {
-        assertThat(LuhnUtils.isLuhnValid(1, 2, 3, "X677")).isTrue();
-        assertThat(LuhnUtils.isLuhnValid(2, 4, 0, "4X364XXX")).isTrue();
+        assertThat(LuhnUtils.isLuhnValid(1, 2, 3, "X679")).isTrue();
+        assertThat(LuhnUtils.isLuhnValid(2, 4, 0, "0X364XXX")).isTrue();
     }
 }


### PR DESCRIPTION
Fix #442 

Trying to fix the issue in question, I ended up rewriting the majority of the Luhn related stuff. I found the use of the check placeholder in the array very confusing for example. Furthermore the algorithm itself was wrong in fact I had to change the test `validWithIndexCheckDigitOutsidePayload` with the correct values. I checked with various online tool like this one https://planetcalc.com/2464/ to be sure that I was in fact in the right.

I open this PR in draft because I think I've found a bug in the Hibernate validator library: they allow `endIndex` and `checkDigitIndex` to be equal. I thought that this would mean that the check digit was in the `endIndex` position and the modulo 10 would be calculated until `endIndex - 1`. But debugging the `LuhnCheckValidator` class they seem to use the `endIndex` much more literally as both a digit to compute the modulo and the check digit itself. This to me seems like an error, because finding a correct sequence of number which their check digit is equal to the rightest digit seems a very difficult mathematical problem. I'll need to open an issue on their Jira to clarify this part, but I wanted to hear your thoughts first @armandino 

 