### PR TITLE
Support for specifying selector target depth.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/DepthPredicateSelector.java
+++ b/instancio-core/src/main/java/org/instancio/DepthPredicateSelector.java
@@ -15,11 +15,28 @@
  */
 package org.instancio;
 
+import org.instancio.documentation.ExperimentalApi;
+
+import java.util.function.Predicate;
+
 /**
- * A selector for matching targets using predicates.
+ * Allows specifying target depth using as a predicate.
  *
- * @see Select
- * @since 1.6.0
+ * @see DepthSelector
+ * @see PredicateSelector
+ * @since 2.14.0
  */
-public interface PredicateSelector extends TargetSelector, DepthSelector, DepthPredicateSelector {
+public interface DepthPredicateSelector {
+
+    /**
+     * Restricts this selector's target(s) to a depth
+     * that satisfies the given {@code predicate}.
+     *
+     * @param predicate specifying the depth
+     * @return selector restricted to the specified depth
+     * @since 2.14.0
+     */
+    @ExperimentalApi
+    TargetSelector atDepth(Predicate<Integer> predicate);
+
 }

--- a/instancio-core/src/main/java/org/instancio/DepthSelector.java
+++ b/instancio-core/src/main/java/org/instancio/DepthSelector.java
@@ -15,11 +15,25 @@
  */
 package org.instancio;
 
+import org.instancio.documentation.ExperimentalApi;
+
 /**
- * A selector for matching targets using predicates.
+ * Allows specifying target depth.
  *
- * @see Select
- * @since 1.6.0
+ * @see DepthPredicateSelector
+ * @see Selector
+ * @since 2.14.0
  */
-public interface PredicateSelector extends TargetSelector, DepthSelector, DepthPredicateSelector {
+public interface DepthSelector {
+
+    /**
+     * Restricts this selector's target(s) to the specified depth.
+     *
+     * @param depth the depth at which selector applies
+     * @return selector restricted to the specified depth
+     * @since 2.14.0
+     */
+    @ExperimentalApi
+    TargetSelector atDepth(int depth);
+
 }

--- a/instancio-core/src/main/java/org/instancio/FieldSelectorBuilder.java
+++ b/instancio-core/src/main/java/org/instancio/FieldSelectorBuilder.java
@@ -17,6 +17,7 @@ package org.instancio;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.TypeVariable;
+import java.util.function.Predicate;
 
 /**
  * A builder for constructing predicate-based field selectors.
@@ -36,7 +37,7 @@ import java.lang.reflect.TypeVariable;
  * @see TargetSelector
  * @since 1.6.0
  */
-public interface FieldSelectorBuilder extends TargetSelector {
+public interface FieldSelectorBuilder extends TargetSelector, DepthSelector, DepthPredicateSelector {
 
     /**
      * Matches fields with the specified name.
@@ -108,4 +109,20 @@ public interface FieldSelectorBuilder extends TargetSelector {
      * @since 1.6.0
      */
     <A extends Annotation> FieldSelectorBuilder annotated(Class<? extends A> annotation);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.14.0
+     */
+    @Override
+    TargetSelector atDepth(int depth);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.14.0
+     */
+    @Override
+    TargetSelector atDepth(Predicate<Integer> atDepth);
 }

--- a/instancio-core/src/main/java/org/instancio/Select.java
+++ b/instancio-core/src/main/java/org/instancio/Select.java
@@ -135,7 +135,7 @@ public final class Select {
      * @see #types(Predicate)
      * @since 1.6.0
      */
-    public static TargetSelector fields(final Predicate<Field> predicate) {
+    public static PredicateSelector fields(final Predicate<Field> predicate) {
         ApiValidator.notNull(predicate, "Field predicate must not be null");
         return PredicateSelectorImpl.builder().fieldPredicate(predicate).build();
     }
@@ -150,7 +150,7 @@ public final class Select {
      * @see #fields(Predicate)
      * @since 1.6.0
      */
-    public static TargetSelector types(final Predicate<Class<?>> predicate) {
+    public static PredicateSelector types(final Predicate<Class<?>> predicate) {
         ApiValidator.notNull(predicate, "Type predicate must not be null");
         return PredicateSelectorImpl.builder().typePredicate(predicate).build();
     }

--- a/instancio-core/src/main/java/org/instancio/Selector.java
+++ b/instancio-core/src/main/java/org/instancio/Selector.java
@@ -28,7 +28,7 @@ package org.instancio;
  * @see TargetSelector
  * @since 1.2.0
  */
-public interface Selector extends GroupableSelector, ConvertibleToScope {
+public interface Selector extends DepthSelector, GroupableSelector, ConvertibleToScope {
 
     /**
      * Specifies the scope for this selector in order to narrow down its target.

--- a/instancio-core/src/main/java/org/instancio/TypeSelectorBuilder.java
+++ b/instancio-core/src/main/java/org/instancio/TypeSelectorBuilder.java
@@ -16,6 +16,7 @@
 package org.instancio;
 
 import java.lang.annotation.Annotation;
+import java.util.function.Predicate;
 
 /**
  * A builder for constructing predicate-based type selectors.
@@ -36,7 +37,7 @@ import java.lang.annotation.Annotation;
  * @see TargetSelector
  * @since 1.6.0
  */
-public interface TypeSelectorBuilder extends TargetSelector {
+public interface TypeSelectorBuilder extends TargetSelector, DepthSelector, DepthPredicateSelector {
 
     /**
      * Matches specified type, including subtypes.
@@ -77,4 +78,19 @@ public interface TypeSelectorBuilder extends TargetSelector {
      */
     TypeSelectorBuilder excluding(Class<?> type);
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.14.0
+     */
+    @Override
+    TargetSelector atDepth(int depth);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 2.14.0
+     */
+    @Override
+    TargetSelector atDepth(Predicate<Integer> atDepth);
 }

--- a/instancio-core/src/main/java/org/instancio/generators/Generators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/Generators.java
@@ -327,8 +327,31 @@ public class Generators {
      *
      * <p><b>Warning:</b> using {@code emit()} with cyclic classes,
      * where instances of the same type are generated at different depths,
-     * may produce unexpected results. It might be possible to use
-     * {@link InstancioApi#withMaxDepth(int)} to limit the depth as a workaround.
+     * may produce unexpected results. In case of cyclic classes, use
+     * one of the following methods to limit the depth:
+     *
+     * <ul>
+     *   <li>{@link InstancioApi#withMaxDepth(int)} to limit
+     *       the overall depth, <b>or</b></li>
+     *   <li>{@code atDepth()} method provided by selectors (example below)</li>
+     * </ul>
+     *
+     * <p><b>Example:</b>
+     *
+     * <pre>{@code
+     *   // emit() order status values only at depth 2
+     *   //
+     *   // Depth 0: List (root object)
+     *   // Depth 1: Order class (list element)
+     *   // Depth 2: Order fields (including OrderStatus)
+     *   List<Order> orders = Instancio.ofList(Order.class)
+     *     .size(7)
+     *     .generate(field(Order::getStatus).atDepth(2), gen -> gen.emit()
+     *              .items(OrderStatus.RECEIVED, OrderStatus.SHIPPED)
+     *              .item(OrderStatus.COMPLETED, 3)
+     *              .item(OrderStatus.CANCELLED, 2))
+     *     .create();
+     * }</pre>
      *
      * @param <T> the type to emit
      * @return emitting generator

--- a/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiValidator.java
@@ -34,6 +34,7 @@ import static org.instancio.internal.ApiValidatorMessageHelper.withTypeParameter
 import static org.instancio.internal.ApiValidatorMessageHelper.withTypeParametersNonGenericClass;
 import static org.instancio.internal.ApiValidatorMessageHelper.withTypeParametersNumberOfParameters;
 
+@SuppressWarnings("PMD.GodClass")
 public final class ApiValidator {
 
     // Note: include nested generic class in the example as it's used as a validation message for this use case
@@ -93,7 +94,6 @@ public final class ApiValidator {
             }
         }
     }
-
 
     public static void validateSubtype(final Class<?> from, final Class<?> to) {
         isTrue(from.isAssignableFrom(to), () -> String.format(
@@ -200,9 +200,14 @@ public final class ApiValidator {
         if (condition) throw new InstancioApiException(message.get());
     }
 
+    public static int validateDepth(final int depth) {
+        if (depth < 0) throw new InstancioApiException("Depth must not be negative: " + depth);
+        return depth;
+    }
+
     public static void validateField(final Class<?> declaringClass, final String fieldName, final String message) {
-        ApiValidator.notNull(declaringClass, message);
-        ApiValidator.notNull(fieldName, message);
+        notNull(declaringClass, message);
+        notNull(fieldName, message);
         isTrue(ReflectionUtils.isValidField(declaringClass, fieldName), message);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorMap.java
@@ -261,6 +261,9 @@ final class SelectorMap<V> {
     }
 
     private static boolean selectorScopesMatchNodeHierarchy(final SelectorImpl candidate, final InternalNode targetNode) {
+        if (candidate.getDepth() != null && candidate.getDepth() != targetNode.getDepth()) {
+            return false;
+        }
         if (candidate.getScopes().isEmpty()) {
             return true;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/PredicateSelectorBuilderTemplate.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/PredicateSelectorBuilderTemplate.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.selectors;
+
+import org.instancio.DepthPredicateSelector;
+import org.instancio.DepthSelector;
+import org.instancio.PredicateSelector;
+import org.instancio.TargetSelector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+abstract class PredicateSelectorBuilderTemplate<T>
+        implements SelectorBuilder, DepthSelector, DepthPredicateSelector {
+
+    private final List<Predicate<T>> predicates = new ArrayList<>(3);
+    private final StringBuilder description = new StringBuilder(128);
+
+    PredicateSelectorBuilderTemplate() {
+        description.append(apiMethod());
+    }
+
+    protected abstract PredicateSelectorImpl.Builder createBuilder();
+
+    protected abstract String apiMethod();
+
+    protected final void addPredicate(Predicate<T> predicate) {
+        predicates.add(predicate);
+    }
+
+    protected final StringBuilder description() {
+        return description;
+    }
+
+    @Override
+    public final TargetSelector atDepth(final int depth) {
+        final PredicateSelectorImpl copy = (PredicateSelectorImpl) build();
+        return PredicateSelectorImpl.builder(copy)
+                .depth(depth)
+                .build();
+    }
+
+    @Override
+    public final TargetSelector atDepth(final Predicate<Integer> predicate) {
+        final PredicateSelectorImpl copy = (PredicateSelectorImpl) build();
+        return PredicateSelectorImpl.builder(copy)
+                .depth(predicate)
+                .build();
+    }
+
+    protected final Predicate<T> buildPredicate() {
+        Predicate<T> predicate = Objects::nonNull;
+        for (Predicate<T> p : predicates) {
+            predicate = predicate.and(p);
+        }
+        return predicate;
+    }
+
+    @Override
+    public final PredicateSelector build() {
+        return createBuilder()
+                .apiInvocationDescription(description.toString())
+                .build();
+    }
+
+    @Override
+    public final String toString() {
+        return description.toString();
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
@@ -19,6 +19,7 @@ import org.instancio.Scope;
 import org.instancio.Selector;
 import org.instancio.TargetSelector;
 import org.instancio.exception.InstancioApiException;
+import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Format;
 import org.jetbrains.annotations.NotNull;
 
@@ -66,6 +67,14 @@ public final class PrimitiveAndWrapperSelectorImpl implements Selector, Flattene
     }
 
     @Override
+    public TargetSelector atDepth(final int depth) {
+        ApiValidator.validateDepth(depth);
+        return new PrimitiveAndWrapperSelectorImpl(
+                SelectorImpl.builder(primitive).depth(depth).build(),
+                SelectorImpl.builder(wrapper).depth(depth).build());
+    }
+
+    @Override
     public List<TargetSelector> flatten() {
         return Arrays.asList(primitive, wrapper);
     }
@@ -99,8 +108,12 @@ public final class PrimitiveAndWrapperSelectorImpl implements Selector, Flattene
     @Override
     public String toString() {
         String str = API_METHOD_NAMES.get(primitive.getTargetClass());
+
+        // can have either scopes or depth, but not both
         if (!primitive.getScopes().isEmpty()) {
             str += ", " + Format.formatScopes(primitive.getScopes());
+        } else if (primitive.getDepth() != null) {
+            str += ".atDepth(" + primitive.getDepth() + ")";
         }
         return str;
     }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorDepth.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorDepth.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.selectors;
+
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.nodes.InternalNode;
+import org.instancio.internal.util.Sonar;
+
+import java.util.function.Predicate;
+
+/**
+ * For predicate selectors, depth can be specified as an {@code int}
+ * or a {@code Predicate<Integer>}. This class hides the details
+ * of how depth was specified.
+ */
+final class SelectorDepth {
+
+    private final Integer depth;
+    private final Predicate<InternalNode> depthPredicate;
+
+    SelectorDepth(final int depth) {
+        this.depth = ApiValidator.validateDepth(depth);
+        this.depthPredicate = toNodePredicate(d -> d == depth);
+    }
+
+    SelectorDepth(final Predicate<Integer> depthPredicate) {
+        ApiValidator.notNull(depthPredicate, "Selector depth predicate must not be null");
+        this.depth = null; // NOPMD
+        this.depthPredicate = toNodePredicate(depthPredicate);
+    }
+
+    @SuppressWarnings(Sonar.FUNCTIONAL_INTERFACES_SHOULD_BE_SPECIALISED)
+    private static Predicate<InternalNode> toNodePredicate(final Predicate<Integer> p) {
+        return n -> p.test(n.getDepth());
+    }
+
+    Integer getDepth() {
+        return depth;
+    }
+
+    Predicate<InternalNode> getDepthPredicate() {
+        return depthPredicate;
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
@@ -31,6 +31,7 @@ public final class Sonar {
     public static final String ONE_METHOD_WHEN_TESTING_EXCEPTIONS = "java:S5778";
     public static final String STRING_LITERALS_DUPLICATED = "java:S1192";
     public static final String USE_INSTANCEOF = "java:S1872";
+    public static final String FUNCTIONAL_INTERFACES_SHOULD_BE_SPECIALISED = "java:S4276";
 
     private Sonar() {
         // non-instantiable

--- a/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_RootSelectorDoesNotSupportAtDepth.java
+++ b/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_RootSelectorDoesNotSupportAtDepth.java
@@ -1,0 +1,9 @@
+import org.instancio.*;
+
+class NonCompilable_RootSelectorDoesNotSupportAtDepth {
+
+    void nonCompilable() {
+        // Root selector does not support atDepth() method
+        Select.root().atDepth(1);
+    }
+}

--- a/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_SelectorGroupDoesNotSupportAtDepth.java
+++ b/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_SelectorGroupDoesNotSupportAtDepth.java
@@ -1,0 +1,9 @@
+import org.instancio.*;
+
+class NonCompilable_SelectorGroupDoesNotSupportAtDepth {
+
+    void nonCompilable() {
+        // Group does not support atDepth() method
+        Select.all(Select.allStrings()).atDepth(1);
+    }
+}

--- a/instancio-tests/api-contract-tests/src/test/java/org/instancio/test/contract/SelectorApiContractTest.java
+++ b/instancio-tests/api-contract-tests/src/test/java/org/instancio/test/contract/SelectorApiContractTest.java
@@ -123,14 +123,14 @@ class SelectorApiContractTest {
     @DisplayName("Cannot group predicate field selectors")
     void cannotGroupPredicateFieldSelectors() throws Exception {
         assertCompilationError("NonCompilable_GroupWithPredicateFieldSelector.java",
-                "no suitable method found for all(org.instancio.TargetSelector)");
+                "no suitable method found for all(org.instancio.PredicateSelector)");
     }
 
     @Test
     @DisplayName("Cannot group predicate type selectors")
     void cannotGroupPredicateTypeSelectors() throws Exception {
         assertCompilationError("NonCompilable_GroupWithPredicateTypeSelector.java",
-                "no suitable method found for all(org.instancio.TargetSelector)");
+                "no suitable method found for all(org.instancio.PredicateSelector)");
     }
 
     @Test
@@ -187,6 +187,20 @@ class SelectorApiContractTest {
     void typesPredicateBuilderShouldNotExposeBuildMethod() throws Exception {
         assertCompilationError("NonCompilable_TypesPredicateBuilderBuildMethod.java",
                 "cannot find symbol", "method build()");
+    }
+
+    @Test
+    @DisplayName("GroupableSelector should not expose atDepth() method")
+    void groupableSelectorShouldNotExposeAtDepthMethod() throws Exception {
+        assertCompilationError("NonCompilable_SelectorGroupDoesNotSupportAtDepth.java",
+                "cannot find symbol", "method atDepth");
+    }
+
+    @Test
+    @DisplayName("Root selector should not expose atDepth() method")
+    void rootSelectorShouldNotExposeAtDepthMethod() throws Exception {
+        assertCompilationError("NonCompilable_RootSelectorDoesNotSupportAtDepth.java",
+                "cannot find symbol", "method atDepth");
     }
 
     @Test

--- a/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/TerminalSelectorMethodsTest.java
+++ b/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/TerminalSelectorMethodsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.contract;
+
+import org.instancio.FieldSelectorBuilder;
+import org.instancio.TargetSelector;
+import org.instancio.TypeSelectorBuilder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+class TerminalSelectorMethodsTest {
+
+    /**
+     * {@code atDepth()} should be a terminal method.
+     */
+    @ValueSource(classes = {
+            FieldSelectorBuilder.class,
+            TypeSelectorBuilder.class
+    })
+    @ParameterizedTest
+    void atDepth(final Class<?> klass) {
+        methods().that().areDeclaredIn(klass)
+                .and().haveName("atDepth")
+                .should().haveRawReturnType(TargetSelector.class);
+    }
+
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorCyclicPojoTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorCyclicPojoTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.misc;
+
+import org.instancio.Instancio;
+import org.instancio.TargetSelector;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.cyclic.onetomany.DetailRecord;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.types;
+
+@FeatureTag({
+        Feature.GENERATOR,
+        Feature.EMIT_GENERATOR,
+        Feature.CYCLIC,
+        Feature.SELECTOR,
+        Feature.DEPTH_SELECTOR,
+        Feature.PREDICATE_SELECTOR
+})
+@ExtendWith(InstancioExtension.class)
+class EmitGeneratorCyclicPojoTest {
+
+    @Test
+    void emitCollectionElementField() {
+        final MainRecord result = Instancio.of(MainRecord.class)
+                .generate(all(List.class), gen -> gen.collection().size(3))
+                .generate(field(DetailRecord::getId), gen -> gen.emit().items(1L, 2L, 3L))
+                .create();
+
+        assertThat(result.getDetailRecords())
+                .extracting(DetailRecord::getId)
+                .containsExactly(1L, 2L, 3L);
+    }
+
+    @MethodSource("statusSelectors")
+    @ParameterizedTest
+    void listOfOrdersWithExpectedStatuses(final TargetSelector selector) {
+        final OrderStatus[] statuses = {
+                OrderStatus.SUBMITTED, OrderStatus.SUBMITTED,
+                OrderStatus.SHIPPED, OrderStatus.SHIPPED,
+                OrderStatus.DELIVERED, OrderStatus.DELIVERED
+        };
+
+        final List<Order> result = Instancio.ofList(Order.class)
+                .size(statuses.length)
+                .generate(selector, gen -> gen.emit().items(statuses))
+                .create();
+
+        assertThat(result)
+                .extracting(o -> o.status)
+                .containsExactly(statuses);
+    }
+
+    private static Stream<Arguments> statusSelectors() {
+        final int depth = 2;
+        final Predicate<Integer> predicate = d -> d == depth;
+        return Stream.of(
+                // regular and predicate selectors: depth as an integer
+                Arguments.of(all(OrderStatus.class).atDepth(depth)),
+                Arguments.of(field(Order::getStatus).atDepth(depth)),
+                Arguments.of(field(Order.class, "status").atDepth(depth)),
+                Arguments.of(fields(f -> f.getType() == OrderStatus.class).atDepth(depth)),
+                Arguments.of(types(t -> t == OrderStatus.class).atDepth(depth)),
+
+                // predicate selectors: depth as a predicate
+                Arguments.of(fields(f -> f.getType() == OrderStatus.class).atDepth(predicate)),
+                Arguments.of(types(t -> t == OrderStatus.class).atDepth(predicate)),
+
+                // predicate selector builders: depth as a predicate
+                Arguments.of(fields().ofType(OrderStatus.class).atDepth(predicate)),
+                Arguments.of(types().of(OrderStatus.class).atDepth(predicate))
+        );
+    }
+
+    // used via reflection
+    @SuppressWarnings("unused")
+    private static class Order {
+        private List<OrderItem> items;
+        private OrderStatus status;
+
+        OrderStatus getStatus() {
+            return status;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static class OrderItem {
+        private Order order;
+    }
+
+    private enum OrderStatus {
+        SHIPPED, DELIVERED, SUBMITTED
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
@@ -21,8 +21,6 @@ import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 import org.instancio.test.support.pojo.basic.IntegerHolder;
-import org.instancio.test.support.pojo.cyclic.onetomany.DetailRecord;
-import org.instancio.test.support.pojo.cyclic.onetomany.MainRecord;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +35,6 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.all;
-import static org.instancio.Select.field;
 import static org.instancio.Select.root;
 
 @FeatureTag({Feature.GENERATOR, Feature.EMIT_GENERATOR})
@@ -79,18 +76,6 @@ class EmitGeneratorTest {
                 .create();
 
         assertThat(result).containsExactly((byte) 1, 2, 3L, 4f, 5d);
-    }
-
-    @Test
-    void emitCollectionElementField() {
-        final MainRecord result = Instancio.of(MainRecord.class)
-                .generate(all(List.class), gen -> gen.collection().size(3))
-                .generate(field(DetailRecord::getId), gen -> gen.emit().items(1L, 2L, 3L))
-                .create();
-
-        assertThat(result.getDetailRecords())
-                .extracting(DetailRecord::getId)
-                .containsExactly(1L, 2L, 3L);
     }
 
     @Test

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
@@ -63,7 +63,7 @@ class CustomPredicateNodeSelectorTest {
         private static final int PRIORITY = Integer.MAX_VALUE; // lowest priority
 
         AddressStringSelector(final Predicate<InternalNode> nodePredicate, final String apiInvocationDescription) {
-            super(PRIORITY, nodePredicate, apiInvocationDescription, new Throwable());
+            super(PRIORITY, nodePredicate, /* depth = */ null, apiInvocationDescription, new Throwable());
         }
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/DepthSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/DepthSelectorTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.selector;
+
+import org.instancio.Instancio;
+import org.instancio.TargetSelector;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.allInts;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.types;
+
+/**
+ * Verifies using {@code atDepth()} with:
+ *
+ * <ul>
+ *   <li>regular class selector</li>
+ *   <li>primitive/wrapper selector</li>
+ *   <li>predicate type selector</li>
+ *   <li>predicate field selector builder</li>
+ *   <li>predicate type selector builder</li>
+ * </ul>
+ */
+@FeatureTag({Feature.PREDICATE_SELECTOR, Feature.SELECTOR, Feature.DEPTH_SELECTOR})
+@ExtendWith(InstancioExtension.class)
+class DepthSelectorTest {
+
+    private static final Integer EXPECTED = -12345;
+
+    private static Stream<Arguments> depth1Selectors() {
+        final int depth = 1;
+        final Predicate<Integer> predicate = d -> d == depth;
+        return Stream.of(
+                Arguments.of(all(Integer.class).atDepth(depth)),
+                Arguments.of(allInts().atDepth(depth)),
+                Arguments.of(field(Pojo0::getVal).atDepth(depth)),
+                Arguments.of(fields().ofType(Integer.class).atDepth(depth)),
+                Arguments.of(types(t -> t == Integer.class).atDepth(depth)),
+
+                // predicate depth
+                Arguments.of(fields(f -> f.getType() == Integer.class).atDepth(predicate)),
+                Arguments.of(fields().ofType(Integer.class).atDepth(predicate)),
+                Arguments.of(types().of(Integer.class).atDepth(predicate))
+        );
+    }
+
+    private static Stream<Arguments> depthGreaterThanOneSelectors() {
+        final Predicate<Integer> predicate = d -> d > 1;
+        return Stream.of(
+                Arguments.of(types(t -> t == Integer.class).atDepth(predicate)),
+                Arguments.of(fields(f -> f.getType() == Integer.class).atDepth(predicate)),
+                Arguments.of(fields().ofType(Integer.class).atDepth(predicate)),
+                Arguments.of(types().of(Integer.class).atDepth(predicate))
+        );
+    }
+
+    @MethodSource("depth1Selectors")
+    @ParameterizedTest
+    void depth1(final TargetSelector selector) {
+        final Pojo0 result = Instancio.of(Pojo0.class)
+                .set(selector, EXPECTED)
+                .create();
+
+        assertThat(result.val).isEqualTo(EXPECTED);
+        assertThat(result.pojo1.val).isNotEqualTo(EXPECTED);
+        assertThat(result.pojo1.pojo2.val).isNotEqualTo(EXPECTED);
+        assertThat(result.pojo1.pojo2.pojo3.val).isNotEqualTo(EXPECTED);
+    }
+
+    @MethodSource("depthGreaterThanOneSelectors")
+    @ParameterizedTest
+    void depthGreaterThanOne(final TargetSelector selector) {
+        final Pojo0 result = Instancio.of(Pojo0.class)
+                .set(selector, EXPECTED)
+                .create();
+
+        assertThat(result.val).isNotEqualTo(EXPECTED);
+        assertThat(result.pojo1.val).isEqualTo(EXPECTED);
+        assertThat(result.pojo1.pojo2.val).isEqualTo(EXPECTED);
+        assertThat(result.pojo1.pojo2.pojo3.val).isEqualTo(EXPECTED);
+    }
+
+    @Test
+    void depthZeroShouldTargetTheRoot() {
+        final List<Pojo0> result = Instancio.ofList(Pojo0.class)
+                .set(all(List.class).atDepth(0), null)
+                .create();
+
+        assertThat(result).isNull();
+    }
+
+    @Nested
+    class DepthSelectorPrecedenceTest {
+
+        @Test
+        void differentValuePerDepthWithRegularSelectors() {
+            final Pojo0 result = Instancio.of(Pojo0.class)
+                    .set(allInts().atDepth(3), 3)
+                    .set(allInts().atDepth(4), 4)
+                    .set(allInts().atDepth(1), 1)
+                    .set(allInts().atDepth(2), 2)
+                    .create();
+
+            assertThat(result.val).isEqualTo(1);
+            assertThat(result.pojo1.val).isEqualTo(2);
+            assertThat(result.pojo1.pojo2.val).isEqualTo(3);
+            assertThat(result.pojo1.pojo2.pojo3.val).isEqualTo(4);
+        }
+
+        @Test
+        void differentValuePerDepthWithPredicateSelectors() {
+            final Pojo0 result = Instancio.of(Pojo0.class)
+                    .set(types().of(Integer.class).atDepth(3), 3)
+                    .set(types().of(Integer.class).atDepth(4), 4)
+                    .set(types().of(Integer.class).atDepth(1), 1)
+                    .set(types().of(Integer.class).atDepth(2), 2)
+                    .create();
+
+            assertThat(result.val).isEqualTo(1);
+            assertThat(result.pojo1.val).isEqualTo(2);
+            assertThat(result.pojo1.pojo2.val).isEqualTo(3);
+            assertThat(result.pojo1.pojo2.pojo3.val).isEqualTo(4);
+        }
+
+        @Test
+        void lastSelectorWins1() {
+            final Pojo0 result = Instancio.of(Pojo0.class)
+                    .set(allInts(), 1)
+                    .set(allInts().atDepth(3), 3)
+                    .create();
+
+            assertThat(result.val).isEqualTo(1);
+            assertThat(result.pojo1.val).isEqualTo(1);
+            assertThat(result.pojo1.pojo2.val).isEqualTo(3);
+            assertThat(result.pojo1.pojo2.pojo3.val).isEqualTo(1);
+        }
+
+        @Test
+        void lastSelectorWins2() {
+            final Pojo0 result = Instancio.of(Pojo0.class)
+                    .set(allInts().atDepth(3), 3) // unused selector, since allInts() wins
+                    .set(allInts(), 1)
+                    .lenient()
+                    .create();
+
+            assertThat(result.val).isEqualTo(1);
+            assertThat(result.pojo1.val).isEqualTo(1);
+            assertThat(result.pojo1.pojo2.val).isEqualTo(1);
+            assertThat(result.pojo1.pojo2.pojo3.val).isEqualTo(1);
+        }
+    }
+
+    private static class Pojo0 {
+        private Integer val;
+        private Pojo1 pojo1;
+
+        Integer getVal() {
+            return val;
+        }
+    }
+
+    private static class Pojo1 {
+        private Integer val;
+        private Pojo2 pojo2;
+    }
+
+    private static class Pojo2 {
+        private Integer val;
+        private Pojo3 pojo3;
+    }
+
+    private static class Pojo3 {
+        private Integer val;
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/DepthSelectorWithIgnoreTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/DepthSelectorWithIgnoreTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.selector;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.cyclic.ClassesABCWithCrossReferences;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.fields;
+import static org.instancio.test.support.asserts.Asserts.assertAllNulls;
+
+@FeatureTag({
+        Feature.PREDICATE_SELECTOR,
+        Feature.SELECTOR,
+        Feature.DEPTH_SELECTOR,
+        Feature.IGNORE
+})
+@ExtendWith(InstancioExtension.class)
+class DepthSelectorWithIgnoreTest {
+
+    @Test
+    void classWithCrossReferences() {
+        final ClassesABCWithCrossReferences result = Instancio.of(ClassesABCWithCrossReferences.class)
+                .ignore(fields().matching("object.*").atDepth(d -> d > 1))
+                .create();
+
+        assertThat(result).hasNoNullFieldsOrProperties();
+        assertAllNulls(
+                // A
+                result.getObjectA().getObjectA(),
+                result.getObjectA().getObjectB(),
+                result.getObjectA().getObjectC(),
+                // B
+                result.getObjectB().getObjectA(),
+                result.getObjectB().getObjectB(),
+                result.getObjectB().getObjectC(),
+                // C
+                result.getObjectC().getObjectA(),
+                result.getObjectC().getObjectB(),
+                result.getObjectC().getObjectC()
+        );
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/support/UnusedSelectorsAssert.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/support/UnusedSelectorsAssert.java
@@ -149,8 +149,7 @@ public class UnusedSelectorsAssert extends ThrowableAssert<UnusedSelectorExcepti
 
     private static String extractUnusedSelectorsFromExceptionMessage(final String message) {
         // Remove everything after "possible causes" from the exception message.
-        // This is to prevent the selectors in the examples in the error message examples
-        // from being counted.
+        // This is to prevent examples selectors in the error message from being counted.
         return message.substring(0, message.indexOf("Possible causes"));
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/UnusedSelectorLocationWithDepthTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/other/test/features/mode/UnusedSelectorLocationWithDepthTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.other.test.features.mode;
+
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.TargetSelector;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.pojo.person.PersonName;
+import org.instancio.test.support.pojo.person.Pojo;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.UnusedSelectorsAssert.assertThrowsUnusedSelectorException;
+import static org.instancio.test.support.UnusedSelectorsAssert.line;
+
+@FeatureTag({Feature.MODE, Feature.PREDICATE_SELECTOR})
+class UnusedSelectorLocationWithDepthTest {
+
+    @Test
+    void unused() {
+        final TargetSelector timestampSelector = types().of(Timestamp.class).atDepth(1);
+        final InstancioApi<Person> api = Instancio.of(Person.class)
+                .withMaxDepth(0) // all selectors with greater depth are unused
+                .set(timestampSelector, null)
+                .ignore(types().annotated(Pojo.class).annotated(PersonName.class).atDepth(2))
+                .supply(fields().named("foo").atDepth(3), () -> fail("not called"))
+                .ignore(types(klass -> false).atDepth(o -> true))
+                .supply(fields(field -> false).atDepth(o -> true), () -> fail("not called"));
+
+        int l = 45;
+        assertThrowsUnusedSelectorException(api)
+                .hasUnusedSelectorCount(5)
+                .generatorSelector(timestampSelector, line(getClass(), 41)) // Special case: selector assigned to variable
+                .ignoreSelector(types().annotated(Pojo.class).annotated(PersonName.class).atDepth(2), line(getClass(), l++))
+                .generatorSelector(fields().named("foo").atDepth(3), line(getClass(), l++))
+                .ignoreSelector(types(klass -> false).atDepth(o -> true), line(getClass(), l++))
+                .generatorSelector(fields(field -> false).atDepth(o -> true), line(getClass(), l++));
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/FieldSelectorBuilderImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/FieldSelectorBuilderImplTest.java
@@ -24,6 +24,7 @@ import org.instancio.test.support.pojo.person.Person;
 import org.instancio.test.support.pojo.person.PersonName;
 import org.instancio.test.support.pojo.person.Pet;
 import org.instancio.test.support.pojo.person.Pojo;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -115,21 +116,45 @@ class FieldSelectorBuilderImplTest {
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("Field's declared annotation must not be null.")
                 .hasMessageContaining("Method invocation: fields().annotated( -> null <- )");
+
+        assertThatThrownBy(() -> selectorBuilder.atDepth(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("Depth must not be negative: -1");
     }
 
-    @Test
-    void verifyToString() {
-        final String result = selectorBuilder
-                .named("name")
-                .matching("regex")
-                .ofType(String.class)
-                .declaredIn(Person.class)
-                .annotated(Pojo.class)
-                .annotated(PersonName.class)
-                .toString();
+    @Nested
+    class ToStringTest {
+        @Test
+        void minimal() {
+            final String result = selectorBuilder.toString();
 
-        assertThat(result).isEqualTo("fields().named(\"name\").matching(\"regex\").ofType(String)" +
-                ".declaredIn(Person).annotated(Pojo).annotated(PersonName)");
+            assertThat(result).isEqualTo("fields()");
+        }
+
+        @Test
+        void predicateDepth() {
+            final String result = selectorBuilder
+                    .atDepth(d -> true)
+                    .toString();
+
+            assertThat(result).isEqualTo("fields().atDepth(Predicate<Integer>)");
+        }
+
+        @Test
+        void full() {
+            final String result = selectorBuilder
+                    .named("name")
+                    .matching("regex")
+                    .ofType(String.class)
+                    .declaredIn(Person.class)
+                    .annotated(Pojo.class)
+                    .annotated(PersonName.class)
+                    .atDepth(5)
+                    .toString();
+
+            assertThat(result).isEqualTo("fields().named(\"name\").matching(\"regex\").ofType(String)" +
+                    ".declaredIn(Person).annotated(Pojo).annotated(PersonName).atDepth(5)");
+        }
     }
 
     // Note: creates a minimal node for tests to pass (will throw an exception if toString() is called)

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImplTest.java
@@ -66,6 +66,9 @@ class PrimitiveAndWrapperSelectorImplTest {
         assertThat(Select.allLongs()).hasToString("allLongs()");
         assertThat(Select.allFloats()).hasToString("allFloats()");
         assertThat(Select.allDoubles()).hasToString("allDoubles()");
+
+        // with depth
+        assertThat(Select.allInts().atDepth(5)).hasToString("allInts().atDepth(5)");
     }
 
     @Test
@@ -83,5 +86,14 @@ class PrimitiveAndWrapperSelectorImplTest {
         assertThatThrownBy(selector::toScope)
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessage("Method 'toScope()' is not supported for selector 'allInts()'");
+    }
+
+    @Test
+    void depthValidation() {
+        final Selector selector = Select.allInts();
+
+        assertThatThrownBy(() -> selector.atDepth(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("Depth must not be negative: -1");
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
@@ -20,6 +20,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.instancio.Select;
 import org.instancio.Selector;
 import org.instancio.TargetSelector;
+import org.instancio.exception.InstancioApiException;
 import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.pojo.generics.foobarbaz.Foo;
 import org.instancio.test.support.pojo.person.Address;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.scope;
 
 class SelectorImplTest {
@@ -125,6 +127,9 @@ class SelectorImplTest {
         assertThat(Select.field(Person.class, "name"))
                 .hasToString("field(Person, \"name\")");
 
+        assertThat(Select.field(Phone.class, "number").atDepth(3))
+                .hasToString("field(Phone, \"number\").atDepth(3)");
+
         assertThat(Select.field(Phone.class, "number").within(scope(Address.class)))
                 .hasToString("field(Phone, \"number\"), scope(Address)");
 
@@ -133,5 +138,14 @@ class SelectorImplTest {
                 scope(Address.class)))
                 .hasToString(
                         "field(Phone, \"number\"), scope(Person, \"address\"), scope(Address)");
+    }
+
+    @Test
+    void depthValidation() {
+        final Selector selector = Select.field(Phone.class, "number");
+
+        assertThatThrownBy(() -> selector.atDepth(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("Depth must not be negative: -1");
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/TypeSelectorBuilderImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/TypeSelectorBuilderImplTest.java
@@ -26,6 +26,7 @@ import org.instancio.test.support.pojo.person.Person;
 import org.instancio.test.support.pojo.person.PersonName;
 import org.instancio.test.support.pojo.person.Phone;
 import org.instancio.test.support.pojo.person.Pojo;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -83,19 +84,44 @@ class TypeSelectorBuilderImplTest {
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("Excluded type must not be null.")
                 .hasMessageContaining("Method invocation: types().excluding( -> null <- )");
+
+        assertThatThrownBy(() -> selectorBuilder.atDepth(-1))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessage("Depth must not be negative: -1");
     }
 
-    @Test
-    void verifyToString() {
-        final String result = selectorBuilder
-                .of(Object.class)
-                .excluding(Foo.class)
-                .excluding(Bar.class)
-                .annotated(Pojo.class)
-                .annotated(PersonName.class)
-                .toString();
+    @Nested
+    class ToStringTest {
+        @Test
+        void minimal() {
+            final String result = selectorBuilder.toString();
 
-        assertThat(result).isEqualTo("types().of(Object).excluding(Foo).excluding(Bar).annotated(Pojo).annotated(PersonName)");
+            assertThat(result).isEqualTo("types()");
+        }
+
+        @Test
+        void predicateDepth() {
+            final String result = selectorBuilder
+                    .atDepth(d -> true)
+                    .toString();
+
+            assertThat(result).isEqualTo("types().atDepth(Predicate<Integer>)");
+        }
+
+        @Test
+        void full() {
+            final String result = selectorBuilder
+                    .of(Object.class)
+                    .excluding(Foo.class)
+                    .excluding(Bar.class)
+                    .annotated(Pojo.class)
+                    .annotated(PersonName.class)
+                    .atDepth(5)
+                    .toString();
+
+            assertThat(result).isEqualTo("types().of(Object).excluding(Foo).excluding(Bar)" +
+                    ".annotated(Pojo).annotated(PersonName).atDepth(5)");
+        }
     }
 
     private static List<InternalNode> toNodes(final Class<?>... types) {

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailRecord.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailRecord.java
@@ -16,10 +16,8 @@
 package org.instancio.test.support.pojo.cyclic.onetomany;
 
 import lombok.Data;
-import lombok.ToString;
 
 @Data
-@ToString
 public class DetailRecord {
     private Long id;
     private MainRecord mainRecord;

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainRecord.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainRecord.java
@@ -16,12 +16,10 @@
 package org.instancio.test.support.pojo.cyclic.onetomany;
 
 import lombok.Data;
-import lombok.ToString;
 
 import java.util.List;
 
 @Data
-@ToString
 public class MainRecord {
     private Long id;
     private List<DetailRecord> detailRecords;

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
@@ -83,6 +83,7 @@ public enum Feature {
     ROOT_SELECTOR,
     SCOPE,
     SELECTOR,
+    DEPTH_SELECTOR,
     SELECTOR_PRECEDENCE,
     SET,
     SETTINGS,

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/EmitGeneratorCyclicRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/EmitGeneratorCyclicRecordTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.GENERATOR, Feature.EMIT_GENERATOR, Feature.CYCLIC})
+@ExtendWith(InstancioExtension.class)
+class EmitGeneratorCyclicRecordTest {
+
+    private record OrderRecord(List<OrderItemRecord> items, OrderStatus status) {}
+
+    private record OrderItemRecord(OrderRecord order) {}
+
+    private enum OrderStatus {SHIPPED, DELIVERED, SUBMITTED}
+
+    @Test
+    void emitWithCyclicClasses() {
+        final OrderStatus[] statuses = {
+                OrderStatus.SUBMITTED, OrderStatus.SUBMITTED, OrderStatus.SUBMITTED,
+                OrderStatus.SHIPPED, OrderStatus.SHIPPED, OrderStatus.SHIPPED,
+                OrderStatus.DELIVERED, OrderStatus.DELIVERED, OrderStatus.DELIVERED
+        };
+
+        // emit() happens to work with cyclic records without specifying depth
+        // because record nodes are processed differently than POJOs.
+        // This test would fail for a POJO with similar structure unless depth was specified.
+        final List<OrderRecord> result = Instancio.ofList(OrderRecord.class)
+                .size(statuses.length)
+                .generate(field(OrderRecord::status), gen -> gen.emit().items(statuses))
+                .create();
+
+        assertThat(result).extracting(OrderRecord::status).containsExactly(statuses);
+    }
+
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/SelectorDepthRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/SelectorDepthRecordTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.allInts;
+
+@FeatureTag(Feature.DEPTH_SELECTOR)
+@ExtendWith(InstancioExtension.class)
+class SelectorDepthRecordTest {
+
+    @Test
+    void recordDepth() {
+        final Pojo0 result = Instancio.of(Pojo0.class)
+                .set(allInts().atDepth(1), 10)
+                .set(allInts().atDepth(2), 20)
+                .set(allInts().atDepth(3), 30)
+                .create();
+
+        assertThat(result.val).isEqualTo(10);
+        assertThat(result.pojo1.val).isEqualTo(20);
+        assertThat(result.pojo1.pojo2.val).isEqualTo(30);
+    }
+
+    private record Pojo0(Integer val, Pojo1 pojo1) {}
+
+    private record Pojo1(Integer val, Pojo2 pojo2) {}
+
+    private record Pojo2(Integer val) {}
+}

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -538,6 +538,43 @@ set(allStrings().within(scope(Person.class)), "foo")
 set(allStrings().within(all(Person.class).toScope()), "foo")
 ```
 
+### Selector Depth
+
+Regular and predicate selectors can also be narrowed down by specifying target's depth.
+Both selector types allow specifying depth as an integer value:
+
+``` java linenums="1"
+Select.all(Class<T> targetClass).atDepth(int depth)
+Select.field(Class<T> targetClass, String field).atDepth(int depth)
+Select.field(GetMethodSelector<T, R> methodReference).atDepth(int depth)
+
+Select.fields(Predicate<Field> fieldPredicate).atDepth(int depth)
+Select.types(Predicate<Class> typePredicate).atDepth(int depth)
+```
+
+In addition, predicate selectors also support specifying depth as a predicate:
+
+``` java linenums="1"
+Select.fields(Predicate<Field> fieldPredicate).atDepth(Predicate<Integer> depthPredicate)
+Select.types(Predicate<Class> typePredicate).atDepth(Predicate<Integer> depthPredicate)
+```
+
+Using depth is particularly useful for dealing with cyclic classes.
+Instancio does not support back-references. Instead, it detects and terminates cycles with a null reference.
+However, it is still possible it might generate an object structure as shown below:
+
+```
+A -> B -> C -> A -> null
+```
+
+Using `atDepth()` it is possible to prevent the last `A` from being generated:
+
+```java
+A a = Instancio.of(A.class)
+    .ignore(types().of(A.class).atDepth(depth -> depth > 0))
+    .create();
+```
+
 ### Selector Strictness
 
 #### Strict Mode


### PR DESCRIPTION
- [x] regular selector `atDepth(int)`
- [x] predicate selector `atDepth(int)` and `atDepth(Predicate<Integer>)`
- [x] tests with `emit()`
- [x] `PredicateSelectorImpl` should include `atDepth()` in description
- [x] `atDepth()` tests with records
- [x] `ignore()` with cyclic class
- [x] unused selectors error message with `atDepth(int)` `atDepth(Predicate<Integer>)`
- [x] user guide

---------


### Feature description

This PR adds support for specifying target depth at selector level.

### Motivation

Currently, Instancio supports regular and predicate selectors:

- Regular selectors provide `within(scope(...))` API for narrowing down the targets.
- Predicate selectors can be tailored by constructing arbitrary `Predicate<Field>` or `Predicate<Class>`.

While the two selector types support most common use cases, they have one limitation when it comes to cyclic objects: they apply to objects at all depths.

This is best illustrated using the `emit()` generator. Assuming the following classes:

```java
class Order {
    List<OrderItem> orderItems;
    OrderStatus status;
}

class OrderItem {
    Order order;
}

enum OrderStatus { SHIPPED, DELIVERED, SUBMITTED }
```

we want to create a list of 4 orders, 2 `SUBMITTED` and 2 `SHIPPED`: 

```java
OrderStatus[] expectedStatuses = {
    OrderStatus.SUBMITTED, OrderStatus.SUBMITTED, OrderStatus.SHIPPED, OrderStatus.SHIPPED
};

List<Order> orders = Instancio.ofList(Order.class)
    .size(expectedStatuses.length)
    .generate(field(Order::getStatus), gen -> gen.emit().items(expectedStatuses))
    .create();

assertThat(orders).extracting(Order::getStatus).containsExactly(expectedStatuses);
```

Currently, this test will fail, because Instancio generates `Order -> OrderItem -> Order`, etc. Due to the cyclic relationship, the `Order` objects are generated at different depths. Therefore, assignment of values from `emit()` is implementation-dependent (DFS/BFS). For POJOs, emitted items get assigned to orders at deeper levels, which is not what a user would expect. 

The current workaround  is to limit the depth. In this case, adding `withMaxDepth(2)` would make the test pass. However, using `withMaxDepth()` restricts **all** objects to the given depth. This is very limiting if a test requires other objects to be present beyond the given depth.

#### Proposed solution

Add support for depth at selector level:

```java
generate(field(Order::getStatus).atDepth(2), gen -> gen.emit().items(expectedStatuses))
```

Another alternative is to specify the depth using a predicate instead of a fixed value:

```java
fields().ofType(OrderStatus.class).atDepth(depth -> depth == 2)
```

Other use cases for using predicates: 

```java
// prevent Orders other than the root object
.ignore(types().of(Order.class).atDepth(depth -> depth > 0))

// generate empty collections beyond a certain depth
.generate(types().of(Collection.class).atDepth(depth -> depth > 3), gen -> gen.collection.size(0))
```
