### PR TITLE
Simplify maven compilation

### DIFF
--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -11,7 +11,7 @@
     <name>Instancio Tests: Tests Parent</name>
 
     <properties>
-        <maven.enforcer.require.java.version>1.8</maven.enforcer.require.java.version>
+        <maven.enforcer.require.java.version>8</maven.enforcer.require.java.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -158,21 +158,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
-                    <configuration>
-                        <showWarnings>true</showWarnings>
-                    </configuration>
                     <executions>
-                        <execution>
-                            <id>java-8</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <source>1.8</source>
-                                <target>1.8</target>
-                            </configuration>
-                        </execution>
                         <execution>
                             <id>java-16</id>
                             <phase>compile</phase>
@@ -300,9 +286,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.5.0</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
Hi, working on #565 I struggled a bit because there is no proper enforcement of java 8 compatibility.

For example i make large use of the factory methods List.of(), Set.of(), etc. but they can't be used in a library like Instancio that targets java 8. There is nothing that throws an error during the execution of `mvn compile` or `mvn verify` because of the illegal methods used. What I had to do was check manually if the methods I was using were in fact present in java 8.

(Intellij is pretty much useless too in this regard because for some reason it is convinced that the whole project is targeting java 16 so it doesn't warn me either, i suspect it's because multi release jars aren't well supported)

The problem is that the mere use of the source and target parameter isn't enough to check this type of compatibility, because they just make sure that the bytecode version generated is compatible with java 8. Java 9 introduced a new parameter, release, that does exactly this. Given that it's already mandatory to use at least java 17 to compile the project, we can use this parameter (the other possibility is the animal-sniffer maven plugin, but they too suggest to use the release parameter if possible). This is a good article to understand the situation because I'm terrible at explaining things https://www.baeldung.com/java-compiler-release-option.

Of course enabling the release parameter has a problem: the `Unsafe` and `ReflectionFactory` classes aren't considered part of the public API of the JDK and so they throw an error. My solution is to sweep under the carpet the usage of these classes, hiding them behind the reflection. It's not pretty but it works and there are only two very small piece of code where this workaround is necessary.

I also simplified a bit some stuff in the pom. For example the java-8 execution of the maven compiler was redundant. If you notice in the maven log there is a default-compile goal being executed which does the same thing of java-8, basically the classes are being compiled two times. It's not a huge improvement in speed, but it's something at least for my poor notebook lol.

Let me know what you think of this @armandino and if it's fine for you the hide and seek kind of workaround that I used.

Bye!