### PR TITLE
Use animal sniffer maven plugin to check java 8 signature

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/util/IgnoreJRERequirement.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/IgnoreJRERequirement.java
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.nodes.resolvers;
+package org.instancio.internal.util;
 
-import org.instancio.internal.nodes.NodeKind;
-import org.instancio.internal.nodes.NodeKindResolver;
-import org.instancio.internal.util.IgnoreJRERequirement;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import java.util.Optional;
-
-@IgnoreJRERequirement
-public class NodeKindRecordResolver implements NodeKindResolver {
-
-    @Override
-    public Optional<NodeKind> resolve(final Class<?> targetClass) {
-        return targetClass.isRecord()
-                ? Optional.of(NodeKind.RECORD)
-                : Optional.empty();
-    }
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.FIELD})
+public @interface IgnoreJRERequirement {
 }

--- a/instancio-core/src/main/java16/org/instancio/internal/util/RecordUtils.java
+++ b/instancio-core/src/main/java16/org/instancio/internal/util/RecordUtils.java
@@ -16,12 +16,14 @@
 package org.instancio.internal.util;
 
 import org.instancio.exception.InstancioException;
+import org.instancio.internal.util.IgnoreJRERequirement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
 
+@IgnoreJRERequirement
 public final class RecordUtils {
     private static final Logger LOG = LoggerFactory.getLogger(RecordUtils.class);
 

--- a/instancio-tests/bean-validation-hibernate-tests/pom.xml
+++ b/instancio-tests/bean-validation-hibernate-tests/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <sonar.exclusions>**/test/pojo/beanvalidation/**/*</sonar.exclusions>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
     </properties>
 
     <build>

--- a/instancio-tests/java16-tests/pom.xml
+++ b/instancio-tests/java16-tests/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <maven.enforcer.require.java.version>[16,)</maven.enforcer.require.java.version>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
     </properties>
 
     <build>

--- a/instancio-tests/java17-tests/pom.xml
+++ b/instancio-tests/java17-tests/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <maven.enforcer.require.java.version>[17,)</maven.enforcer.require.java.version>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
     </properties>
 
     <build>

--- a/instancio-tests/spi-tests/pom.xml
+++ b/instancio-tests/spi-tests/pom.xml
@@ -10,6 +10,10 @@
     <packaging>jar</packaging>
     <name>Instancio tests: Instancio SPI Tests</name>
 
+    <properties>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,30 @@
                         <arguments>-Pupdate-latest-release-version</arguments>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.23</version>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java18</artifactId>
+                            <version>1.0</version>
+                        </signature>
+                        <annotations>
+                            <annotation>org.instancio.internal.util.IgnoreJRERequirement</annotation>
+                        </annotations>
+                        <checkTestClasses>true</checkTestClasses>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>animal-sniffer</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -364,6 +388,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Hi, after a first bad attempt with the animal sniffer plugin I tried again with much more determination.

It turns out that it wasn't that complicated to exclude the java16 directory from the sniffing.

It is much less intrusive than the attempt with the release parameter given that it almost works out of the box.

I know we have decided to try the matrix workflow approach, but this seems a much more proper check. And this time it doesn't have any performance trade off :D

Let me know what you think!

Bye!