### PR TITLE
Enhance deploy workflow

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -6,12 +6,13 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    name: "Deploy"
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Maven Central Repository
+      - name: "Set up Maven Central Repository"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
           server-id: sonatype-snapshots
           server-username: MAVEN_USERNAME
@@ -21,15 +22,19 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
-  notify:
+  verify:
     needs: deploy
+    strategy:
+      matrix:
+        java: [ 8, 11, 17, 20 ]
     runs-on: ubuntu-latest
+    name: "Verify snapshots JDK ${{ matrix.java }}"
     steps:
       - uses: actions/checkout@v3
-      - name: "Run tests with JDK 8 using deployed snapshots"
+      - name: "Set up JDK"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: 8
-      # exclude test modules that require versions higher than 8
-      - run: cd instancio-tests && mvn -v && mvn -B -pl '!java16-tests,!java17-tests,!spi-tests,!bean-validation-hibernate-tests' install
+          distribution: "temurin"
+          java-version: ${{ matrix.java }}
+      - name: "Test"
+        run: cd instancio-tests && mvn -B install

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.instancio</groupId>
@@ -35,19 +36,14 @@
         <module>feature-tests</module>
         <module>default-package-tests</module>
         <module>global-seed-tests</module>
-        <module>java16-tests</module>
-        <module>java17-tests</module>
         <module>api-contract-tests</module>
         <module>arch-tests</module>
         <module>spi-old-tests</module>
-        <module>spi-tests</module>
         <module>kotlin-tests</module>
         <module>bean-validation-javax-tests</module>
         <module>bean-validation-jakarta-tests</module>
-        <module>bean-validation-hibernate-tests</module>
         <module>bean-validation-hibernate5-tests</module>
         <module>annotation-processor-with-lombok</module>
-        <module>annotation-processor-with-gradle</module>
         <module>packaging-tests</module>
         <module>report-aggregate</module>
     </modules>
@@ -147,5 +143,38 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>java-16</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <modules>
+                <module>java16-tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <modules>
+                <module>java17-tests</module>
+                <module>bean-validation-hibernate-tests</module>
+                <module>spi-tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <!-- Gradle doesn't support jdk 20 yet https://github.com/gradle/gradle/issues/23488 -->
+            <id>java-20</id>
+            <activation>
+                <jdk>(,20)</jdk>
+            </activation>
+            <modules>
+                <module>annotation-processor-with-gradle</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -93,12 +93,6 @@
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
-            <artifactId>bean-validation-hibernate-tests</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.instancio</groupId>
             <artifactId>bean-validation-hibernate5-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -129,27 +123,52 @@
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
-            <artifactId>spi-tests</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.instancio</groupId>
             <artifactId>kotlin-tests</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.instancio</groupId>
-            <artifactId>java16-tests</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.instancio</groupId>
-            <artifactId>java17-tests</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>java-16</id>
+            <activation>
+                <jdk>[16,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>java16-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>java-17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>java17-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>spi-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>bean-validation-hibernate-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Let me premise that I still have no idea why putting the animal sniffer plugin caused maven to crash. I swear that there are times when maven behaves like an annoying child lol

To fix the problem I took a more radical approach: I created several profiles to slice the test modules. This way maven can autonomously decide which test to run depending on the java version used. A similar set of profiles regulates the dependencies of the jacoco aggregate. This way if some test modules are excluded from the compilation, jacoco won't need them for its aggregate and maven finally shuts up about not finding its precious missing dependencies.

A nice side effect of not needing to manually exclude the test modules is that it becomes very simple to create a matrix workflow to verify the snaphots. As a reference I put all the currently supported jdk versions, but maybe it's unnecessary. I don't know the billing time constraint, so I'll update the matrix on what you @armandino think is best. I'm also fine removing the matrix altogether if you think it's not needed anymore, this was just to demonstrate that now it's very easy to do :D

Bye!