### PR TITLE
Search recursively for parameterized supertype

### DIFF
--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/TypeUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/TypeUtilsTest.java
@@ -42,9 +42,7 @@ class TypeUtilsTest {
     void getGenericSuperclassTypeArgument() {
         assertThat(TypeUtils.getGenericSuperclassTypeArgument(StringGenerator.class)).isEqualTo(String.class);
         assertThat(TypeUtils.getGenericSuperclassTypeArgument(TextPatternGenerator.class)).isEqualTo(String.class);
-        assertThat(TypeUtils.getGenericSuperclassTypeArgument(Bar.class))
-                .as("Should return String.class. Currently unsupported as it's needed at this time.")
-                .isNull();
+        assertThat(TypeUtils.getGenericSuperclassTypeArgument(Bar.class)).isEqualTo(String.class);
     }
 
     @Test


### PR DESCRIPTION
Hi, I'm still working on #567 and i'm trying to create a base generator for all the other generators that need some kind of module computation.

The problem is that if I introduce a new abstract class all the feature-tests breaks down because `ValueSpec` searches for a parameterized type only on the direct super types of the class. If the hierarchy of some class is changed the whole search doesn't work anymore.

I've updated the `TypeUtils` methods with a depth first search: now it will scan the whole hierarchy searching for a parameterized type.

This can introduce some weird behavior like for example the class `String` implements `Comparable<String>`, so it will return `String` now even if it's not immediately obvious. For this reason I added the possibility to focus the search on a particular type. For reference I applied this filter on the `ValueSpec` search that now will only search of a parameterized type of `ValueSpec` type. I'm not sure if it's the right type to filter on in this case.

To make your life easier I cherry picked this PR so that it can be reviewed without all the module stuff :D