### PR TITLE
InstancioSource doesn't play nice with entities and dtos generation

### DIFF
--- a/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedInstancioSourceTest.java
+++ b/instancio-tests/global-seed-tests/src/test/java/org/instancio/test/properties/GlobalSeedInstancioSourceTest.java
@@ -32,6 +32,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GlobalSeedInstancioSourceTest {
 
     private static final long ANNOTATION_SEED = -123;
+    private static final String PARAMETERIZED_NON_PARAM = "FCGVRXSUU";
+    private static final String PARAMETERIZED_WITH_SEED_NON_PARAM1 = "HCVIN";
+    private static final String PARAMETERIZED_WITH_SEED_NON_PARAM2 = "CKIR";
 
     @ParameterizedTest
     @InstancioSource
@@ -43,8 +46,8 @@ class GlobalSeedInstancioSourceTest {
         final Result<String> nonParam = Instancio.of(String.class).asResult();
 
         // (!) Random instance gets reset after parameters are generated,
-        // therefore nonParam value is the same as param1
-        assertThat(nonParam.get()).isEqualTo(param1);
+        // therefore nonParam value is the same as if it weren't presents any parameters
+        assertThat(nonParam.get()).isEqualTo(PARAMETERIZED_NON_PARAM);
         assertThat(nonParam.getSeed()).isEqualTo(TestConstants.GLOBAL_SEED);
     }
 
@@ -60,11 +63,11 @@ class GlobalSeedInstancioSourceTest {
         final Result<String> nonParam2 = Instancio.of(String.class).asResult();
 
         // (!) Random instance gets reset after parameters are generated,
-        // therefore nonParam value is the same as param1
-        assertThat(nonParam1.get()).isEqualTo(param1);
+        // therefore nonParam value is the same as if it weren't presents any parameters
+        assertThat(nonParam1.get()).isEqualTo(PARAMETERIZED_WITH_SEED_NON_PARAM1);
         assertThat(nonParam1.getSeed()).isEqualTo(ANNOTATION_SEED);
 
-        assertThat(nonParam2.get()).isEqualTo(param2);
+        assertThat(nonParam2.get()).isEqualTo(PARAMETERIZED_WITH_SEED_NON_PARAM2);
         assertThat(nonParam2.getSeed()).isEqualTo(ANNOTATION_SEED);
     }
 }

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceTest.java
@@ -28,6 +28,11 @@ class InstancioSourceTest {
 
     @InstancioSource
     @ParameterizedTest
+    void zeroArg() {
+    }
+
+    @InstancioSource
+    @ParameterizedTest
     void oneArg(final String arg) {
         assertThat(arg).isNotBlank();
     }
@@ -69,6 +74,14 @@ class InstancioSourceTest {
         assertThat(arg.second).isNotEmpty().doesNotContainNull();
     }
 
+    @InstancioSource
+    @ParameterizedTest
+    void differentTypesWithSameFields(final Entity entity, final Dto dto) {
+        assertThat(entity).isNotNull();
+        assertThat(dto).isNotNull();
+        assertThat(entity).usingRecursiveComparison().isNotEqualTo(dto);
+    }
+
     static class First {
         String foo;
 
@@ -95,6 +108,52 @@ class InstancioSourceTest {
 
         public void setSecond(final List<E> second) {
             this.second = second;
+        }
+    }
+
+    static class Entity {
+        int id;
+        boolean valid;
+        String name;
+        UUID group;
+
+        public void setId(final int id) {
+            this.id = id;
+        }
+
+        public void setValid(final boolean valid) {
+            this.valid = valid;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public void setGroup(final UUID group) {
+            this.group = group;
+        }
+    }
+
+    static class Dto {
+        int id;
+        boolean valid;
+        String name;
+        UUID group;
+
+        public void setId(final int id) {
+            this.id = id;
+        }
+
+        public void setValid(final boolean valid) {
+            this.valid = valid;
+        }
+
+        public void setName(final String name) {
+            this.name = name;
+        }
+
+        public void setGroup(final UUID group) {
+            this.group = group;
         }
     }
 }

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceWithSeedTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioSourceWithSeedTest.java
@@ -16,9 +16,9 @@
 package org.instancio.junit;
 
 import org.instancio.Instancio;
-import org.instancio.support.ThreadLocalRandom;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
+import org.instancio.support.ThreadLocalRandom;
 import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(InstancioExtension.class)
 class InstancioSourceWithSeedTest {
     private static final Logger LOG = LoggerFactory.getLogger(InstancioSourceWithSeedTest.class);
-    private static final String EXPECTED_STRING = "YDOQGZUVWOINKQNTDAONTOBMAYC";
+    private static final String SOURCE_EXPECTED_STRING = "LWJNPOYHFLFDNHMUUSBQ";
+    private static final String CREATE_EXPECTED_STRING = "YDOQGZUVWOINKQNTDAONTOBMAYC";
     private static final int STRING_MIN_LENGTH = 20;
     private static final long SEED = -1234;
 
@@ -51,7 +52,7 @@ class InstancioSourceWithSeedTest {
     void parameterizedWithSeed(final String value) {
         LOG.debug("ThreadLocalRandom seed: {}", ThreadLocalRandom.getInstance().get().getSeed());
         assertThat(ThreadLocalRandom.getInstance().get().getSeed()).isEqualTo(SEED);
-        assertThat(value).isEqualTo(EXPECTED_STRING);
+        assertThat(value).isEqualTo(SOURCE_EXPECTED_STRING);
     }
 
     @Seed(SEED)
@@ -60,7 +61,7 @@ class InstancioSourceWithSeedTest {
     void nonParameterizedWithSeed() {
         LOG.debug("ThreadLocalRandom seed: {}", ThreadLocalRandom.getInstance().get().getSeed());
         assertThat(ThreadLocalRandom.getInstance().get().getSeed()).isEqualTo(SEED);
-        assertThat(Instancio.create(String.class)).isEqualTo(EXPECTED_STRING);
+        assertThat(Instancio.create(String.class)).isEqualTo(CREATE_EXPECTED_STRING);
     }
 
     @NonDeterministicTag("Assuming the random seed will not be equal to the SEED constant")

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
@@ -57,13 +57,13 @@ class InstancioArgumentsProviderTest {
         provider.accept(instancioSource);
         final Stream<? extends Arguments> stream = provider.provideArguments(mockContext);
 
-        assertThat(stream).isEmpty();
+        assertThat(stream).doesNotContainNull().hasSize(1).allSatisfy(arguments -> assertThat(arguments.get()).isEmpty());
     }
 
     @NonDeterministicTag("Small chance of duplicate values being generated")
     @MethodSource("types")
     @ParameterizedTest
-    void createObjectsGroupingByType(final Class<?>[] types) {
+    void createObjects(final Class<?>[] types) {
         final Random random = new DefaultRandom();
         final Settings settings = Settings.create()
                 .set(Keys.STRING_MIN_LENGTH, 20)
@@ -72,7 +72,7 @@ class InstancioArgumentsProviderTest {
                 .set(Keys.LONG_MIN, Long.MIN_VALUE)
                 .set(Keys.LONG_MAX, Long.MAX_VALUE);
 
-        final Object[] results = InstancioArgumentsProvider.createObjectsGroupingByType(types, random, settings);
+        final Object[] results = InstancioArgumentsProvider.createObjects(types, random, settings);
 
         assertThat(results).hasExactlyElementsOfTypes(types);
         assertThat(new HashSet<>(Arrays.asList(results)))


### PR DESCRIPTION
Hi,
I was setting up some tests for some mapstruct mappers and I noticed that `InstancioSource` was generating entities and dtos with the same exact fields.

This is because in the `InstancioArgumentsProvider` the seed is resetted with every new type, so an entity and a dto will ask for the same fields and generate the same values.

I think this isn't pretty at all, so I updated the arguments generation in a way where every objects will be generated from a seed derived from the actual seed.

This works quite well in regards of generating different objects (for example it isn't necessary anymore to segregate the parameters by type because everybody will receive its own personal seed now :D), but has a downside: `InstancioSource` isn't compatible with the normal `Instancio.create()` now, meaning that the same seed generates two different object depending on which method the user chooses.

For me it isn't much of a problem because I doubt that some user will care about it, but I wanted to ask you @armandino what do you think first.

Given this the PR it's still a bit rough because I didn't polish everything and I just disabled the failing test for now.

Bye!