### PR TITLE
Minor clean up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
                         <excludeRoots>
                             <excludeRoot>target/generated-sources/</excludeRoot>
                         </excludeRoots>
+                        <linkXRef>false</linkXRef>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -338,9 +339,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
-                        <!-- install release jars into local m2
-                             (required for the Gradle test module to work during release) -->
-                        <preparationGoals>versions:set-property versions:commit install</preparationGoals>
+                        <preparationGoals>versions:set-property versions:commit verify</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <localCheckout>true</localCheckout>
                         <arguments>-Pupdate-latest-release-version</arguments>

--- a/website/docs/articles/using-instancio-with-junit-jupiter.md
+++ b/website/docs/articles/using-instancio-with-junit-jupiter.md
@@ -135,19 +135,19 @@ Once you have the dependency on the classpath, you can declare a test method as 
 class PersonToPersonDTOTest {
 
     @ParameterizedTest
-    @InstancioSource(Person.class)
+    @InstancioSource
     void singleArgument(Person person) {
         // provides a fully-populated person as an argument
     }
 }
 ```
 
-Instancio will provide a populated instance of the class specified in the annotation. You can specify any number of classes in the annotation. Just remember to declare a method argument for each class in the annotation:
+Instancio will provide a populated instance of the class specified in the annotation. You can specify as many parameters as you need:
 
 
 ``` java linenums="1" title="Parameterized test with multiple arguments"
 @ParameterizedTest
-@InstancioSource(String.class, UUID.class, Foo.class)
+@InstancioSource
 void multipleArguments(String str, UUID uuid, Foo foo) {
     // any number of arguments can be specified...
 }
@@ -155,9 +155,7 @@ void multipleArguments(String str, UUID uuid, Foo foo) {
 
 There are a couple of important limitations to using @InstancioSource to be aware of.
 
-First, it cannot provide instances of generic types. For example, there is no way to specify a List<Person>.
-
-Second, you cannot customise the object as you would with the builder API. In other words, there is no way to specify something like this:
+For example, you cannot customise the object as you would with the builder API. In other words, there is no way to specify something like this:
 
 ``` java linenums="1"
 Person person = Instancio.of(Person.class)

--- a/website/docs/building.md
+++ b/website/docs/building.md
@@ -13,13 +13,8 @@ Building Instancio from sources requires JDK 17 or higher:
 ```sh
 git clone https://github.com/instancio/instancio.git
 cd instancio
-mvn install
+mvn verify
 ```
-
-!!! note
-    The build includes a Gradle test module which requires the dependencies to be installed into
-    the local `~/.m2` repository. For this reason, `mvn install` must be run at least once
-    for the Gradle test module to build successfully.
 
 # Building the Website
 


### PR DESCRIPTION
Hi,
I just found some small things to clean up around the project. I'm clumping them all together in a single PR just because they are very small.

- Removed from the `Building From Sources` the mandatory installation for the gradle module. Now a `verify` is enough to trigger all the checks and tests even the first time.
- Updated the Junit article (I didn't know the articles section exists until now lol)
- Removed the reference of installing for the gradle module from the `maven-release-plugin`. I lowered the phase from `install` to `verify`, but I admit I don't know precisely its usage so maybe `install` is still necessary or instead it could be removed completely. I'll wait for your feedback on this.
- Explicitly disabled the PMD `linkXRef` usage. If i'm not mistaken we aren't interested in the report generated from PMD, but just to break the compilation if a violation is detected. This remove the `Unable to locate Source XRef to link to - DISABLED` warning. I followed this SO answer https://stackoverflow.com/a/18390459

Bye!