### PR TITLE
Collection API type token support.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -16,6 +16,7 @@
 package org.instancio;
 
 import org.instancio.internal.ApiImpl;
+import org.instancio.internal.ApiValidator;
 import org.instancio.internal.OfClassApiImpl;
 import org.instancio.internal.OfCollectionApiImpl;
 import org.instancio.internal.OfMapApiImpl;
@@ -329,7 +330,20 @@ public final class Instancio {
      */
     @SuppressWarnings("all")
     public static <T> InstancioOfCollectionApi<List<T>> ofList(final Class<T> elementType) {
-        return new OfCollectionApiImpl(List.class, elementType);
+        return new OfCollectionApiImpl(List.class, ApiValidator.validateOfListElementType(elementType));
+    }
+
+    /**
+     * Builder API for generating a {@link List} using a type token.
+     *
+     * @param elementTypeToken specifying the element type
+     * @param <T>              element type
+     * @return API builder reference
+     * @since 2.16.0
+     */
+    @SuppressWarnings("all")
+    public static <T> InstancioOfCollectionApi<List<T>> ofList(final TypeTokenSupplier<T> elementTypeToken) {
+        return new OfCollectionApiImpl(List.class, elementTypeToken);
     }
 
     /**
@@ -354,7 +368,20 @@ public final class Instancio {
      */
     @SuppressWarnings("all")
     public static <T> InstancioOfCollectionApi<Set<T>> ofSet(final Class<T> elementType) {
-        return new OfCollectionApiImpl(Set.class, elementType);
+        return new OfCollectionApiImpl(Set.class, ApiValidator.validateOfSetElementType(elementType));
+    }
+
+    /**
+     * Builder API for generating a {@link Set} using a type token.
+     *
+     * @param elementTypeToken specifying the element type
+     * @param <T>              element type
+     * @return API builder reference
+     * @since 2.16.0
+     */
+    @SuppressWarnings("all")
+    public static <T> InstancioOfCollectionApi<Set<T>> ofSet(final TypeTokenSupplier<T> elementTypeToken) {
+        return new OfCollectionApiImpl(Set.class, elementTypeToken);
     }
 
     /**
@@ -384,7 +411,27 @@ public final class Instancio {
             final Class<K> keyType,
             final Class<V> valueType) {
 
-        return new OfMapApiImpl(Map.class, keyType, valueType);
+        return new OfMapApiImpl(Map.class,
+                ApiValidator.validateOfMapKeyOrValueType(keyType),
+                ApiValidator.validateOfMapKeyOrValueType(valueType));
+    }
+
+    /**
+     * Builder API for generating a {@link Map} using type tokens.
+     *
+     * @param keyTypeToken   specifying the key type
+     * @param valueTypeToken specifying the value type
+     * @param <K>            key type
+     * @param <V>            value type
+     * @return API builder reference
+     * @since 2.16.0
+     */
+    @SuppressWarnings("all")
+    public static <K, V> InstancioOfCollectionApi<Map<K, V>> ofMap(
+            final TypeTokenSupplier<K> keyTypeToken,
+            final TypeTokenSupplier<V> valueTypeToken) {
+
+        return new OfMapApiImpl(Map.class, keyTypeToken, valueTypeToken);
     }
 
     @SuppressWarnings("unchecked")

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -27,6 +27,7 @@ import org.instancio.generator.GeneratorSpec;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.settings.Settings;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -50,8 +51,8 @@ public class ApiImpl<T> implements InstancioApi<T> {
         this.modelContextBuilder = suppliedContext.toBuilder();
     }
 
-    protected void addTypeParameters(final Class<?>... type) {
-        modelContextBuilder.withRootTypeParameters(Arrays.asList(type));
+    protected final void addTypeParameters(final Type... types) {
+        modelContextBuilder.withRootTypeParameters(Arrays.asList(types));
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/ApiValidatorMessageHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiValidatorMessageHelper.java
@@ -17,6 +17,7 @@ package org.instancio.internal;
 
 import org.instancio.internal.util.Format;
 
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
 
@@ -34,6 +35,62 @@ final class ApiValidatorMessageHelper {
                 .append(INVALID_USAGE_OF_WITH_TYPE_PARAMETERS).append(NL)
                 .append(" -> class ").append(Format.withoutPackage(rootClass))
                 .append(" is not generic and does not require type parameters")
+                .toString();
+    }
+
+    static String ofCollectionElementType(final Class<?> elementType, final String method) {
+        final String classWithTypeParams = String.format("%s<%s>",
+                elementType.getSimpleName(), Format.getTypeVariablesCsv(elementType));
+
+        return new StringBuilder()
+                .append("invalid usage of ").append(method).append(" method").append(NL)
+                .append(NL)
+                .append("  -> The argument ").append(classWithTypeParams)
+                .append(" is a generic class and also requires type parameter(s),").append(NL)
+                .append("     but this method does not support nested generics.").append(NL)
+                .append(NL)
+                .append("To resolve this error:").append(NL)
+                .append(NL)
+                .append(" -> Use one of the methods that accepts a type token, e.g:").append(NL)
+                .append(NL)
+                .append("    List<Pair<String, Integer>> list = Instancio.ofList(new TypeToken<Pair<String, Integer>>() {})").append(NL)
+                .append("            // additional API methods...").append(NL)
+                .append("            .create();")
+                .append(NL)
+                .append("    or:").append(NL)
+                .append(NL)
+                .append("    List<Pair<String, Integer>> list = Instancio.of(new TypeToken<List<Pair<String, Integer>>>(){})").append(NL)
+                .append("            // additional API methods...").append(NL)
+                .append("            .create();")
+                .toString();
+    }
+
+    static String ofMapKeyOrValueType(final Class<?> keyOrValue) {
+        final String classWithTypeParams = String.format("%s<%s>",
+                keyOrValue.getSimpleName(), Format.getTypeVariablesCsv(keyOrValue));
+
+        return new StringBuilder()
+                .append("invalid usage of ofMap() method").append(NL)
+                .append(NL)
+                .append("  -> The argument ").append(classWithTypeParams)
+                .append(" is a generic class and also requires type parameter(s),").append(NL)
+                .append("     but this method does not support nested generics.").append(NL)
+                .append(NL)
+                .append("To resolve this error:").append(NL)
+                .append(NL)
+                .append(" -> Use one of the methods that accepts a type token, e.g:").append(NL)
+                .append(NL)
+                .append("    Map<Item<String>, Pair<String, Integer>> map = Instancio.ofMap(").append(NL)
+                .append("                    new TypeToken<Item<String>>() {},").append(NL)
+                .append("                    new TypeToken<Pair<String, Integer>>() {})").append(NL)
+                .append("            // additional API methods...").append(NL)
+                .append("            .create();")
+                .append(NL)
+                .append("    or:").append(NL)
+                .append(NL)
+                .append("    Map<Item<String>, Pair<String, Integer>> map = Instancio.of(new TypeToken<Map<Item<String>, Pair<String, Integer>>>(){})").append(NL)
+                .append("            // additional API methods...").append(NL)
+                .append("            .create();")
                 .toString();
     }
 
@@ -61,7 +118,7 @@ final class ApiValidatorMessageHelper {
 
     static String withTypeParametersNumberOfParameters(
             final Class<?> rootClass,
-            final List<Class<?>> rootTypeParameters) {
+            final List<Type> rootTypeParameters) {
 
         final StringBuilder sb = new StringBuilder()
                 .append(INVALID_USAGE_OF_WITH_TYPE_PARAMETERS).append(NL)

--- a/instancio-core/src/main/java/org/instancio/internal/OfClassApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfClassApiImpl.java
@@ -19,6 +19,8 @@ import org.instancio.InstancioApi;
 import org.instancio.InstancioOfClassApi;
 import org.instancio.Model;
 
+import java.lang.reflect.Type;
+
 public class OfClassApiImpl<T> extends ApiImpl<T> implements InstancioOfClassApi<T> {
 
     public OfClassApiImpl(final Class<T> klass) {
@@ -35,4 +37,7 @@ public class OfClassApiImpl<T> extends ApiImpl<T> implements InstancioOfClassApi
         return this;
     }
 
+    protected final void withTypeParameters(final Type... type) {
+        super.addTypeParameters(type);
+    }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/OfCollectionApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfCollectionApiImpl.java
@@ -18,6 +18,7 @@ package org.instancio.internal;
 import org.instancio.InstancioOfCollectionApi;
 import org.instancio.Model;
 import org.instancio.Select;
+import org.instancio.TypeTokenSupplier;
 import org.instancio.internal.context.ModelContext;
 
 import java.util.Collection;
@@ -32,6 +33,14 @@ public final class OfCollectionApiImpl<T, C extends Collection<T>>
 
         super(collectionType);
         withTypeParameters(elementType);
+    }
+
+    public OfCollectionApiImpl(
+            final Class<C> collectionType,
+            final TypeTokenSupplier<T> typeToken) {
+
+        super(collectionType);
+        withTypeParameters(ApiValidator.validateTypeToken(typeToken));
     }
 
     private OfCollectionApiImpl(final Model<C> collectionModel) {

--- a/instancio-core/src/main/java/org/instancio/internal/OfMapApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfMapApiImpl.java
@@ -17,6 +17,7 @@ package org.instancio.internal;
 
 import org.instancio.InstancioOfCollectionApi;
 import org.instancio.Select;
+import org.instancio.TypeTokenSupplier;
 
 import java.util.Map;
 
@@ -31,6 +32,17 @@ public final class OfMapApiImpl<K, V, M extends Map<K, V>>
 
         super(mapType);
         withTypeParameters(keyType, valueType);
+    }
+
+    public OfMapApiImpl(
+            final Class<M> mapType,
+            final TypeTokenSupplier<K> keyTypeToken,
+            final TypeTokenSupplier<V> valueTypeToken) {
+
+        super(mapType);
+        withTypeParameters(
+                ApiValidator.validateTypeToken(keyTypeToken),
+                ApiValidator.validateTypeToken(valueTypeToken));
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -71,8 +71,8 @@ public final class ModelContext<T> {
 
     private final Providers providers;
     private final Type rootType;
-    private final List<Class<?>> rootTypeParameters;
-    private final Map<TypeVariable<?>, Class<?>> rootTypeMap;
+    private final List<Type> rootTypeParameters;
+    private final Map<TypeVariable<?>, Type> rootTypeMap;
     private final Integer maxDepth;
     private final Long seed;
     private final Random random;
@@ -198,7 +198,7 @@ public final class ModelContext<T> {
     }
 
     @SuppressWarnings(Sonar.GENERIC_WILDCARD_IN_RETURN)
-    public Map<TypeVariable<?>, Class<?>> getRootTypeMap() {
+    public Map<TypeVariable<?>, Type> getRootTypeMap() {
         return rootTypeMap;
     }
 
@@ -234,7 +234,7 @@ public final class ModelContext<T> {
         private final Type rootType;
         private final Class<T> rootClass;
 
-        private final List<Class<?>> rootTypeParameters = new ArrayList<>();
+        private final List<Type> rootTypeParameters = new ArrayList<>();
         private final Map<TargetSelector, Class<?>> subtypeSelectors = new LinkedHashMap<>();
         private final Map<TargetSelector, GeneratorSpecProvider<?>> generatorSpecSelectors = new LinkedHashMap<>();
         private final Map<TargetSelector, Generator<?>> generatorSelectors = new LinkedHashMap<>();
@@ -251,7 +251,7 @@ public final class ModelContext<T> {
             this.rootClass = TypeUtils.getRawType(this.rootType);
         }
 
-        public Builder<T> withRootTypeParameters(final List<Class<?>> rootTypeParameters) {
+        public Builder<T> withRootTypeParameters(final List<Type> rootTypeParameters) {
             ApiValidator.validateTypeParameters(rootClass, rootTypeParameters);
             this.rootTypeParameters.addAll(rootTypeParameters);
             return this;

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContextHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContextHelper.java
@@ -140,9 +140,9 @@ final class ModelContextHelper {
         return results;
     }
 
-    static Map<TypeVariable<?>, Class<?>> buildRootTypeMap(
+    static Map<TypeVariable<?>, Type> buildRootTypeMap(
             final Type rootType,
-            final List<Class<?>> rootTypeParameters) {
+            final List<Type> rootTypeParameters) {
 
         final Class<?> rootClass = TypeUtils.getRawType(rootType);
         ApiValidator.validateTypeParameters(rootClass, rootTypeParameters);
@@ -152,11 +152,11 @@ final class ModelContextHelper {
                 : rootClass;
 
         final TypeVariable<?>[] typeVariables = targetClass.getTypeParameters();
-        final Map<TypeVariable<?>, Class<?>> typeMap = new HashMap<>();
+        final Map<TypeVariable<?>, Type> typeMap = new HashMap<>();
 
         for (int i = 0; i < typeVariables.length; i++) {
             final TypeVariable<?> typeVariable = typeVariables[i];
-            final Class<?> actualType = rootTypeParameters.get(i);
+            final Type actualType = rootTypeParameters.get(i);
             LOG.trace("Mapping type variable '{}' to '{}'", typeVariable, actualType);
             typeMap.put(typeVariable, actualType);
         }
@@ -167,7 +167,7 @@ final class ModelContextHelper {
 
     private static void populateTypeMapFromGenericSuperclass(
             @Nullable final Class<?> rootClass,
-            final Map<TypeVariable<?>, Class<?>> typeMap) {
+            final Map<TypeVariable<?>, Type> typeMap) {
 
         if (rootClass == null) {
             return;

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
@@ -25,6 +25,7 @@ import org.instancio.internal.spi.ProviderEntry;
 import org.instancio.settings.Settings;
 import org.instancio.spi.InstancioServiceProvider.TypeResolver;
 
+import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.Collections;
 import java.util.List;
@@ -33,7 +34,7 @@ import java.util.Optional;
 
 public final class NodeContext {
     private final int maxDepth;
-    private final Map<TypeVariable<?>, Class<?>> rootTypeMap;
+    private final Map<TypeVariable<?>, Type> rootTypeMap;
     private final BooleanSelectorMap ignoredSelectorMap;
     private final SubtypeSelectorMap subtypeSelectorMap;
     private final Map<Class<?>, Class<?>> subtypeMappingFromSettings;
@@ -54,7 +55,7 @@ public final class NodeContext {
         return maxDepth;
     }
 
-    public Map<TypeVariable<?>, Class<?>> getRootTypeMap() {
+    public Map<TypeVariable<?>, Type> getRootTypeMap() {
         return rootTypeMap;
     }
 
@@ -96,7 +97,7 @@ public final class NodeContext {
 
     public static final class Builder {
         private int maxDepth;
-        private Map<TypeVariable<?>, Class<?>> rootTypeMap = Collections.emptyMap();
+        private Map<TypeVariable<?>, Type> rootTypeMap = Collections.emptyMap();
         private BooleanSelectorMap ignoredSelectorMap;
         private SubtypeSelectorMap subtypeSelectorMap;
         private Map<Class<?>, Class<?>> subtypeMappingFromSettings = Collections.emptyMap();
@@ -111,7 +112,7 @@ public final class NodeContext {
             return this;
         }
 
-        public Builder rootTypeMap(final Map<TypeVariable<?>, Class<?>> rootTypeMap) {
+        public Builder rootTypeMap(final Map<TypeVariable<?>, Type> rootTypeMap) {
             this.rootTypeMap = rootTypeMap;
             return this;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/TypeMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/TypeMap.java
@@ -33,15 +33,15 @@ import java.util.Objects;
  */
 public final class TypeMap {
 
-    private final Map<TypeVariable<?>, Class<?>> rootTypeMap;
+    private final Map<TypeVariable<?>, Type> rootTypeMap;
     private final Map<Type, Type> typeMap;
 
-    public TypeMap(final Type genericType, final Map<TypeVariable<?>, Class<?>> rootTypeMap) {
+    public TypeMap(final Type genericType, final Map<TypeVariable<?>, Type> rootTypeMap) {
         this(genericType, rootTypeMap, Collections.emptyMap());
     }
 
     public TypeMap(final Type genericType,
-                   final Map<TypeVariable<?>, Class<?>> rootTypeMap,
+                   final Map<TypeVariable<?>, Type> rootTypeMap,
                    final Map<Type, Type> subtypeMappingTypeMap) {
 
         this.rootTypeMap = Collections.unmodifiableMap(rootTypeMap);
@@ -91,7 +91,7 @@ public final class TypeMap {
         }
 
         if (genericType instanceof TypeVariable && rootTypeMap.containsKey(genericType)) {
-            final Class<?> mappedType = rootTypeMap.get(genericType);
+            final Type mappedType = rootTypeMap.get(genericType);
             map.put(genericType, mappedType);
             return map;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/util/TypeUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/TypeUtils.java
@@ -33,6 +33,12 @@ public final class TypeUtils {
         // non-instantiable
     }
 
+    public static int getTypeParameterCount(final Class<?> klass) {
+        return klass.isArray()
+                ? klass.getComponentType().getTypeParameters().length
+                : klass.getTypeParameters().length;
+    }
+
     public static Class<?> getArrayClass(@Nullable final Type type) {
         if (type instanceof Class) {
             final Class<?> klass = (Class<?>) type;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListTypeTokenTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListTypeTokenTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.oflist;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.test.support.pojo.generics.basic.Item;
+import org.instancio.test.support.pojo.interfaces.ItemInterface;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+
+@FeatureTag(Feature.OF_LIST)
+class OfListTypeTokenTest {
+
+    @Test
+    void typeToken() {
+        final List<ItemInterface<String>> results = Instancio.ofList(new TypeToken<ItemInterface<String>>() {})
+                .subtype(all(ItemInterface.class), Item.class)
+                .create();
+
+        assertThat(results)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
+                .allSatisfy(item -> assertThat(item)
+                        .isExactlyInstanceOf(Item.class)
+                        .hasNoNullFieldsOrProperties());
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofmap/OfMapTypeTokenTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofmap/OfMapTypeTokenTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.ofmap;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.test.support.pojo.generics.basic.Item;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.OF_MAP)
+class OfMapTypeTokenTest {
+
+    @Test
+    void typeToken() {
+        final Map<Item<String>, Item<Integer>> results = Instancio.ofMap(
+                        new TypeToken<Item<String>>() {},
+                        new TypeToken<Item<Integer>>() {})
+                .create();
+
+        assertThat(results)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
+                .allSatisfy((k, v) -> {
+                    assertThat(k).hasNoNullFieldsOrProperties();
+                    assertThat(v).hasNoNullFieldsOrProperties();
+                });
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofset/OfSetTypeTokenTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofset/OfSetTypeTokenTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.ofset;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.test.support.pojo.generics.basic.Item;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.OF_SET)
+class OfSetTypeTokenTest {
+
+    @Test
+    void typeToken() {
+        final Set<Item<String>> results = Instancio.ofSet(new TypeToken<Item<String>>() {})
+                .create();
+
+        assertThat(results)
+                .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
+                .allSatisfy(item -> assertThat(item).hasNoNullFieldsOrProperties());
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfListClassWithGenericTypeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfListClassWithGenericTypeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.generics.basic.Pair;
+
+class OfListClassWithGenericTypeTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.ofList(Pair.class);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.OfListClassWithGenericTypeTest.methodUnderTest(OfListClassWithGenericTypeTest.java:25)
+
+                Reason: invalid usage of ofList() method
+
+                  -> The argument Pair<L, R> is a generic class and also requires type parameter(s),
+                     but this method does not support nested generics.
+
+                To resolve this error:
+
+                 -> Use one of the methods that accepts a type token, e.g:
+
+                    List<Pair<String, Integer>> list = Instancio.ofList(new TypeToken<Pair<String, Integer>>() {})
+                            // additional API methods...
+                            .create();
+                    or:
+
+                    List<Pair<String, Integer>> list = Instancio.of(new TypeToken<List<Pair<String, Integer>>>(){})
+                            // additional API methods...
+                            .create();
+
+                """;
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfListWithNullTypeTokenTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfListWithNullTypeTokenTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+
+class OfListWithNullTypeTokenTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.ofList((TypeToken<String>) null);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.OfListWithNullTypeTokenTest.methodUnderTest(OfListWithNullTypeTokenTest.java:25)
+
+                Reason: type token must not be null
+                 -> Please provide a valid type token
+
+                	Example:
+                	Map<String, List<Integer>> map = Instancio.create(new TypeToken<Map<String, List<Integer>>>(){});
+
+                	// or the builder version
+                	Map<String, List<Integer>> map = Instancio.of(new TypeToken<Map<String, List<Integer>>>(){}).create();
+
+                """;
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfMapClassWithGenericKeyTypeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfMapClassWithGenericKeyTypeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.generics.basic.Item;
+
+class OfMapClassWithGenericKeyTypeTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.ofMap(Item.class, String.class);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.OfMapClassWithGenericKeyTypeTest.methodUnderTest(OfMapClassWithGenericKeyTypeTest.java:25)
+
+                Reason: invalid usage of ofMap() method
+
+                  -> The argument Item<K> is a generic class and also requires type parameter(s),
+                     but this method does not support nested generics.
+
+                To resolve this error:
+
+                 -> Use one of the methods that accepts a type token, e.g:
+
+                    Map<Item<String>, Pair<String, Integer>> map = Instancio.ofMap(
+                                    new TypeToken<Item<String>>() {},
+                                    new TypeToken<Pair<String, Integer>>() {})
+                            // additional API methods...
+                            .create();
+                    or:
+
+                    Map<Item<String>, Pair<String, Integer>> map = Instancio.of(new TypeToken<Map<Item<String>, Pair<String, Integer>>>(){})
+                            // additional API methods...
+                            .create();
+
+                """;
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfMapClassWithGenericValueTypeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfMapClassWithGenericValueTypeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.generics.basic.Item;
+
+class OfMapClassWithGenericValueTypeTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.ofMap(String.class, Item.class);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.OfMapClassWithGenericValueTypeTest.methodUnderTest(OfMapClassWithGenericValueTypeTest.java:25)
+
+                Reason: invalid usage of ofMap() method
+
+                  -> The argument Item<K> is a generic class and also requires type parameter(s),
+                     but this method does not support nested generics.
+
+                To resolve this error:
+
+                 -> Use one of the methods that accepts a type token, e.g:
+
+                    Map<Item<String>, Pair<String, Integer>> map = Instancio.ofMap(
+                                    new TypeToken<Item<String>>() {},
+                                    new TypeToken<Pair<String, Integer>>() {})
+                            // additional API methods...
+                            .create();
+                    or:
+
+                    Map<Item<String>, Pair<String, Integer>> map = Instancio.of(new TypeToken<Map<Item<String>, Pair<String, Integer>>>(){})
+                            // additional API methods...
+                            .create();
+
+                """;
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfSetClassWithGenericTypeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/OfSetClassWithGenericTypeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.generics.basic.Pair;
+
+class OfSetClassWithGenericTypeTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.ofSet(Pair.class);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.OfSetClassWithGenericTypeTest.methodUnderTest(OfSetClassWithGenericTypeTest.java:25)
+
+                Reason: invalid usage of ofSet() method
+
+                  -> The argument Pair<L, R> is a generic class and also requires type parameter(s),
+                     but this method does not support nested generics.
+
+                To resolve this error:
+
+                 -> Use one of the methods that accepts a type token, e.g:
+
+                    List<Pair<String, Integer>> list = Instancio.ofList(new TypeToken<Pair<String, Integer>>() {})
+                            // additional API methods...
+                            .create();
+                    or:
+
+                    List<Pair<String, Integer>> list = Instancio.of(new TypeToken<List<Pair<String, Integer>>>(){})
+                            // additional API methods...
+                            .create();
+
+                """;
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/TypeUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/TypeUtilsTest.java
@@ -25,9 +25,18 @@ import org.instancio.test.support.pojo.generics.inheritance.NonGenericSubclassOf
 import org.instancio.test.support.pojo.generics.inheritance.NonGenericSubclassOfMap;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TypeUtilsTest {
+
+    @Test
+    void getTypeParameterCount() {
+        assertThat(TypeUtils.getTypeParameterCount(String.class)).isZero();
+        assertThat(TypeUtils.getTypeParameterCount(List.class)).isOne();
+        assertThat(TypeUtils.getTypeParameterCount(List[].class)).isOne();
+    }
 
     @Test
     void getArrayClass() {

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/TypeMapTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/TypeMapTest.java
@@ -38,7 +38,7 @@ import static org.instancio.testsupport.asserts.TypeMapResolverAssert.assertThat
 @GenericsTag
 class TypeMapTest {
 
-    public static final Map<TypeVariable<?>, Class<?>> EMPTY_ROOT_TYPE_MAP = Collections.emptyMap();
+    public static final Map<TypeVariable<?>, Type> EMPTY_ROOT_TYPE_MAP = Collections.emptyMap();
 
     @Test
     void verifyEqualsAndHashcode() {

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/utils/TypeMapBuilder.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/utils/TypeMapBuilder.java
@@ -15,13 +15,14 @@
  */
 package org.instancio.testsupport.utils;
 
+import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.HashMap;
 import java.util.Map;
 
 public class TypeMapBuilder {
 
-    private final Map<TypeVariable<?>, Class<?>> typeMap = new HashMap<>();
+    private final Map<TypeVariable<?>, Type> typeMap = new HashMap<>();
     private final Class<?> klass;
 
     private TypeMapBuilder(Class<?> klass) {
@@ -32,12 +33,12 @@ public class TypeMapBuilder {
         return new TypeMapBuilder(klass);
     }
 
-    public TypeMapBuilder with(String typeVariable, Class<?> mappedType) {
+    public TypeMapBuilder with(String typeVariable, Type mappedType) {
         typeMap.put(TypeUtils.getTypeVar(klass, typeVariable), mappedType);
         return this;
     }
 
-    public Map<TypeVariable<?>, Class<?>> get() {
+    public Map<TypeVariable<?>, Type> get() {
         return typeMap;
     }
 }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -97,6 +97,14 @@ Instancio.ofSet(Class<T> elementType).create()
 Instancio.ofMap(Class<K> keyType, Class<V> valueType).create()
 ```
 
+If the element is a generic type, the following methods can be used instead:
+
+``` java linenums="1" title="Collections API: using TypeToken"
+Instancio.ofList(TypeTokenSupplier<T> elementType).create()
+Instancio.ofSet(TypeTokenSupplier<T> elementType).create()
+Instancio.ofMap(TypeTokenSupplier<K> keyType, TypeTokenSupplier<V> valueType).create()
+```
+
 In addition, `ofList()` and `ofSet()` can be used to create collections
 from models:
 
@@ -107,6 +115,8 @@ Instancio.ofSet(Model<T> elementModel).create()
 
 ```java linenums="1" title="Examples"
 List<Person> list = Instancio.ofList(Person.class).size(10).create();
+
+List<Pair<String, Integer>> list = Instancio.ofList(new TypeToken<Pair<String, Integer>>() {}).create();
 
 Map<UUID, Address> map = Instancio.ofMap(UUID.class, Address.class).size(3)
     .set(field(Address::getCity), "Vancouver")


### PR DESCRIPTION
New API methods:

 - `ofList(TypeTokenSupplier)`
 - `ofSet(TypeTokenSupplier)`
 - `ofMap(TypeTokenSupplier, TypeTokenSupplier)`