### PR TITLE
Bug fix: creating nested collections from a Model

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -269,6 +269,7 @@ public final class Instancio {
      * @return API builder reference
      */
     public static <T> InstancioOfClassApi<T> of(final Class<T> type) {
+        ApiValidator.validateRootClass(type);
         return new OfClassApiImpl<>(type);
     }
 
@@ -343,7 +344,7 @@ public final class Instancio {
      */
     @SuppressWarnings("all")
     public static <T> InstancioOfCollectionApi<List<T>> ofList(final TypeTokenSupplier<T> elementTypeToken) {
-        return new OfCollectionApiImpl(List.class, elementTypeToken);
+        return new OfCollectionApiImpl(List.class, ApiValidator.validateTypeToken(elementTypeToken));
     }
 
     /**
@@ -381,7 +382,7 @@ public final class Instancio {
      */
     @SuppressWarnings("all")
     public static <T> InstancioOfCollectionApi<Set<T>> ofSet(final TypeTokenSupplier<T> elementTypeToken) {
-        return new OfCollectionApiImpl(Set.class, elementTypeToken);
+        return new OfCollectionApiImpl(Set.class, ApiValidator.validateTypeToken(elementTypeToken));
     }
 
     /**
@@ -431,7 +432,9 @@ public final class Instancio {
             final TypeTokenSupplier<K> keyTypeToken,
             final TypeTokenSupplier<V> valueTypeToken) {
 
-        return new OfMapApiImpl(Map.class, keyTypeToken, valueTypeToken);
+        return new OfMapApiImpl(Map.class,
+                ApiValidator.validateTypeToken(keyTypeToken),
+                ApiValidator.validateTypeToken(valueTypeToken));
     }
 
     @SuppressWarnings("unchecked")

--- a/instancio-core/src/main/java/org/instancio/TypeToken.java
+++ b/instancio-core/src/main/java/org/instancio/TypeToken.java
@@ -15,8 +15,6 @@
  */
 package org.instancio;
 
-import org.instancio.internal.util.Verify;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
@@ -51,9 +49,8 @@ public interface TypeToken<T> extends TypeTokenSupplier<T> {
      */
     @Override
     default Type get() {
-        Type superClass = getClass().getGenericInterfaces()[0];
-        Verify.isTrue(superClass instanceof ParameterizedType, "Missing type parameter");
-        return ((ParameterizedType) superClass).getActualTypeArguments()[0];
+        Type type = getClass().getGenericInterfaces()[0];
+        return ((ParameterizedType) type).getActualTypeArguments()[0];
     }
 
 }

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -36,8 +36,8 @@ public class ApiImpl<T> implements InstancioApi<T> {
 
     private final ModelContext.Builder<T> modelContextBuilder;
 
-    public ApiImpl(final Class<T> klass) {
-        this.modelContextBuilder = ModelContext.builder(ApiValidator.validateRootClass(klass));
+    public ApiImpl(final Type klass) {
+        this.modelContextBuilder = ModelContext.builder(klass);
     }
 
     public ApiImpl(final TypeTokenSupplier<T> typeToken) {

--- a/instancio-core/src/main/java/org/instancio/internal/OfClassApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfClassApiImpl.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Type;
 
 public class OfClassApiImpl<T> extends ApiImpl<T> implements InstancioOfClassApi<T> {
 
-    public OfClassApiImpl(final Class<T> klass) {
+    public OfClassApiImpl(final Type klass) {
         super(klass);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/OfCollectionApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfCollectionApiImpl.java
@@ -18,29 +18,18 @@ package org.instancio.internal;
 import org.instancio.InstancioOfCollectionApi;
 import org.instancio.Model;
 import org.instancio.Select;
-import org.instancio.TypeTokenSupplier;
 import org.instancio.internal.context.ModelContext;
+import org.instancio.internal.reflect.ParameterizedTypeImpl;
 
+import java.lang.reflect.Type;
 import java.util.Collection;
 
 public final class OfCollectionApiImpl<T, C extends Collection<T>>
         extends OfClassApiImpl<C>
         implements InstancioOfCollectionApi<C> {
 
-    public OfCollectionApiImpl(
-            final Class<C> collectionType,
-            final Class<T> elementType) {
-
-        super(collectionType);
-        withTypeParameters(elementType);
-    }
-
-    public OfCollectionApiImpl(
-            final Class<C> collectionType,
-            final TypeTokenSupplier<T> typeToken) {
-
-        super(collectionType);
-        withTypeParameters(ApiValidator.validateTypeToken(typeToken));
+    public OfCollectionApiImpl(final Class<C> collectionType, final Type elementType) {
+        super(new ParameterizedTypeImpl(collectionType, elementType));
     }
 
     private OfCollectionApiImpl(final Model<C> collectionModel) {

--- a/instancio-core/src/main/java/org/instancio/internal/OfMapApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/OfMapApiImpl.java
@@ -17,32 +17,17 @@ package org.instancio.internal;
 
 import org.instancio.InstancioOfCollectionApi;
 import org.instancio.Select;
-import org.instancio.TypeTokenSupplier;
+import org.instancio.internal.reflect.ParameterizedTypeImpl;
 
+import java.lang.reflect.Type;
 import java.util.Map;
 
 public final class OfMapApiImpl<K, V, M extends Map<K, V>>
         extends OfClassApiImpl<M>
         implements InstancioOfCollectionApi<M> {
 
-    public OfMapApiImpl(
-            final Class<M> mapType,
-            final Class<K> keyType,
-            final Class<V> valueType) {
-
-        super(mapType);
-        withTypeParameters(keyType, valueType);
-    }
-
-    public OfMapApiImpl(
-            final Class<M> mapType,
-            final TypeTokenSupplier<K> keyTypeToken,
-            final TypeTokenSupplier<V> valueTypeToken) {
-
-        super(mapType);
-        withTypeParameters(
-                ApiValidator.validateTypeToken(keyTypeToken),
-                ApiValidator.validateTypeToken(valueTypeToken));
+    public OfMapApiImpl(final Class<M> mapType, final Type keyType, final Type valueType) {
+        super(new ParameterizedTypeImpl(mapType, keyType, valueType));
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -320,7 +320,7 @@ public final class ModelContext<T> {
         }
 
         public Builder<T> useModelAsTypeArgument(final ModelContext<?> otherContext) {
-            rootTypeParameters.add(TypeUtils.getRawType(otherContext.getRootType()));
+            rootTypeParameters.add(otherContext.getRootType());
             maxDepth = otherContext.maxDepth;
             seed = otherContext.seed;
             settings = otherContext.settings;

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -16,8 +16,8 @@
 package org.instancio.internal.nodes;
 
 import org.instancio.exception.InstancioException;
-import org.instancio.internal.reflection.DeclaredAndInheritedFieldsCollector;
-import org.instancio.internal.reflection.FieldCollector;
+import org.instancio.internal.reflect.DeclaredAndInheritedFieldsCollector;
+import org.instancio.internal.reflect.FieldCollector;
 import org.instancio.internal.util.ObjectUtils;
 import org.instancio.internal.util.TypeUtils;
 import org.jetbrains.annotations.NotNull;

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/DeclaredAndInheritedFieldsCollector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/DeclaredAndInheritedFieldsCollector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/DefaultPackageFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/DefaultPackageFilter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.instancio.internal.util.StringUtils;
 import org.jetbrains.annotations.Nullable;

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/FieldCollector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/FieldCollector.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.instancio.documentation.InternalApi;
 

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/PackageFilter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/PackageFilter.java
@@ -13,7 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.instancio.internal.reflect;
+
+import org.instancio.documentation.InternalApi;
+
 /**
- * Implementation classes providing support for reflection.
+ * A filter for checking whether a {@link Package} should be excluded from processing.
  */
-package org.instancio.internal.reflection;
+@InternalApi
+public interface PackageFilter {
+
+    /**
+     * Checks if given package is excluded.
+     *
+     * @param pkg package to check
+     * @return {@code true} if package should be excluded, {@code false} otherwise
+     */
+    boolean isExcluded(Package pkg);
+}

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/ParameterizedTypeImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/ParameterizedTypeImpl.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.reflect;
+
+import org.instancio.internal.util.Format;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ParameterizedTypeImpl implements ParameterizedType {
+
+    private final Type ownerType;
+    private final Class<?> rawType;
+    private final Type[] typeArguments;
+
+    private ParameterizedTypeImpl(final Type ownerType, final Class<?> rawType, final Type... typeArguments) {
+        this.ownerType = ownerType;
+        this.rawType = rawType;
+        this.typeArguments = typeArguments;
+    }
+
+    public ParameterizedTypeImpl(final Class<?> rawType, final Type... typeArguments) {
+        this(null, rawType, typeArguments);
+    }
+
+    @Override
+    public Type getOwnerType() {
+        return ownerType;
+    }
+
+    @Override
+    public Type getRawType() {
+        return rawType;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+        return typeArguments.clone();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ParameterizedTypeImpl)) return false;
+
+        final ParameterizedTypeImpl that = (ParameterizedTypeImpl) o;
+
+        if (!Objects.equals(ownerType, that.ownerType)) return false;
+        if (!Objects.equals(rawType, that.rawType)) return false;
+        return Arrays.equals(typeArguments, that.typeArguments);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ownerType != null ? ownerType.hashCode() : 0;
+        result = 31 * result + (rawType != null ? rawType.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(typeArguments);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final String args = Stream.of(typeArguments)
+                .map(Format::withoutPackage)
+                .collect(Collectors.joining(", "));
+
+        return Format.withoutPackage(rawType) + "<" + args + ">";
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/package-info.java
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
-
-import org.instancio.documentation.InternalApi;
-
 /**
- * A filter for checking whether a {@link Package} should be excluded from processing.
+ * Implementation classes providing support for reflection.
  */
-@InternalApi
-public interface PackageFilter {
-
-    /**
-     * Checks if given package is excluded.
-     *
-     * @param pkg package to check
-     * @return {@code true} if package should be excluded, {@code false} otherwise
-     */
-    boolean isExcluded(Package pkg);
-}
+package org.instancio.internal.reflect;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListToModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListToModelTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.allStrings;
 
 @FeatureTag({Feature.OF_LIST, Feature.MODEL})
 class OfListToModelTest {
@@ -44,5 +45,18 @@ class OfListToModelTest {
                 .hasSize(expectedSize)
                 .extracting(Phone::getCountryCode)
                 .containsOnly("+1");
+    }
+
+    @Test
+    void nestedListsFromModel() {
+        final Model<List<String>> model = Instancio.ofList(String.class)
+                .generate(allStrings(), gen -> gen.string().length(1))
+                .toModel();
+
+        final List<List<String>> results = Instancio.ofList(model).create();
+
+        assertThat(results).isNotEmpty().allSatisfy(nested ->
+                assertThat(nested).isNotEmpty().allSatisfy(s ->
+                        assertThat(s).hasSize(1)));
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofset/OfSetFromModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofset/OfSetFromModelTest.java
@@ -1,4 +1,19 @@
-package org.instancio.test.features.ofmap;
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.ofset;
 
 import org.instancio.Instancio;
 import org.instancio.Model;
@@ -12,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.allStrings;
 import static org.instancio.Select.field;
 
 @FeatureTag({Feature.OF_SET, Feature.MODEL})
@@ -72,6 +88,19 @@ class OfSetFromModelTest {
         assertThat(result1)
                 .hasSize(EXPECTED_SIZE)
                 .isEqualTo(result2);
+    }
+
+    @Test
+    void nestedSetsFromModel() {
+        final Model<Set<String>> model = Instancio.ofSet(String.class)
+                .generate(allStrings(), gen -> gen.string().length(1))
+                .toModel();
+
+        final Set<Set<String>> results = Instancio.ofSet(model).create();
+
+        assertThat(results).isNotEmpty().allSatisfy(nested ->
+                assertThat(nested).isNotEmpty().allSatisfy(s ->
+                        assertThat(s).hasSize(1)));
     }
 
     private static void assertMatchesModel(final Collection<Phone> actual) {

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/DeclaredAndInheritedFieldsCollectorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/DeclaredAndInheritedFieldsCollectorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.instancio.test.support.pojo.inheritance.BaseClassSubClassInheritance;
 import org.instancio.test.support.pojo.person.Person;

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/DefaultPackageFilterTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/DefaultPackageFilterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/ParameterizedTypeImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/reflect/ParameterizedTypeImplTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.reflect;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParameterizedTypeImplTest {
+
+    @Test
+    void verifyEqualsAndHashCode() {
+        EqualsVerifier.forClass(ParameterizedTypeImpl.class).verify();
+    }
+
+    @Test
+    void ownerType() {
+        final ParameterizedTypeImpl type = new ParameterizedTypeImpl(List.class, String.class);
+
+        assertThat(type.getOwnerType()).isNull();
+    }
+
+    @Test
+    void verifyToString() {
+        final ParameterizedTypeImpl listOfStrings = new ParameterizedTypeImpl(List.class, String.class);
+
+        assertThat(listOfStrings)
+                .hasToString("List<String>");
+
+        assertThat(new ParameterizedTypeImpl(List.class, listOfStrings))
+                .hasToString("List<List<String>>");
+
+        assertThat(new ParameterizedTypeImpl(Map.class, Integer.class, Long.class))
+                .hasToString("Map<Integer, Long>");
+    }
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/internal/reflect/RecordUtilsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/internal/reflect/RecordUtilsTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.reflection;
+package org.instancio.internal.reflect;
 
 import org.instancio.internal.util.RecordUtils;
 import org.instancio.test.support.java16.record.AddressRecord;


### PR DESCRIPTION
Fixes an error produced when passing a `Model` containing a collection to `ofList()` or `ofSet()`:

```java
Model<List<Foo>> model = Instancio.ofList(Foo.class)
        // ...snip
        .toModel();

List<List<Foo>> results = Instancio.ofList(model).create();
```
