### PR TITLE
New setting key `SETTER_EXCLUDE_MODIFIER` (#618)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/assignment/MethodModifier.java
+++ b/instancio-core/src/main/java/org/instancio/assignment/MethodModifier.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.assignment;
+
+import org.instancio.documentation.ExperimentalApi;
+
+import java.lang.reflect.Modifier;
+
+/**
+ * A class containing modifier constants.
+ *
+ * <p>This class contains a subset of method modifiers from {@link Modifier},
+ * with the addition of a custom {@link #PACKAGE_PRIVATE} modifier
+ * to represent package-private methods.
+ *
+ * @since 2.16.0
+ */
+@ExperimentalApi
+public final class MethodModifier {
+
+    /**
+     * Modifier for package-private method.
+     *
+     * <p>This is a custom value specific to Instancio.
+     * It is not defined in the {@link Modifier} class.
+     */
+    public static final int PACKAGE_PRIVATE = 0x00008000;
+
+    /**
+     * Modifier for {@code private} method.
+     */
+    public static final int PRIVATE = Modifier.PRIVATE;
+
+    /**
+     * Modifier for {@code protected} method.
+     */
+    public static final int PROTECTED = Modifier.PROTECTED;
+
+    /**
+     * Modifier for {@code public} method.
+     */
+    public static final int PUBLIC = Modifier.PUBLIC;
+
+    /**
+     * Modifier for {@code static} method.
+     */
+    public static final int STATIC = Modifier.STATIC;
+
+    private MethodModifier() {
+        // non-instantiable
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/AssignerUtil.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/AssignerUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.assigners;
+
+import org.instancio.assignment.MethodModifier;
+
+import java.lang.reflect.Modifier;
+
+final class AssignerUtil {
+
+    private AssignerUtil() {
+        // non-instantiable
+    }
+
+    static boolean isExcluded(final int modifiers, final int excludeModifiers) {
+        return (modifiers & excludeModifiers) > 0
+                || shouldExcludePackagePrivate(modifiers, excludeModifiers);
+    }
+
+    private static boolean shouldExcludePackagePrivate(final int modifiers, final int exclusionModifiers) {
+        final boolean excludePackagePrivate = (exclusionModifiers & MethodModifier.PACKAGE_PRIVATE) > 0;
+
+        return excludePackagePrivate
+                && !Modifier.isPrivate(modifiers)
+                && !Modifier.isProtected(modifiers)
+                && !Modifier.isPublic(modifiers);
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/MethodAssigner.java
@@ -43,11 +43,13 @@ final class MethodAssigner implements Assigner {
     private final Assigner fieldAssigner;
     private final Settings settings;
     private final MethodNameResolver setterNameResolver;
+    private final int excludedModifiers;
 
     MethodAssigner(final Settings settings) {
         this.settings = settings;
         this.setterNameResolver = getMethodNameResolver(settings.get(Keys.SETTER_STYLE));
         this.fieldAssigner = new FieldAssigner(settings);
+        this.excludedModifiers = settings.get(Keys.SETTER_EXCLUDE_MODIFIER);
 
         LOG.trace("{}, {}, {}, {}", AssignmentType.METHOD,
                 settings.get(Keys.SETTER_STYLE),
@@ -90,6 +92,11 @@ final class MethodAssigner implements Assigner {
 
         if (methodOpt.isPresent()) {
             final Method method = methodOpt.get();
+
+            if (AssignerUtil.isExcluded(method.getModifiers(), excludedModifiers)) {
+                return;
+            }
+
             try {
                 method.setAccessible(true);
                 method.invoke(target, arg);

--- a/instancio-core/src/main/java/org/instancio/settings/Keys.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Keys.java
@@ -17,6 +17,7 @@ package org.instancio.settings;
 
 import org.instancio.Mode;
 import org.instancio.assignment.AssignmentType;
+import org.instancio.assignment.MethodModifier;
 import org.instancio.assignment.OnSetFieldError;
 import org.instancio.assignment.OnSetMethodError;
 import org.instancio.assignment.OnSetMethodNotFound;
@@ -265,6 +266,10 @@ public final class Keys {
      * default is {@link AssignmentType#FIELD}; property name {@code assignment.type}.
      *
      * @see AssignmentType
+     * @see #ON_SET_METHOD_ERROR
+     * @see #ON_SET_METHOD_NOT_FOUND
+     * @see #SETTER_EXCLUDE_MODIFIER
+     * @see #SETTER_STYLE
      * @since 2.1.0
      */
     @ExperimentalApi
@@ -313,6 +318,35 @@ public final class Keys {
     @ExperimentalApi
     public static final SettingKey<SetterStyle> SETTER_STYLE = register(
             "setter.style", SetterStyle.class, SetterStyle.SET);
+    /**
+     * Specifies modifier exclusions for setter-methods;
+     * default is {@code 0} (no exclusions);
+     * property name {@code setter.exclude.modifier}.
+     *
+     * <p>This setting can be used to control which setter methods are allowed
+     * to be invoked (based on method modifiers) when {@link #ASSIGNMENT_TYPE}
+     * is set to {@link AssignmentType#METHOD}). For instance, using this
+     * setting, it is possible to restrict method assignment to {@code public}
+     * setters only (by default, a setter is invoked even if it is {@code private}).
+     *
+     * <p>Multiple modifiers can be specified using logical {@code OR}
+     * operator. For example, the following allows only {@code public} methods:
+     *
+     * <pre>{@code
+     *   int exclusions = MethodModifier.PACKAGE_PRIVATE
+     *                  | MethodModifier.PROTECTED
+     *                  | MethodModifier.PRIVATE;
+     *
+     *   Settings.create().set(Keys.SETTER_EXCLUDE_MODIFIER, exclusions);
+     * }</pre>
+     *
+     * @see #ASSIGNMENT_TYPE
+     * @see MethodModifier
+     * @since 2.16.0
+     */
+    @ExperimentalApi
+    public static final SettingKey<Integer> SETTER_EXCLUDE_MODIFIER = register(
+            "setter.exclude.modifier", Integer.class, 0);
     /**
      * Specifies whether values should be generated based on
      * <a href="https://beanvalidation.org/3.0/">Jakarta Bean Validation 3.0</a>

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignment/MethodAssignmentExcludeModifierTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignment/MethodAssignmentExcludeModifierTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.assignment;
+
+import org.instancio.Instancio;
+import org.instancio.assignment.AssignmentType;
+import org.instancio.assignment.MethodModifier;
+import org.instancio.assignment.OnSetMethodError;
+import org.instancio.assignment.OnSetMethodNotFound;
+import org.instancio.internal.util.SystemProperties;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.ASSIGNMENT)
+@ExtendWith(InstancioExtension.class)
+@DisabledIfSystemProperty(named = SystemProperties.ASSIGNMENT_TYPE, matches = "FIELD")
+class MethodAssignmentExcludeModifierTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.ASSIGNMENT_TYPE, AssignmentType.METHOD)
+            .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL)
+            .set(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.FAIL);
+
+    @Test
+    @DisplayName("Default behaviour: should invoke all setters regardless of modifiers")
+    void shouldInvokeAllSettersByDefault() {
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.foo).isNotNull();
+        assertThat(result.bar).isNotNull();
+        assertThat(result.baz).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should exclude private and package-private setters")
+    void excludePrivateAndPackagePrivateSetters() {
+        final int exclusions = MethodModifier.PRIVATE | MethodModifier.PACKAGE_PRIVATE;
+
+        final Pojo result = Instancio.of(Pojo.class)
+                .withSettings(Settings.create()
+                        .set(Keys.SETTER_EXCLUDE_MODIFIER, exclusions))
+                .create();
+
+        assertThat(result.foo).isNotNull();
+        assertThat(result.bar).isNull();
+        assertThat(result.baz).isNull();
+    }
+
+    private static class Pojo {
+        private String foo;
+        private String bar;
+        private String baz;
+
+        public void setFoo(final String foo) {
+            this.foo = foo;
+        }
+
+        // used via reflection
+        @SuppressWarnings("unused")
+        private void setBar(final String bar) {
+            this.bar = bar;
+        }
+
+        // used via reflection
+        @SuppressWarnings("unused")
+        void setBaz(final String baz) {
+            this.baz = baz;
+        }
+    }
+}

--- a/instancio-tests/instancio-core-tests/pom.xml
+++ b/instancio-tests/instancio-core-tests/pom.xml
@@ -10,6 +10,10 @@
     <packaging>jar</packaging>
     <name>Instancio tests: instancio-core Tests</name>
 
+    <properties>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/assigners/AssignerUtilTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/assigners/AssignerUtilTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.assigners;
+
+import org.instancio.assignment.MethodModifier;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssignerUtilTest {
+    private static final String PUBLIC_METHOD = "publicMethod";
+    private static final String PUBLIC_STATIC_METHOD = "publicStaticMethod";
+    private static final String PROTECTED_METHOD = "protectedMethod";
+    private static final String PACKAGE_PRIVATE_METHOD = "packagePrivateMethod";
+    private static final String PACKAGE_PRIVATE_STATIC_METHOD = "packagePrivateStaticMethod";
+    private static final String PRIVATE_METHOD = "privateMethod";
+    private static final String PRIVATE_STATIC_METHOD = "privateStaticMethod";
+
+    private static final Set<String> ALL_METHODS = Set.of(
+            PUBLIC_METHOD,
+            PUBLIC_STATIC_METHOD,
+            PROTECTED_METHOD,
+            PACKAGE_PRIVATE_METHOD,
+            PACKAGE_PRIVATE_STATIC_METHOD,
+            PRIVATE_METHOD,
+            PRIVATE_STATIC_METHOD
+    );
+
+    //@formatter:off
+    @SuppressWarnings("unused")
+    private static class Pojo {
+        public void publicMethod() {}
+        public static void publicStaticMethod() {}
+        protected void protectedMethod() {}
+        void packagePrivateMethod() {}
+        static void packagePrivateStaticMethod() {}
+        private void privateMethod() {}
+        private static void privateStaticMethod() {}
+    }
+    //@formatter:on
+
+    @Test
+    void excludeNone() {
+        final int exclude = 0;
+        final String[] expectedExclusions = {};
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePublic() {
+        final int exclude = MethodModifier.PUBLIC;
+        final String[] expectedExclusions = {PUBLIC_METHOD, PUBLIC_STATIC_METHOD};
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePrivate() {
+        final int exclude = MethodModifier.PRIVATE;
+        final String[] expectedExclusions = {PRIVATE_METHOD, PRIVATE_STATIC_METHOD};
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePackagePrivate() {
+        final int exclude = MethodModifier.PACKAGE_PRIVATE;
+        final String[] expectedExclusions = {PACKAGE_PRIVATE_METHOD, PACKAGE_PRIVATE_STATIC_METHOD};
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePrivateProtectedAndStatic() {
+        final int exclude = MethodModifier.PRIVATE
+                | MethodModifier.PROTECTED
+                | MethodModifier.STATIC;
+
+        final String[] expectedExclusions = {
+                PUBLIC_STATIC_METHOD,
+                PACKAGE_PRIVATE_STATIC_METHOD,
+                PROTECTED_METHOD,
+                PRIVATE_METHOD,
+                PRIVATE_STATIC_METHOD
+        };
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePrivateProtectedAndPackagePrivate() {
+        final int exclude = MethodModifier.PRIVATE
+                | MethodModifier.PROTECTED
+                | MethodModifier.PACKAGE_PRIVATE;
+
+        final String[] expectedExclusions = {
+                PACKAGE_PRIVATE_METHOD,
+                PACKAGE_PRIVATE_STATIC_METHOD,
+                PROTECTED_METHOD,
+                PRIVATE_METHOD,
+                PRIVATE_STATIC_METHOD
+        };
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludePrivateProtectedPackagePrivateAndStatic() {
+        // effectively allows only non-static public methods
+        final int exclude = MethodModifier.PRIVATE
+                | MethodModifier.PROTECTED
+                | MethodModifier.PACKAGE_PRIVATE
+                | MethodModifier.STATIC;
+
+        final String[] expectedExclusions = {
+                PUBLIC_STATIC_METHOD,
+                PACKAGE_PRIVATE_METHOD,
+                PACKAGE_PRIVATE_STATIC_METHOD,
+                PROTECTED_METHOD,
+                PRIVATE_METHOD,
+                PRIVATE_STATIC_METHOD
+        };
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    @Test
+    void excludeStatic() {
+        final int exclude = MethodModifier.STATIC;
+
+        final String[] expectedExclusions = {
+                PUBLIC_STATIC_METHOD,
+                PACKAGE_PRIVATE_STATIC_METHOD,
+                PRIVATE_STATIC_METHOD
+        };
+
+        assertExcludedMethods(exclude, expectedExclusions);
+    }
+
+    private static void assertExcludedMethods(final int modifierExclusions, final String... expectedMethods) {
+        assertExcluded(true, modifierExclusions, expectedMethods);
+
+        // remaining methods should NOT be excluded
+        final Set<String> included = new HashSet<>(ALL_METHODS);
+        Stream.of(expectedMethods).forEach(included::remove);
+        assertExcluded(false, modifierExclusions, included.toArray(String[]::new));
+    }
+
+    private static void assertExcluded(
+            final boolean expectedResult, final int modifierExclusions, final String... expectedMethods) {
+
+        for (String methodName : expectedMethods) {
+            final Method method = getMethod(methodName);
+            final int modifiers = method.getModifiers();
+            final boolean result = AssignerUtil.isExcluded(modifiers, modifierExclusions);
+
+            assertThat(result)
+                    .as("Method: '%s'", methodName)
+                    .isEqualTo(expectedResult);
+        }
+    }
+
+    private static Method getMethod(final String method) {
+        try {
+            return Pojo.class.getDeclaredMethod(method);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("Method not found: " + method);
+        }
+    }
+}


### PR DESCRIPTION
The new setting allows specifying setter-method modifiers to be excluded when `Keys.ASSIGNMENT_TYPE` is set to `AssignmentType.METHOD` (for example, for populating a POJO via public setters only).

Example:

```java
class Pojo {
    private String foo;
    private String bar;
    private String baz;

    public void setFoo(String foo) { this.foo = foo; }

    private void setBar(String bar) { this.bar = bar; }

    void setBaz(String baz) { this.baz = baz; }
}

// Do not invoke private and package-private setters
int exclusions = MethodModifier.PRIVATE | MethodModifier.PACKAGE_PRIVATE;

Pojo pojo = Instancio.of(Pojo.class)
        .withSettings(Settings.create()
                .set(Keys.SETTER_EXCLUDE_MODIFIER, exclusions))
        .create();

assertThat(pojo.foo).isNotNull();
assertThat(pojo.bar).isNull();
assertThat(pojo.baz).isNull();
```

