### PR TITLE
Increment max depth when creating a collection from a model (#639)

### DIFF
--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/maxdepth/MaxDepthWithModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/maxdepth/MaxDepthWithModelTest.java
@@ -23,14 +23,48 @@ import org.instancio.settings.Settings;
 import org.instancio.test.support.pojo.person.Address;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
 
 @FeatureTag({Feature.MAX_DEPTH, Feature.MODEL, Feature.SETTINGS})
 @ExtendWith(InstancioExtension.class)
 class MaxDepthWithModelTest {
+
+    @Nested
+    class CollectionFromModelTest {
+        @Test
+        void maxDepthViaBuilderApi() {
+            final Model<Address> model = Instancio.of(Address.class)
+                    .withMaxDepth(0)
+                    .toModel();
+
+            assertMaxDepth(model);
+        }
+
+        @Test
+        void maxDepthViaSettings() {
+            final Model<Address> model = Instancio.of(Address.class)
+                    .withSettings(Settings.create().set(Keys.MAX_DEPTH, 0))
+                    .toModel();
+
+            assertMaxDepth(model);
+        }
+
+        private void assertMaxDepth(final Model<Address> model) {
+            final List<Address> results = Instancio.ofList(model).create();
+
+            assertThat(results).isNotEmpty().allSatisfy(result -> {
+                assertThatObject(result).hasAllFieldsOfTypeSetToNull(String.class);
+                assertThat(result.getPhoneNumbers()).isNull();
+            });
+        }
+    }
 
     @Test
     void shouldInheritMaxDepthFromModelSpecifiedViaBuilderApi() {


### PR DESCRIPTION
When creating a collection from a model, the collection becomes the root type which effectively decreases the model's max depth by 1.