### PR TITLE
Removed deprecated `value()` attribute from `InstancioSource` annotation

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
@@ -47,16 +47,4 @@ import java.lang.annotation.Target;
 @Documented
 @ArgumentsSource(InstancioArgumentsProvider.class)
 public @interface InstancioSource {
-
-    /**
-     * Specifies parameter types to generate. Each specified type
-     * represents a parameter in the {@code ParameterizedTest} method.
-     *
-     * @return parameter types to generate
-     * @deprecated parameter types will be resolved from method arguments,
-     * therefore specifying the types via the annotation is no longer necessary
-     * (this method will be removed in version {@code 3.0.0}).
-     */
-    @Deprecated
-    Class<?>[] value() default {};
 }

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/InstancioArgumentsProviderTest.java
@@ -41,7 +41,7 @@ class InstancioArgumentsProviderTest {
 
     private final InstancioArgumentsProvider provider = new InstancioArgumentsProvider();
 
-    @InstancioSource({String.class, Integer.class})
+    @InstancioSource
     private void dummy() {
     }
 

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2445,8 +2445,6 @@ class ExampleTest {
 }
 ```
 
-It should be noted that using `@InstancioSource` has a couple of important limitations that make it unsuitable in many situations.
-
-The biggest limitation is that the generated objects cannot be customised.
+It should be noted that using `@InstancioSource` has one important limitations in that generated objects cannot be customised.
 The only option is to customise generated values using [settings injection](#settings-injection).
-However, it is not possible to customise values on a per-field basis, as you would with the builder API.
+However, it is not possible to customise values on a per-field basis like with the builder API.


### PR DESCRIPTION
The attribute is redundant since argument types can be resolved from method parameters :


```java
// Before
@InstancioSource({String.class, String.class})
@ParameterizedTest
void example(String first, String second) {}

// After
@InstancioSource
@ParameterizedTest
void example(String first, String second) {}
```