### PR TITLE
Support for scopes when using `atDepth()` with regular selectors

### DIFF
--- a/instancio-core/src/main/java/org/instancio/DepthSelector.java
+++ b/instancio-core/src/main/java/org/instancio/DepthSelector.java
@@ -29,6 +29,10 @@ public interface DepthSelector {
     /**
      * Restricts this selector's target(s) to the specified depth.
      *
+     * <p>When a selector {@code atDepth(N)} is converted {@code toScope()},
+     * the semantics of {@link Selector#within(Scope...)} method still hold,
+     * meaning: at depth equal to <b>or greater than</b> {@code N}.
+     *
      * @param depth the depth at which selector applies
      * @return selector restricted to the specified depth
      * @since 2.14.0

--- a/instancio-core/src/main/java/org/instancio/ScopeableSelector.java
+++ b/instancio-core/src/main/java/org/instancio/ScopeableSelector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+/**
+ * Represents a selector that can be scoped using
+ * {@code within(Scope...scopes)}.
+ *
+ * @since 3.0.0
+ */
+public interface ScopeableSelector extends GroupableSelector, ConvertibleToScope {
+
+    /**
+     * Specifies the scope for this selector in order to narrow
+     * down its target.
+     *
+     * <p>For example, given the following classes:
+     *
+     * <pre>{@code
+     * record Phone(String countryCode, String number) {}
+     *
+     * record Person(Phone home, Phone cell) {}
+     * }</pre>
+     *
+     * <p>setting {@code home} and {@code cell} phone numbers to different
+     * values would require differentiating between two
+     * {@code field(Phone::number)}  selectors. This can be achieved using
+     * scopes as follows:
+     *
+     * <pre>{@code
+     * Scope homePhone = field(Person::home).toScope();
+     * Scope cellPhone = field(Person::cell).toScope();
+     *
+     * Person person = Instancio.of(Person.class)
+     *     .set(field(Phone::number).within(homePhone), "777-88-99")
+     *     .set(field(Phone::number).within(cellPhone), "123-45-67")
+     *     .create();
+     * }</pre>
+     *
+     * <p>See <a href="https://instancio.org/user-guide/#selector-scopes">Selector Scopes</a>
+     * section of the user guide for details.
+     *
+     * @param scopes one or more scopes to apply
+     * @return a selector with the specified scope
+     * @since 3.0.0
+     */
+    GroupableSelector within(Scope... scopes);
+}

--- a/instancio-core/src/main/java/org/instancio/Selector.java
+++ b/instancio-core/src/main/java/org/instancio/Selector.java
@@ -28,41 +28,21 @@ package org.instancio;
  * @see TargetSelector
  * @since 1.2.0
  */
-public interface Selector extends DepthSelector, GroupableSelector, ConvertibleToScope {
+public interface Selector extends DepthSelector, GroupableSelector, ScopeableSelector, ConvertibleToScope {
 
     /**
-     * Specifies the scope for this selector in order to narrow down its target.
-     * <p>
-     * For example, if the {@code Person} class has two {@code Phone} fields:
-     * <p>
-     * <pre>{@code
-     *     class Person {
-     *         private Phone home;
-     *         private Phone cell;
-     *         // snip...
-     *     }
-     * }</pre>
+     * {@inheritDoc}
      *
-     * <p>and we want to set only the {@code cell} phone to a specific value, we can narrow
-     * down the selector as follows:
+     * @since 3.0.0
+     */
+    @Override
+    ScopeableSelector atDepth(int depth);
+
+    /**
+     * {@inheritDoc}
      *
-     * <pre>{@code
-     *   // Scope can be created using:
-     *   Scope cellPhone = scope(Person.class, "cell");
-     *   // or selector toScope() method
-     *   Scope cellPhone = field(Person::getCell).toScope();
-     *
-     *   Person person = Instancio.of(Person.class)
-     *       .set(field(Phone.class, "number").within(cellPhone), "123-45-67")
-     *       .create();
-     * }</pre>
-     *
-     * <p>See <a href="http://localhost:8000/user-guide/#selector-scopes">Selector Scopes</a>
-     * section of the user guide for details.
-     *
-     * @param scopes one or more scopes to apply
-     * @return a selector with the specified scope
      * @since 1.3.0
      */
+    @Override
     GroupableSelector within(Scope... scopes);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContextHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContextHelper.java
@@ -116,7 +116,7 @@ final class ModelContextHelper {
         for (Scope scope : scopes) {
             ScopeImpl s = (ScopeImpl) scope;
             if (s.getTargetClass() == null) {
-                results.add(new ScopeImpl(rootClass, s.getFieldName()));
+                results.add(new ScopeImpl(rootClass, s.getFieldName(), s.getDepth()));
             } else {
                 results.add(scope);
             }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/PrimitiveAndWrapperSelectorImpl.java
@@ -67,7 +67,7 @@ public final class PrimitiveAndWrapperSelectorImpl implements Selector, Flattene
     }
 
     @Override
-    public TargetSelector atDepth(final int depth) {
+    public Selector atDepth(final int depth) {
         ApiValidator.validateDepth(depth);
         return new PrimitiveAndWrapperSelectorImpl(
                 primitive.toBuilder().depth(depth).build(),

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/ScopeImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/ScopeImpl.java
@@ -26,10 +26,21 @@ import java.util.Objects;
 public final class ScopeImpl implements Scope {
     private final Class<?> targetClass;
     private final String fieldName;
+    private final Integer depth;
 
-    public ScopeImpl(final Class<?> targetClass, @Nullable final String fieldName) {
+    public ScopeImpl(@Nullable final Class<?> targetClass,
+                     @Nullable final String fieldName,
+                     @Nullable final Integer depth) {
+
         this.targetClass = targetClass;
         this.fieldName = fieldName;
+        this.depth = depth;
+    }
+
+    public ScopeImpl(@Nullable final Class<?> targetClass,
+                     @Nullable final String fieldName) {
+
+        this(targetClass, fieldName, null);
     }
 
     public Class<?> getTargetClass() {
@@ -38,6 +49,10 @@ public final class ScopeImpl implements Scope {
 
     public String getFieldName() {
         return fieldName;
+    }
+
+    public Integer getDepth() {
+        return depth;
     }
 
     public boolean isFieldScope() {
@@ -55,21 +70,27 @@ public final class ScopeImpl implements Scope {
         if (!(o instanceof ScopeImpl)) return false;
         final ScopeImpl scope = (ScopeImpl) o;
         return Objects.equals(targetClass, scope.targetClass)
-                && Objects.equals(fieldName, scope.fieldName);
+                && Objects.equals(fieldName, scope.fieldName)
+                && Objects.equals(depth, scope.depth);
     }
 
     @Override
     public int hashCode() {
-        int result = targetClass != null ? targetClass.hashCode() : 0;
-        result = 31 * result + (fieldName != null ? fieldName.hashCode() : 0);
+        int result = targetClass == null ? 0 : targetClass.hashCode();
+        result = 31 * result + (fieldName == null ? 0 : fieldName.hashCode());
+        result = 31 * result + (depth == null ? 0 : depth.hashCode());
         return result;
     }
 
     @Override
     public String toString() {
-        if (fieldName == null) {
-            return String.format("scope(%s)", targetClass.getSimpleName());
+        String s = "scope(" + targetClass.getSimpleName();
+        if (fieldName != null) {
+            s += ", \"" + fieldName + '"';
         }
-        return String.format("scope(%s, \"%s\")", getTargetClass().getSimpleName(), fieldName);
+        if (depth != null) {
+            s += ", atDepth(" + depth + ')';
+        }
+        return s + ')';
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
@@ -104,7 +104,7 @@ public final class SelectorImpl
     }
 
     @Override
-    public TargetSelector atDepth(final int depth) {
+    public Selector atDepth(final int depth) {
         return toBuilder()
                 .depth(ApiValidator.validateDepth(depth))
                 .build();
@@ -122,7 +122,7 @@ public final class SelectorImpl
 
     @Override
     public Scope toScope() {
-        return new ScopeImpl(targetClass, fieldName);
+        return new ScopeImpl(targetClass, fieldName, depth);
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/util/Format.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Format.java
@@ -16,7 +16,6 @@
 package org.instancio.internal.util;
 
 import org.instancio.Scope;
-import org.instancio.internal.selectors.ScopeImpl;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -51,10 +50,7 @@ public final class Format {
 
     public static String formatScopes(final List<Scope> scopes) {
         return scopes.stream()
-                .map(ScopeImpl.class::cast)
-                .map(s -> s.getFieldName() == null
-                        ? String.format("scope(%s)", s.getTargetClass().getSimpleName())
-                        : String.format("scope(%s, \"%s\")", s.getTargetClass().getSimpleName(), s.getFieldName()))
+                .map(Object::toString)
                 .collect(joining(", "));
     }
 

--- a/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_SelectorAtDepthCannotBeCalledMoreThanOnce.java
+++ b/instancio-tests/api-contract-tests/src/main/non-build/NonCompilable_SelectorAtDepthCannotBeCalledMoreThanOnce.java
@@ -1,0 +1,9 @@
+import org.instancio.*;
+
+class NonCompilable_SelectorAtDepthCannotBeCalledMoreThanOnce {
+
+    void nonCompilable() {
+        // The second call to atDepth() should produce compilation error
+        Select.all(String.class).atDepth(1).atDepth(2);
+    }
+}

--- a/instancio-tests/api-contract-tests/src/test/java/org/instancio/test/contract/SelectorApiContractTest.java
+++ b/instancio-tests/api-contract-tests/src/test/java/org/instancio/test/contract/SelectorApiContractTest.java
@@ -204,6 +204,13 @@ class SelectorApiContractTest {
     }
 
     @Test
+    @DisplayName("atDepth() cannot be called more than once")
+    void atDepthCannotBeCalledMoreThanOnce() throws Exception {
+        assertCompilationError("NonCompilable_SelectorAtDepthCannotBeCalledMoreThanOnce.java",
+                "cannot find symbol", "method atDepth");
+    }
+
+    @Test
     @DisplayName("ofList() should not expose withTypeParameters() method")
     void ofListWithTypeParametersNotAllowed() throws Exception {
         assertCompilationError("NonCompilable_OfListWithTypeParameters.java",

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/ScopeImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/ScopeImplTest.java
@@ -39,5 +39,9 @@ class ScopeImplTest {
     void verifyToString() {
         assertThat(new ScopeImpl(String.class, null)).hasToString("scope(String)");
         assertThat(new ScopeImpl(Person.class, "name")).hasToString("scope(Person, \"name\")");
+
+        // with depth
+        assertThat(new ScopeImpl(String.class, null, 1)).hasToString("scope(String, atDepth(1))");
+        assertThat(new ScopeImpl(Person.class, "name", 2)).hasToString("scope(Person, \"name\", atDepth(2))");
     }
 }

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailRecord.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailRecord.java
@@ -20,5 +20,6 @@ import lombok.Data;
 @Data
 public class DetailRecord {
     private Long id;
+    private Long mainRecordId;
     private MainRecord mainRecord;
 }


### PR DESCRIPTION
- Support for converting a selector `atDepth()` to `Scope`:

```java
all(Foo.class).atDepth(3).toScope();
field(Foo::getBar).atDepth(3).toScope();
```

- Support for scoping `atDepth()` selector using `within()`:

```java
all(Foo.class).atDepth(2).within(scope(Bar.class));
```

- Support for adding selectors `atDepth()` to a group:

```java
TargetSelector group = Select.all(
      all(Foo.class).atDepth(1),
      field(Foo::getBar).atDepth(2),
      all(Baz.class).atDepth(3).within(scope(Jazz.class))
);
```