### PR TITLE
Removed a conditional branch that never executed.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
@@ -35,7 +35,6 @@ import org.instancio.settings.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Modifier;
 import java.util.Set;
 
 class GeneratorFacade {
@@ -82,10 +81,6 @@ class GeneratorFacade {
         return isEnabled ? new BeanValidationProcessor() : new NoopBeanValidationProvider();
     }
 
-    private boolean hasStaticField(final InternalNode node) {
-        return node.getField() != null && Modifier.isStatic(node.getField().getModifiers());
-    }
-
     private boolean shouldReturnNullForNullable(final InternalNode node) {
         final boolean precondition = context.isNullable(node);
         return context.getRandom().diceRoll(precondition);
@@ -94,7 +89,7 @@ class GeneratorFacade {
     GeneratorResult generateNodeValue(final InternalNode node) {
         GeneratorResult result = GeneratorResult.emptyResult();
 
-        if (node.isIgnored() || hasStaticField(node)) {
+        if (node.isIgnored()) {
             result = GeneratorResult.ignoredResult();
         } else if (shouldReturnNullForNullable(node)) {
             result = GeneratorResult.nullResult();

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/InstancioApiTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/InstancioApiTest.java
@@ -215,4 +215,15 @@ class InstancioApiTest {
 
         assertThat(result).isNotNull();
     }
+
+    @Test
+    void staticFieldShouldNotBePopulated() {
+        final ClassWithStaticField result = Instancio.create(ClassWithStaticField.class);
+
+        assertThat(result.value).isNull();
+    }
+
+    private static class ClassWithStaticField {
+        private static String value;
+    }
 }


### PR DESCRIPTION
Since static fields are ignored, the check was redundant.