### PR TITLE
Support for setting back-references to the `root()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generators/Generators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/Generators.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.generators;
 
-import org.instancio.InstancioApi;
 import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.ArrayGeneratorSpec;
@@ -325,33 +324,9 @@ public class Generators {
      *   // Then => FooBar[foo=BAZ, bar=BAZ]
      * }</pre>
      *
-     * <p><b>Warning:</b> using {@code emit()} with cyclic classes,
-     * where instances of the same type are generated at different depths,
-     * may produce unexpected results. In case of cyclic classes, use
-     * one of the following methods to limit the depth:
-     *
-     * <ul>
-     *   <li>{@link InstancioApi#withMaxDepth(int)} to limit
-     *       the overall depth, <b>or</b></li>
-     *   <li>{@code atDepth()} method provided by selectors (example below)</li>
-     * </ul>
-     *
-     * <p><b>Example:</b>
-     *
-     * <pre>{@code
-     *   // emit() order status values only at depth 2
-     *   //
-     *   // Depth 0: List (root object)
-     *   // Depth 1: Order class (list element)
-     *   // Depth 2: Order fields (including OrderStatus)
-     *   List<Order> orders = Instancio.ofList(Order.class)
-     *     .size(7)
-     *     .generate(field(Order::getStatus).atDepth(2), gen -> gen.emit()
-     *              .items(OrderStatus.RECEIVED, OrderStatus.SHIPPED)
-     *              .item(OrderStatus.COMPLETED, 3)
-     *              .item(OrderStatus.CANCELLED, 2))
-     *     .create();
-     * }</pre>
+     * <p><b>Warning:</b> special care must be taken to ensure that the
+     * selector associated with {@code emit()} matches only the expected target
+     * and nothing else. Failure to do so may produce unexpected results.
      *
      * @param <T> the type to emit
      * @return emitting generator

--- a/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GeneratorFacade.java
@@ -91,6 +91,9 @@ class GeneratorFacade {
 
         if (node.isIgnored()) {
             result = GeneratorResult.ignoredResult();
+        } else if (node.isCyclic()) {
+            // Cyclic nodes can only be set via an assignment
+            result = assignmentNodeHandler.getResult(node);
         } else if (shouldReturnNullForNullable(node)) {
             result = GeneratorResult.nullResult();
         } else {

--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -147,7 +147,7 @@ class InstancioEngine {
             generatorResult = generateRecord(node);
         } else if (node.is(NodeKind.CONTAINER)) {
             generatorResult = generateContainer(node);
-        } else if (node.is(NodeKind.DEFAULT)) {
+        } else if (node.is(NodeKind.DEFAULT) || node.isCyclic()) {
             generatorResult = generatePojo(node);
         } else { // unreachable
             throw Fail.withFataInternalError("Unhandled node kind: '%s' for %s", node.getNodeKind(), node);

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
@@ -182,7 +182,7 @@ class NodeCreator {
 
     private InternalNode fromClass(final Class<?> type, @Nullable final Field field, @Nullable final InternalNode parent) {
         final InternalNode node = createNodeWithSubtypeMapping(type, field, parent);
-        return node.hasAncestorEqualToSelf() ? null : node;
+        return node.hasAncestorWithSameTargetType() ? node.toBuilder().cyclic().build() : node;
     }
 
     private NodeKind getNodeKind(final Class<?> rawType) {
@@ -195,7 +195,7 @@ class NodeCreator {
             @Nullable final InternalNode parent) {
 
         final InternalNode node = createNodeWithSubtypeMapping(type, field, parent);
-        return node.hasAncestorEqualToSelf() ? null : node;
+        return node.hasAncestorWithSameTargetType() ? node.toBuilder().cyclic().build() : node;
     }
 
     private InternalNode fromGenericArrayNode(

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -66,6 +66,10 @@ public final class NodeFactory {
 
         while (!childlessNodeQueue.isEmpty()) {
             final InternalNode node = childlessNodeQueue.poll();
+            if (node.isCyclic()) {
+                continue;
+            }
+
             originSelectorValidator.checkNode(node);
 
             final List<InternalNode> children = createChildlessChildren(node);

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeStats.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeStats.java
@@ -82,9 +82,15 @@ public final class NodeStats {
                     .append(' ')
                     .append(node.getField().getName());
         }
+
         if (node.isIgnored()) {
             sb.append(" [IGNORED]");
         }
+
+        if (node.isCyclic()) {
+            sb.append(" [CYCLIC]");
+        }
+
         return sb.append('>').toString();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignBackReferenceTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignBackReferenceTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.assign;
+
+import org.instancio.Instancio;
+import org.instancio.Selector;
+import org.instancio.TargetSelector;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.cyclic.onetomany.DetailPojo;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojoContainer;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Assign.valueOf;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+import static org.instancio.Select.scope;
+
+@FeatureTag({Feature.ASSIGN, Feature.ROOT_SELECTOR})
+@ExtendWith(InstancioExtension.class)
+class AssignBackReferenceTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AssignBackReferenceToMainPojoTest {
+
+        private Stream<Arguments> rootSelector() {
+            return Stream.of(Arguments.of(root()), Arguments.of(all(MainPojo.class)));
+        }
+
+        @MethodSource("rootSelector")
+        @ParameterizedTest
+        void withRoot(final TargetSelector rootObjectSelector) {
+            final MainPojo result = Instancio.of(MainPojo.class)
+                    .assign(valueOf(rootObjectSelector).to(DetailPojo::getMainPojo))
+                    .assign(valueOf(MainPojo::getId).to(DetailPojo::getMainPojoId))
+                    .create();
+
+            assertThat(result.getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                assertThat(detail.getMainPojo()).isSameAs(result);
+                assertThat(detail.getMainPojoId()).isEqualTo(result.getId());
+            });
+        }
+
+        @Test
+        void createList() {
+            final List<MainPojo> results = Instancio.ofList(MainPojo.class)
+                    .assign(valueOf(all(MainPojo.class)).to(DetailPojo::getMainPojo))
+                    .assign(valueOf(MainPojo::getId).to(DetailPojo::getMainPojoId))
+                    .create();
+
+            assertThat(results).isNotEmpty().allSatisfy(result -> {
+                assertThat(result.getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                    assertThat(detail.getMainPojo()).isSameAs(result);
+                    assertThat(detail.getMainPojoId()).isEqualTo(result.getId());
+                });
+            });
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AssignBackReferenceToDetailPojoTest {
+
+        private Stream<Arguments> rootSelector() {
+            return Stream.of(Arguments.of(root()), Arguments.of(all(DetailPojo.class)));
+        }
+
+        @MethodSource("rootSelector")
+        @ParameterizedTest
+        void withRoot(final TargetSelector selector) {
+            final DetailPojo result = Instancio.of(DetailPojo.class)
+                    .assign(valueOf(selector).to(all(DetailPojo.class).within(scope(List.class))))
+                    .assign(valueOf(MainPojo::getId).to(DetailPojo::getMainPojoId))
+                    .create();
+
+            assertThat(result.getMainPojo().getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                assertThat(detail).isSameAs(result);
+                assertThat(detail.getMainPojoId()).isSameAs(result.getMainPojoId());
+            });
+        }
+
+
+        private Stream<Arguments> rootListElementSelector() {
+            return Stream.of(
+                    Arguments.of(all(DetailPojo.class)),
+                    Arguments.of(all(DetailPojo.class).atDepth(1)));
+        }
+
+        @MethodSource("rootListElementSelector")
+        @ParameterizedTest
+        void createList(final TargetSelector rootListElementSelector) {
+            final List<DetailPojo> results = Instancio.ofList(DetailPojo.class)
+                    .assign(valueOf(rootListElementSelector)
+                            .to(all(DetailPojo.class).within(scope(MainPojo.class))))
+                    .assign(valueOf(MainPojo::getId).to(DetailPojo::getMainPojoId))
+                    .create();
+
+            assertThat(results).isNotEmpty().allSatisfy(result -> {
+                assertThat(result.getMainPojo().getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                    assertThat(detail).isSameAs(result);
+                    assertThat(detail.getMainPojoId()).isSameAs(result.getMainPojoId());
+                });
+            });
+        }
+    }
+
+    @Nested
+    class AssignBackReferenceWithMainPojoContainerTest {
+        private final Selector mainPojo1 = field(MainPojoContainer::getMainPojo1);
+        private final Selector mainPojo2 = field(MainPojoContainer::getMainPojo2);
+        private final Selector mainPojoId = field(MainPojo::getId);
+
+        @Test
+        void create() {
+            final MainPojoContainer result = Instancio.of(MainPojoContainer.class)
+                    .assign(valueOf(mainPojo1).to(field(DetailPojo::getMainPojo).within(mainPojo1.toScope())))
+                    .assign(valueOf(mainPojo2).to(field(DetailPojo::getMainPojo).within(mainPojo2.toScope())))
+
+                    .assign(valueOf(mainPojoId.atDepth(2).within(mainPojo1.toScope()))
+                            .to(field(DetailPojo::getMainPojoId).within(mainPojo1.toScope())))
+
+                    .assign(valueOf(mainPojoId.atDepth(2).within(mainPojo2.toScope()))
+                            .to(field(DetailPojo::getMainPojoId).within(mainPojo2.toScope())))
+                    .create();
+
+            assertContainer(result);
+        }
+
+        @Test
+        void createList() {
+            final List<MainPojoContainer> results = Instancio.ofList(MainPojoContainer.class)
+                    .assign(valueOf(mainPojo1).to(field(DetailPojo::getMainPojo).within(mainPojo1.toScope())))
+                    .assign(valueOf(mainPojo2).to(field(DetailPojo::getMainPojo).within(mainPojo2.toScope())))
+
+                    .assign(valueOf(mainPojoId.atDepth(3).within(mainPojo1.toScope()))
+                            .to(field(DetailPojo::getMainPojoId).within(mainPojo1.toScope())))
+
+                    .assign(valueOf(mainPojoId.atDepth(3).within(mainPojo2.toScope()))
+                            .to(field(DetailPojo::getMainPojoId).within(mainPojo2.toScope())))
+                    .create();
+
+            results.forEach(this::assertContainer);
+        }
+
+        private void assertContainer(final MainPojoContainer result) {
+            assertThat(result.getMainPojo1().getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                assertThat(detail.getMainPojo()).isSameAs(result.getMainPojo1());
+                assertThat(detail.getMainPojoId()).isSameAs(result.getMainPojo1().getId());
+            });
+
+            assertThat(result.getMainPojo2().getDetailPojos()).isNotEmpty().allSatisfy(detail -> {
+                assertThat(detail.getMainPojo()).isSameAs(result.getMainPojo2());
+                assertThat(detail.getMainPojoId()).isSameAs(result.getMainPojo2().getId());
+            });
+        }
+    }
+
+    @Test
+    void optionalContainer() {
+        @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+        class Container {
+            Optional<Container> optional;
+        }
+
+        final Container result = Instancio.of(Container.class)
+                .assign(valueOf(root()).to(all(Container.class).within(scope(Optional.class))))
+                .create();
+
+        assertThat(result.optional).get().isSameAs(result);
+    }
+
+    @Test
+    void arrayContainer() {
+        class Container {
+            Container[] array;
+        }
+
+        final Container result = Instancio.of(Container.class)
+                .assign(valueOf(root()).to(all(Container.class).within(scope(Container[].class))))
+                .create();
+
+        assertThat(result.array)
+                .isNotEmpty()
+                .allSatisfy(element -> assertThat(element).isSameAs(result));
+    }
+
+    @Test
+    void listContainer() {
+        class Container {
+            List<Container> list;
+        }
+
+        final Container result = Instancio.of(Container.class)
+                .assign(valueOf(root()).to(all(Container.class).within(scope(List.class))))
+                .create();
+
+        assertThat(result.list)
+                .isNotEmpty()
+                .allSatisfy(element -> assertThat(element).isSameAs(result));
+    }
+
+    @Test
+    void mapContainer() {
+        class Container {
+            Map<String, Container> map;
+        }
+
+        final Container result = Instancio.of(Container.class)
+                .assign(valueOf(root()).to(all(Container.class).within(scope(Map.class))))
+                .create();
+
+        assertThat(result.map.values())
+                .isNotEmpty()
+                .allSatisfy(value -> assertThat(value).isSameAs(result));
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignCyclicClassTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignCyclicClassTest.java
@@ -60,15 +60,11 @@ class AssignCyclicClassTest {
 
         // prev
         assertThat(result.getPrev().getPrev()).isNull();
-        assertThat(result.getPrev().getNext().getValue())
-                .isNotNull()
-                .isNotEqualTo(childVal);
+        assertThat(result.getPrev().getNext()).isNull();
 
         // next
         assertThat(result.getNext().getNext()).isNull();
-        assertThat(result.getNext().getPrev().getValue())
-                .isNotNull()
-                .isNotEqualTo(childVal);
+        assertThat(result.getNext().getPrev()).isNull();
     }
 
     @Test
@@ -100,14 +96,10 @@ class AssignCyclicClassTest {
 
         // prev
         assertThat(result.getPrev().getPrev()).isNull();
-        assertThat(result.getPrev().getNext().getValue())
-                .isNotNull()
-                .isEqualTo(childVal);
+        assertThat(result.getPrev().getNext()).isNull();
 
         // next
         assertThat(result.getNext().getNext()).isNull();
-        assertThat(result.getNext().getPrev().getValue())
-                .isNotNull()
-                .isEqualTo(childVal);
+        assertThat(result.getNext().getPrev()).isNull();
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignUnsupportedTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignUnsupportedTest.java
@@ -15,10 +15,8 @@
  */
 package org.instancio.test.features.assign;
 
-import lombok.Data;
 import org.instancio.Assign;
 import org.instancio.Instancio;
-import org.instancio.internal.nodes.NodeFactory;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.support.pojo.person.Address;
 import org.instancio.test.support.pojo.person.Phone;
@@ -27,17 +25,13 @@ import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.Assign.valueOf;
 import static org.instancio.Select.all;
 import static org.instancio.Select.field;
-import static org.instancio.Select.root;
 
 /**
  * This test is disabled and is for documentation purposes only.
@@ -46,27 +40,6 @@ import static org.instancio.Select.root;
 @FeatureTag({Feature.ASSIGN, Feature.UNSUPPORTED})
 @ExtendWith(InstancioExtension.class)
 class AssignUnsupportedTest {
-
-    //@formatter:off
-    private static @Data class Order { List<OrderItem> items; }
-    private static @Data class OrderItem { Order order; }
-    //@formatter:on
-
-    /**
-     * Currently unsupported because {@code OrderItem.order} is set
-     * to {@code null} to terminate the cycle. Will probably require
-     * changes to the {@link NodeFactory} to support this use case.
-     */
-    @Test
-    void assignRoot() {
-        final Order order = Instancio.of(Order.class)
-                .assign(valueOf(root()).to(OrderItem::getOrder))
-                .create();
-
-        assertThat(order.getItems()).isNotEmpty().allSatisfy(item ->
-                assertThat(item.getOrder()).isSameAs(order));
-    }
-
 
     /**
      * What happens when the origin selector matches multiple targets?

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cyclic/OneToManyWithCrossReferencesTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cyclic/OneToManyWithCrossReferencesTest.java
@@ -53,20 +53,19 @@ class OneToManyWithCrossReferencesTest {
                 .getObjectE()  // 4
                 .getObjectF()  // 5
                 .getObjectG()  // 6
-                .getObjectB()  // 7
-                .getObjectC(); // 8
+                .getObjectB(); // 7
 
         assertThat(maxDepthObject).hasAllNullFieldsOrProperties();
 
         // Cycles should be terminated with a null
         assertThat(objectA.getObjectB().get(0).getObjectA()).isNull();
-        assertThat(objectA.getObjectB().get(0).getObjectC().getObjectB().getObjectC()).isNull();
+        assertThat(objectA.getObjectB().get(0).getObjectC().getObjectB()).isNull();
 
         assertThat(objectA.getObjectC().get(0).getObjectA()).isNull();
-        assertThat(objectA.getObjectC().get(0).getObjectD().getObjectG().getObjectD().getObjectG()).isNull();
+        assertThat(objectA.getObjectC().get(0).getObjectD().getObjectG().getObjectD()).isNull();
 
         assertThat(objectA.getObjectD().get(0).getObjectA()).isNull();
-        assertThat(objectA.getObjectD().get(0).getObjectB().getObjectC().getObjectB().getObjectC()).isNull();
+        assertThat(objectA.getObjectD().get(0).getObjectB().getObjectC().getObjectB()).isNull();
     }
 
     @Test

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorCyclicPojoTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorCyclicPojoTest.java
@@ -18,8 +18,8 @@ package org.instancio.test.features.generator.misc;
 import org.instancio.Instancio;
 import org.instancio.TargetSelector;
 import org.instancio.junit.InstancioExtension;
-import org.instancio.test.support.pojo.cyclic.onetomany.DetailRecord;
-import org.instancio.test.support.pojo.cyclic.onetomany.MainRecord;
+import org.instancio.test.support.pojo.cyclic.onetomany.DetailPojo;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Test;
@@ -51,13 +51,13 @@ class EmitGeneratorCyclicPojoTest {
 
     @Test
     void emitCollectionElementField() {
-        final MainRecord result = Instancio.of(MainRecord.class)
+        final MainPojo result = Instancio.of(MainPojo.class)
                 .generate(all(List.class), gen -> gen.collection().size(3))
-                .generate(field(DetailRecord::getId), gen -> gen.emit().items(1L, 2L, 3L))
+                .generate(field(DetailPojo::getId), gen -> gen.emit().items(1L, 2L, 3L))
                 .create();
 
-        assertThat(result.getDetailRecords())
-                .extracting(DetailRecord::getId)
+        assertThat(result.getDetailPojos())
+                .extracting(DetailPojo::getId)
                 .containsExactly(1L, 2L, 3L);
     }
 
@@ -83,20 +83,30 @@ class EmitGeneratorCyclicPojoTest {
     private static Stream<Arguments> statusSelectors() {
         final int depth = 2;
         final Predicate<Integer> predicate = d -> d == depth;
+
         return Stream.of(
-                // regular and predicate selectors: depth as an integer
+                // regular and predicate selectors
+                Arguments.of(all(OrderStatus.class)),
                 Arguments.of(all(OrderStatus.class).atDepth(depth)),
+                Arguments.of(field(Order::getStatus)),
                 Arguments.of(field(Order::getStatus).atDepth(depth)),
+                Arguments.of(field(Order.class, "status")),
                 Arguments.of(field(Order.class, "status").atDepth(depth)),
+                Arguments.of(fields(f -> f.getType() == OrderStatus.class)),
                 Arguments.of(fields(f -> f.getType() == OrderStatus.class).atDepth(depth)),
+                Arguments.of(types(t -> t == OrderStatus.class)),
                 Arguments.of(types(t -> t == OrderStatus.class).atDepth(depth)),
 
-                // predicate selectors: depth as a predicate
+                // predicate selectors
+                Arguments.of(fields(f -> f.getType() == OrderStatus.class)),
                 Arguments.of(fields(f -> f.getType() == OrderStatus.class).atDepth(predicate)),
+                Arguments.of(types(t -> t == OrderStatus.class)),
                 Arguments.of(types(t -> t == OrderStatus.class).atDepth(predicate)),
 
-                // predicate selector builders: depth as a predicate
+                // predicate selector builders
+                Arguments.of(fields().ofType(OrderStatus.class)),
                 Arguments.of(fields().ofType(OrderStatus.class).atDepth(predicate)),
+                Arguments.of(types().of(OrderStatus.class)),
                 Arguments.of(types().of(OrderStatus.class).atDepth(predicate))
         );
     }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/ClassesABCWithCrossReferencesCreationTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/ClassesABCWithCrossReferencesCreationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.creation.cyclic;
+
+import org.instancio.test.support.pojo.cyclic.ClassesABCWithCrossReferences;
+import org.instancio.test.support.tags.CyclicTag;
+import org.instancio.testsupport.templates.AutoVerificationDisabled;
+import org.instancio.testsupport.templates.CreationTestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@CyclicTag
+@AutoVerificationDisabled
+public class ClassesABCWithCrossReferencesCreationTest extends CreationTestTemplate<ClassesABCWithCrossReferences> {
+
+    @Override
+    protected void verify(final ClassesABCWithCrossReferences result) {
+        assertThat(result.getObjectA().getObjectA()).isNull();
+        assertThat(result.getObjectA().getObjectB().getObjectA()).isNull();
+        assertThat(result.getObjectA().getObjectB().getObjectB()).isNull();
+        assertThat(result.getObjectA().getObjectC().getObjectA()).isNull();
+        assertThat(result.getObjectA().getObjectC().getObjectC()).isNull();
+        assertThat(result.getObjectA().getObjectB().getObjectC().getObjectA()).isNull();
+        assertThat(result.getObjectA().getObjectB().getObjectC().getObjectB()).isNull();
+        assertThat(result.getObjectA().getObjectB().getObjectC().getObjectC()).isNull();
+        assertThat(result.getObjectA().getObjectC().getObjectB().getObjectA()).isNull();
+        assertThat(result.getObjectA().getObjectC().getObjectB().getObjectB()).isNull();
+        assertThat(result.getObjectA().getObjectC().getObjectB().getObjectC()).isNull();
+
+        assertThat(result.getObjectB().getObjectB()).isNull();
+        assertThat(result.getObjectB().getObjectA().getObjectA()).isNull();
+        assertThat(result.getObjectB().getObjectA().getObjectB()).isNull();
+        assertThat(result.getObjectB().getObjectC().getObjectB()).isNull();
+        assertThat(result.getObjectB().getObjectC().getObjectC()).isNull();
+        assertThat(result.getObjectB().getObjectA().getObjectC().getObjectA()).isNull();
+        assertThat(result.getObjectB().getObjectA().getObjectC().getObjectB()).isNull();
+        assertThat(result.getObjectB().getObjectA().getObjectC().getObjectC()).isNull();
+        assertThat(result.getObjectB().getObjectC().getObjectA().getObjectA()).isNull();
+        assertThat(result.getObjectB().getObjectC().getObjectA().getObjectB()).isNull();
+        assertThat(result.getObjectB().getObjectC().getObjectA().getObjectC()).isNull();
+
+        assertThat(result.getObjectC().getObjectC()).isNull();
+        assertThat(result.getObjectC().getObjectA().getObjectA()).isNull();
+        assertThat(result.getObjectC().getObjectA().getObjectC()).isNull();
+        assertThat(result.getObjectC().getObjectB().getObjectB()).isNull();
+        assertThat(result.getObjectC().getObjectB().getObjectC()).isNull();
+        assertThat(result.getObjectC().getObjectA().getObjectB().getObjectA()).isNull();
+        assertThat(result.getObjectC().getObjectA().getObjectB().getObjectB()).isNull();
+        assertThat(result.getObjectC().getObjectA().getObjectB().getObjectC()).isNull();
+        assertThat(result.getObjectC().getObjectB().getObjectA().getObjectA()).isNull();
+        assertThat(result.getObjectC().getObjectB().getObjectA().getObjectB()).isNull();
+        assertThat(result.getObjectC().getObjectB().getObjectA().getObjectC()).isNull();
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/IndirectCircularRefCreationTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/IndirectCircularRefCreationTest.java
@@ -37,12 +37,7 @@ public class IndirectCircularRefCreationTest extends CreationTestTemplate<Indire
                 .satisfies(c -> assertThat(c).isNotNull())
                 // C -> endA
                 .extracting(IndirectCircularRef.C::getEndA)
-                .satisfies(endA -> assertThat(endA).isNotNull())
-                // A -> B
-                .extracting(IndirectCircularRef.A::getB)
-                .satisfies(b -> assertThat(b)
-                        .as("Reached 'B' again; end cycle with a null value")
-                        .isNull());
+                .satisfies(endA -> assertThat(endA).isNull());
     }
 
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/onetomany/DetailPojoCreationTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/onetomany/DetailPojoCreationTest.java
@@ -15,7 +15,8 @@
  */
 package org.instancio.creation.cyclic.onetomany;
 
-import org.instancio.test.support.pojo.cyclic.onetomany.MainRecord;
+import org.instancio.test.support.pojo.cyclic.onetomany.DetailPojo;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.testsupport.templates.AutoVerificationDisabled;
 import org.instancio.testsupport.templates.CreationTestTemplate;
@@ -24,15 +25,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @CyclicTag
 @AutoVerificationDisabled
-public class MainRecordCreationTest extends CreationTestTemplate<MainRecord> {
+public class DetailPojoCreationTest extends CreationTestTemplate<DetailPojo> {
 
     @Override
-    protected void verify(MainRecord result) {
-        assertThat(result.getDetailRecords())
-                .isNotEmpty()
-                .allSatisfy(detail -> {
-                    assertThat(detail.getId()).isNotNull();
-                    assertThat(detail.getMainRecord()).isNull();
-                });
+    protected void verify(DetailPojo result) {
+        final MainPojo mainPojo = result.getMainPojo();
+        assertThat(mainPojo).isNotNull();
+        assertThat(mainPojo.getDetailPojos())
+                .as("Should have an empty collection to break the cycle")
+                .isEmpty();
     }
+
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/onetomany/MainPojoCreationTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/cyclic/onetomany/MainPojoCreationTest.java
@@ -15,8 +15,7 @@
  */
 package org.instancio.creation.cyclic.onetomany;
 
-import org.instancio.test.support.pojo.cyclic.onetomany.DetailRecord;
-import org.instancio.test.support.pojo.cyclic.onetomany.MainRecord;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
 import org.instancio.test.support.tags.CyclicTag;
 import org.instancio.testsupport.templates.AutoVerificationDisabled;
 import org.instancio.testsupport.templates.CreationTestTemplate;
@@ -25,15 +24,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @CyclicTag
 @AutoVerificationDisabled
-public class DetailRecordCreationTest extends CreationTestTemplate<DetailRecord> {
+public class MainPojoCreationTest extends CreationTestTemplate<MainPojo> {
 
     @Override
-    protected void verify(DetailRecord result) {
-        final MainRecord mainRecord = result.getMainRecord();
-        assertThat(mainRecord).isNotNull();
-        assertThat(mainRecord.getDetailRecords())
-                .as("Should have an empty collection to break the cycle")
-                .isEmpty();
+    protected void verify(MainPojo result) {
+        assertThat(result.getDetailPojos())
+                .isNotEmpty()
+                .allSatisfy(detail -> {
+                    assertThat(detail.getId()).isNotNull();
+                    assertThat(detail.getMainPojo()).isNull();
+                });
     }
-
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/InternalNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/InternalNodeTest.java
@@ -79,6 +79,7 @@ class InternalNodeTest {
                 .parent(parent)
                 .nodeContext(NODE_CONTEXT)
                 .children(children)
+                .cyclic()
                 .build();
 
         final InternalNode copy = node.toBuilder().build();
@@ -93,6 +94,7 @@ class InternalNodeTest {
         assertThat(copy.getOnlyChild()).isEqualTo(node.getOnlyChild());
         assertThat(copy.getChildren()).isEqualTo(node.getChildren());
         assertThat(copy.getNodeKind()).isEqualTo(node.getNodeKind());
+        assertThat(copy.isCyclic()).isEqualTo(node.isCyclic());
     }
 
     @Nested

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeStatsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/nodes/NodeStatsTest.java
@@ -18,6 +18,7 @@ package org.instancio.internal.nodes;
 import org.instancio.Select;
 import org.instancio.TargetSelector;
 import org.instancio.internal.context.BooleanSelectorMap;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
 import org.instancio.test.support.pojo.misc.ClassWithoutFields;
 import org.instancio.test.support.pojo.misc.StringsDef;
 import org.instancio.test.support.pojo.misc.StringsGhi;
@@ -105,5 +106,23 @@ class NodeStatsTest {
         assertThat(stats.getTreeString()).isEqualTo(expected);
         assertThat(stats.getTotalNodes()).isEqualTo(8);
         assertThat(stats.getHeight()).isEqualTo(2);
+    }
+
+    @Test
+    void withCyclicNode() {
+        final InternalNode node = NODE_FACTORY.createRootNode(MainPojo.class);
+        final NodeStats stats = NodeStats.compute(node);
+
+        final String expected = """
+                <0:MainPojo>
+                 ├──<1:MainPojo: Long id>
+                 └──<1:MainPojo: List<DetailPojo> detailPojos>
+                     └──<2:DetailPojo>
+                         ├──<3:DetailPojo: Long id>
+                         ├──<3:DetailPojo: Long mainPojoId>
+                         └──<3:DetailPojo: MainPojo mainPojo [CYCLIC]>
+                """;
+
+        assertThat(stats.getTreeString()).isEqualTo(expected);
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BidirectionalOneToOneNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/BidirectionalOneToOneNodeTest.java
@@ -38,14 +38,22 @@ class BidirectionalOneToOneNodeTest extends NodeTestTemplate<BidirectionalOneToO
                 .hasParent(rootNode)
                 .hasFieldName("child")
                 .hasTargetClass(BidirectionalOneToOne.Child.class)
-                .hasChildrenOfSize(1)
+                .hasChildrenOfSize(2)
                 .get();
 
-        assertNode(child.getOnlyChild())
+        assertNode(NodeUtils.getChildNode(child, "childName"))
                 .hasDepth(2)
                 .hasParent(child)
                 .hasFieldName("childName")
                 .hasTargetClass(String.class)
+                .hasNoChildren();
+
+        assertNode(NodeUtils.getChildNode(child, "parent"))
+                .hasDepth(2)
+                .hasParent(child)
+                .hasFieldName("parent")
+                .hasTargetClass(BidirectionalOneToOne.Parent.class)
+                .isCyclic()
                 .hasNoChildren();
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesABCWithCrossReferencesNodeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/nodes/ClassesABCWithCrossReferencesNodeTest.java
@@ -29,7 +29,7 @@ import static org.instancio.testsupport.utils.NodeUtils.getChildNode;
 @CyclicTag
 class ClassesABCWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesABCWithCrossReferences> {
 
-    private static final int EXPECTED_MAX_DEPTH = 10;
+    private static final int EXPECTED_MAX_DEPTH = 5;
 
     @Override
     protected void verify(InternalNode rootNode) {
@@ -40,37 +40,15 @@ class ClassesABCWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesABCW
         final Stats stats = new Stats();
         assertNodeRecursively(rootNode, 0, stats);
 
-        // Sample path:
-        // Root: ClassesABCWithCrossReferences[0]
-        // > ClassesABCWithCrossReferences.objectA[1]
-        // > ObjectA.objectA[2]
-        // > ObjectA.objectB[3]
-        // > ObjectB.objectA[4]
-        // > ObjectA.objectC[5]
-        // > ObjectC.objectB[6]
-        // > ObjectB.objectB[7]
-        // > ObjectB.objectC[8]
-        // > ObjectC.objectC[9]
-        // > ObjectC.objectA[10]
-        // > ObjectC.objectB - null since already occurred at depth [6]
-        assertThat(stats.maxDepth).isEqualTo(EXPECTED_MAX_DEPTH);
+        final int totalNodes = Arrays.stream(stats.nodesAtDepth).sum();
+        assertThat(totalNodes).isEqualTo(49);
 
-        // Note: the expected counts were put in after running the test.
-        // Need a calculation to confirm whether these expectations are actually correct
-        // (some nodes were discarded due to cycles)
-        assertThat(Arrays.stream(stats.nodesAtDepth).sum()).isEqualTo(1885);
-
+        assertThat(stats.maxDepth).isEqualTo(4);
         assertThat(stats.nodesAtDepth[0]).isEqualTo(1);
         assertThat(stats.nodesAtDepth[1]).isEqualTo(3);
         assertThat(stats.nodesAtDepth[2]).isEqualTo(9);
-        assertThat(stats.nodesAtDepth[3]).isEqualTo(24);
-        assertThat(stats.nodesAtDepth[4]).isEqualTo(60);
-        assertThat(stats.nodesAtDepth[5]).isEqualTo(126);
-        assertThat(stats.nodesAtDepth[6]).isEqualTo(234);
-        assertThat(stats.nodesAtDepth[7]).isEqualTo(348);
-        assertThat(stats.nodesAtDepth[8]).isEqualTo(432);
-        assertThat(stats.nodesAtDepth[9]).isEqualTo(432);
-        assertThat(stats.nodesAtDepth[10]).isEqualTo(216);
+        assertThat(stats.nodesAtDepth[3]).isEqualTo(18);
+        assertThat(stats.nodesAtDepth[4]).isEqualTo(18);
     }
 
     private void assertNodeRecursively(final InternalNode node, final int expectedDepth, final Stats stats) {
@@ -87,6 +65,6 @@ class ClassesABCWithCrossReferencesNodeTest extends NodeTestTemplate<ClassesABCW
 
     private static class Stats {
         int maxDepth;
-        final int[] nodesAtDepth = new int[EXPECTED_MAX_DEPTH + 1];
+        final int[] nodesAtDepth = new int[EXPECTED_MAX_DEPTH];
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/asserts/NodeAssert.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/testsupport/asserts/NodeAssert.java
@@ -160,6 +160,12 @@ public class NodeAssert extends AbstractAssert<NodeAssert, InternalNode> {
         return this;
     }
 
+    public NodeAssert isCyclic() {
+        isNotNull();
+        assertThat(actual.isCyclic()).isTrue();
+        return this;
+    }
+
     public NodeAssert hasDepth(final int expected) {
         isNotNull();
         assertThat(actual.getDepth()).isEqualTo(expected);

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailPojo.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/DetailPojo.java
@@ -18,8 +18,8 @@ package org.instancio.test.support.pojo.cyclic.onetomany;
 import lombok.Data;
 
 @Data
-public class DetailRecord {
+public class DetailPojo {
     private Long id;
-    private Long mainRecordId;
-    private MainRecord mainRecord;
+    private Long mainPojoId;
+    private MainPojo mainPojo;
 }

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainPojo.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainPojo.java
@@ -20,7 +20,7 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class MainRecord {
+public class MainPojo {
     private Long id;
-    private List<DetailRecord> detailRecords;
+    private List<DetailPojo> detailPojos;
 }

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainPojoContainer.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/cyclic/onetomany/MainPojoContainer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.pojo.cyclic.onetomany;
+
+import lombok.Data;
+
+@Data
+public class MainPojoContainer {
+    private MainPojo mainPojo1;
+    private MainPojo mainPojo2;
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/CyclicRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/CyclicRecordTest.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.test.java16;
 
-import org.assertj.core.api.Assertions;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.junit.InstancioExtension;
@@ -46,9 +45,15 @@ class CyclicRecordTest {
     void cyclicGenericRecord() {
         final NodeRecord<String> result = Instancio.create(new TypeToken<>() {});
 
-        assertThat(result.next()).isNull();
-        assertThat(result.prev()).isNull();
         assertThat(result.value()).isNotBlank();
+        // next
+        assertThat(result.next().value()).isNotBlank();
+        assertThat(result.next().next()).isNull();
+        assertThat(result.next().prev()).isNull();
+        // prev
+        assertThat(result.prev().value()).isNotBlank();
+        assertThat(result.prev().next()).isNull();
+        assertThat(result.prev().prev()).isNull();
     }
 
     @Test
@@ -56,7 +61,15 @@ class CyclicRecordTest {
         final ParentRecord parent = Instancio.create(ParentRecord.class);
 
         assertThat(parent.name()).isNotBlank();
-        assertThat(parent.children()).isNotEmpty()
-                .allSatisfy(child -> Assertions.assertThat(child.parent()).isNull());
+        assertThat(parent.children())
+                .isNotEmpty()
+                .allSatisfy(child -> assertThat(child.parent()).isNull());
     }
+
+    record Rec(Pojo pojo) {}
+
+    static class Pojo {
+        Rec rec;
+    }
+
 }

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/EmitGeneratorCyclicRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/EmitGeneratorCyclicRecordTest.java
@@ -45,9 +45,6 @@ class EmitGeneratorCyclicRecordTest {
                 OrderStatus.DELIVERED, OrderStatus.DELIVERED, OrderStatus.DELIVERED
         };
 
-        // emit() happens to work with cyclic records without specifying depth
-        // because record nodes are processed differently than POJOs.
-        // This test would fail for a POJO with similar structure unless depth was specified.
         final List<OrderRecord> result = Instancio.ofList(OrderRecord.class)
                 .size(statuses.length)
                 .generate(field(OrderRecord::status), gen -> gen.emit().items(statuses))

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignBackReferenceRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignBackReferenceRecordTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16.assign;
+
+import lombok.Data;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Assign.valueOf;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+import static org.instancio.Select.scope;
+
+@FeatureTag(Feature.ASSIGN)
+@ExtendWith(InstancioExtension.class)
+class AssignBackReferenceRecordTest {
+
+    @Nested
+    class RootRecordTest {
+        record Rec(Pojo pojo) {}
+
+        static @Data class Pojo {
+            Rec rec;
+        }
+
+        @Test
+        void rootRecord() {
+            final Rec result = Instancio.of(Rec.class)
+                    .assign(valueOf(root()).to(field(Pojo::getRec)))
+                    .create();
+
+            assertThat(result.pojo.rec).isSameAs(result);
+        }
+
+        @Test
+        void rootPojo() {
+            final Pojo result = Instancio.of(Pojo.class)
+                    .assign(valueOf(root()).to(field(Rec::pojo)))
+                    .create();
+
+            assertThat(result.rec.pojo).isSameAs(result);
+        }
+    }
+
+    @Nested
+    class RootRecordWithListTest {
+        record Rec(Pojo pojo) {}
+
+        static class Pojo {
+            List<Rec> records;
+        }
+
+        @Test
+        void rootRecord() {
+            final Rec result = Instancio.of(Rec.class)
+                    .assign(valueOf(root()).to(all(Rec.class).within(scope(List.class))))
+                    .create();
+
+            assertThat(result.pojo.records)
+                    .isNotEmpty()
+                    .allSatisfy(element -> assertThat(element).isSameAs(result));
+        }
+    }
+
+    @Nested
+    class RootPojoWithListTest {
+        static class Pojo {
+            Rec rec;
+        }
+
+        record Rec(List<Pojo> pojos) {}
+
+        @Test
+        void rootRecord() {
+            final Pojo result = Instancio.of(Pojo.class)
+                    .assign(valueOf(root()).to(all(Pojo.class).within(scope(List.class))))
+                    .create();
+
+            assertThat(result.rec.pojos)
+                    .isNotEmpty()
+                    .allSatisfy(element -> assertThat(element).isSameAs(result));
+        }
+    }
+
+
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignUnsupportedRecordsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignUnsupportedRecordsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16.assign;
+
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.exception.UnresolvedAssignmentException;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.cyclic.ChildRecord;
+import org.instancio.test.support.java16.record.cyclic.ParentRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Assign.valueOf;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.ASSIGN)
+@ExtendWith(InstancioExtension.class)
+class AssignUnsupportedRecordsTest {
+
+    /**
+     * Parent record cannot be fully constructed until all its children are.
+     * The children, in turn, need a reference to the parent object
+     * to set the back-reference. This creates a circular dependency,
+     * therefore the assignment cannot be resolved.
+     */
+    @Test
+    @FeatureTag(Feature.UNSUPPORTED)
+    void cyclicParentChildWithBackReference() {
+        final InstancioApi<ParentRecord> api = Instancio.of(ParentRecord.class)
+                .assign(valueOf(root()).to(ChildRecord::parent));
+
+        assertThatThrownBy(api::create)
+                .isExactlyInstanceOf(UnresolvedAssignmentException.class);
+    }
+}


### PR DESCRIPTION
Support for the following use case:

```java
class Order { List<OrderItem> orderItems; }
class OrderItem { Order order; }

Order order = Instancio.of(Order.class)
        .assign(valueOf(root()).to(OrderItem::getOrder))
        .create();

assertThat(order.getOrderItems()).allSatisfy(orderItem -> {
    assertThat(orderItem.getOrder()).isSameAs(order);
});
```