### PR TITLE
Collection/map population improvements

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -244,11 +244,16 @@ class InstancioEngine {
             }
 
             if (failedAdditions > Constants.FAILED_ADD_THRESHOLD) {
-                conditionalFailOnError(() -> {
-                    throw new InstancioException(
-                            "Unable to populate " + Format.withoutPackage(node.getType())
-                                    + " with requested number of entries: " + hint.generateEntries());
-                });
+                if (!keyNode.isCyclic() && !valueNode.isCyclic()) {
+                    conditionalFailOnError(() -> {
+                        final String errorMsg = String.format("Unable to populate %s with %s entries.%n"
+                                        + "Key node:   %s%n"
+                                        + "Value node: %s",
+                                Format.withoutPackage(node.getType()), hint.generateEntries(), keyNode, valueNode);
+
+                        throw new InstancioException(errorMsg);
+                    });
+                }
                 break;
             }
         }
@@ -417,16 +422,20 @@ class InstancioEngine {
                     failedAdditions++;
                 }
             } else {
-                // Avoid infinite loop (e.g. if value couldn't be generated)
+                // Avoid infinite loop when a value cannot be generated
                 failedAdditions++;
             }
 
             if (failedAdditions > Constants.FAILED_ADD_THRESHOLD) {
-                conditionalFailOnError(() -> {
-                    throw new InstancioException(
-                            "Unable to populate " + Format.withoutPackage(node.getType())
-                                    + " with requested number of elements: " + hint.generateElements());
-                });
+                if (!elementNode.isCyclic()) {
+                    conditionalFailOnError(() -> {
+                        final String errorMsg = String.format("Unable to populate %s with %s elements.%n" +
+                                        "Element node: %s",
+                                Format.withoutPackage(node.getType()), hint.generateElements(), elementNode);
+
+                        throw new InstancioException(errorMsg);
+                    });
+                }
                 break;
             }
         }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorCyclicNodeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorCyclicNodeTest.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2022-2023 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.instancio.test.features.generator.collection;
+
+import lombok.Data;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.internal.util.SystemProperties;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.test.support.asserts.Asserts.assertNoExceptionWithFailOnErrorEnabled;
+
+@FeatureTag(Feature.CYCLIC)
+@ExtendWith(InstancioExtension.class)
+class CollectionGeneratorCyclicNodeTest {
+
+    //@formatter:off
+    private static @Data class Root { A a; }
+    private static @Data class A { B b; }
+    private static @Data class B { List<A> list; }
+    //@formatter:on
+
+    @Test
+    void create() {
+        final Root result = Instancio.create(Root.class);
+
+        assertThat(result.a.b.list).isEmpty();
+    }
+
+    /**
+     * No exception should be thrown when {@link SystemProperties#FAIL_ON_ERROR} is enabled.
+     */
+    @Test
+    void withElement() {
+        final A expectedElement = new A();
+
+        final InstancioApi<Root> api = Instancio.of(Root.class)
+                .generate(field(B::getList), gen -> gen.collection()
+                        .size(100) // won't be able to generate but should not throw an error
+                        .with(expectedElement));
+
+        final Root result = assertNoExceptionWithFailOnErrorEnabled(api::create);
+
+        assertThat(result.a.b.list).containsOnly(expectedElement);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorSizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/collection/CollectionGeneratorSizeTest.java
@@ -15,13 +15,13 @@
  */
 package org.instancio.test.features.generator.collection;
 
+import org.instancio.Gen;
 import org.instancio.Instancio;
 import org.instancio.InstancioApi;
 import org.instancio.TypeToken;
 import org.instancio.exception.InstancioException;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.internal.util.Constants;
-import org.instancio.internal.util.SystemProperties;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.support.pojo.collections.CollectionLong;
 import org.instancio.test.support.pojo.person.Gender;
@@ -31,15 +31,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.all;
+import static org.instancio.test.support.asserts.Asserts.assertWithFailOnErrorEnabled;
 
 @FeatureTag({
         Feature.GENERATE,
@@ -98,15 +97,15 @@ class CollectionGeneratorSizeTest {
         }
 
         @Test
-        @SetSystemProperty(key = SystemProperties.FAIL_ON_ERROR, value = "true")
         void impossibleSetSizeWithFailOnErrorEnabled() {
-            final int size = 1000;
+            final int size = Gen.ints().range(1000, 1100).get();
             final InstancioApi<Set<Boolean>> api = Instancio.of(new TypeToken<Set<Boolean>>() {})
                     .generate(all(Set.class), gen -> gen.collection().size(size));
 
-            assertThatThrownBy(api::create)
+            assertWithFailOnErrorEnabled(api::create)
                     .isExactlyInstanceOf(InstancioException.class)
-                    .hasMessage("Unable to populate Set<Boolean> with requested number of elements: " + size);
+                    .hasMessage("Unable to populate Set<Boolean> with %s elements." +
+                            "%nElement node: Node[Boolean, depth=1, type=Boolean]", size);
         }
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorCyclicNodeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorCyclicNodeTest.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2022-2023 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.instancio.test.features.generator.map;
+
+import lombok.Data;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.internal.util.SystemProperties;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.test.support.asserts.Asserts.assertNoExceptionWithFailOnErrorEnabled;
+
+@FeatureTag(Feature.CYCLIC)
+@ExtendWith(InstancioExtension.class)
+class MapGeneratorCyclicNodeTest {
+
+    //@formatter:off
+    // Use case: map with cyclic key
+    private static @Data class RootCyclicKey { ACyclicKey a; }
+    private static @Data class ACyclicKey { BCyclicKey b; }
+    private static @Data class BCyclicKey { Map<ACyclicKey, UUID> map; }
+
+    // Use case: map with cyclic value
+    private static @Data class RootCyclicValue { ACyclicValue a; }
+    private static @Data class ACyclicValue { BCyclicValue b; }
+    private static @Data class BCyclicValue { Map<UUID, ACyclicValue> map; }
+    //@formatter:on
+
+    @Nested
+    class CyclicKeyTest {
+
+        @Test
+        void create() {
+            final RootCyclicKey result = Instancio.create(RootCyclicKey.class);
+
+            assertThat(result.a.b.map).isEmpty();
+        }
+
+        /**
+         * No exception should be thrown when {@link SystemProperties#FAIL_ON_ERROR} is enabled.
+         */
+        @Test
+        void withEntry() {
+            final ACyclicKey expectedKey = new ACyclicKey();
+            final UUID expectedValue = Instancio.create(UUID.class);
+
+            final InstancioApi<RootCyclicKey> api = Instancio.of(RootCyclicKey.class)
+                    .generate(field(BCyclicKey::getMap), gen -> gen.map()
+                            .size(100) // won't be able to generate but should not throw an error
+                            .with(expectedKey, expectedValue));
+
+            final RootCyclicKey result = assertNoExceptionWithFailOnErrorEnabled(api::create);
+
+            assertThat(result.a.b.map)
+                    .hasSize(1)
+                    .containsOnlyKeys(expectedKey)
+                    .containsValue(expectedValue);
+        }
+    }
+
+    @Nested
+    class CyclicValueTest {
+
+        @Test
+        void create() {
+            final RootCyclicValue result = Instancio.create(RootCyclicValue.class);
+
+            assertThat(result.a.b.map).isEmpty();
+        }
+
+        /**
+         * No exception should be thrown when {@link SystemProperties#FAIL_ON_ERROR} is enabled.
+         */
+        @Test
+        void withEntry() {
+            final UUID expectedKey = Instancio.create(UUID.class);
+            final ACyclicValue expectedValue = new ACyclicValue();
+
+            final InstancioApi<RootCyclicValue> api = Instancio.of(RootCyclicValue.class)
+                    .generate(field(BCyclicValue::getMap), gen -> gen.map()
+                            .size(100) // won't be able to generate but should not throw an error
+                            .with(expectedKey, expectedValue));
+
+            final RootCyclicValue result = assertNoExceptionWithFailOnErrorEnabled(api::create);
+
+            assertThat(result.a.b.map)
+                    .hasSize(1)
+                    .containsOnlyKeys(expectedKey)
+                    .containsValue(expectedValue);
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorSizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/map/MapGeneratorSizeTest.java
@@ -15,13 +15,13 @@
  */
 package org.instancio.test.features.generator.map;
 
+import org.instancio.Gen;
 import org.instancio.Instancio;
 import org.instancio.InstancioApi;
 import org.instancio.TypeToken;
 import org.instancio.exception.InstancioException;
 import org.instancio.generator.specs.MapGeneratorSpec;
 import org.instancio.internal.util.Constants;
-import org.instancio.internal.util.SystemProperties;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
@@ -34,14 +34,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.util.Map;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.all;
+import static org.instancio.test.support.asserts.Asserts.assertWithFailOnErrorEnabled;
 
 @FeatureTag({
         Feature.GENERATE,
@@ -108,18 +107,18 @@ class MapGeneratorSizeTest {
         }
 
         @Test
-        @SetSystemProperty(key = SystemProperties.FAIL_ON_ERROR, value = "true")
         void impossibleMapSizeWithFailOnErrorEnabled() {
-            final int size = 1000;
+            final int size = Gen.ints().range(1000, 1100).get();
             final InstancioApi<Map<Boolean, String>> api = Instancio.of(new TypeToken<Map<Boolean, String>>() {})
                     .generate(all(Map.class), gen -> gen.map().size(size));
 
-            assertThatThrownBy(api::create)
+            assertWithFailOnErrorEnabled(api::create)
                     .isExactlyInstanceOf(InstancioException.class)
-                    .hasMessage("Unable to populate Map<Boolean, String> with requested number of entries: " + size);
+                    .hasMessage("Unable to populate Map<Boolean, String> with %s entries." +
+                            "%nKey node:   Node[Boolean, depth=1, type=Boolean]" +
+                            "%nValue node: Node[String, depth=1, type=String]", size);
         }
     }
-
 
     private void assertSize(Function<MapGeneratorSpec<?, ?>, MapGeneratorSpec<?, ?>> fn, int expectedSize) {
         assertSizeBetween(fn, expectedSize, expectedSize);


### PR DESCRIPTION
- improved error message when collection/map cannot be populated
- do not fail when collection/map cannot be populated due to cyclic child node even when instancio.failOnError is enabled