### PR TITLE
Syntactic sugar for creating collections of random size.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -20,6 +20,7 @@ import org.instancio.internal.ApiValidator;
 import org.instancio.internal.OfClassApiImpl;
 import org.instancio.internal.OfCollectionApiImpl;
 import org.instancio.internal.OfMapApiImpl;
+import org.instancio.settings.Keys;
 
 import java.util.Collection;
 import java.util.List;
@@ -150,6 +151,61 @@ public final class Instancio {
      */
     public static <T> T create(final Class<T> type) {
         return of(type).create();
+    }
+
+    /**
+     * Creates a {@link List} of random size.
+     *
+     * <p>Unless configured otherwise, the generated size will be between
+     * {@link Keys#COLLECTION_MIN_SIZE} and {@link Keys#COLLECTION_MAX_SIZE},
+     * inclusive.
+     *
+     * <p>To create a list of a specific size, use {@link #ofList(Class)}.
+     *
+     * @param elementType class to generate as list elements
+     * @param <T>         element type
+     * @return API builder reference
+     * @since 3.0.1
+     */
+    public static <T> List<T> createList(final Class<T> elementType) {
+        return ofList(elementType).create();
+    }
+
+    /**
+     * Creates a {@link Set} of random size.
+     *
+     * <p>Unless configured otherwise, the generated size will be between
+     * {@link Keys#COLLECTION_MIN_SIZE} and {@link Keys#COLLECTION_MAX_SIZE},
+     * inclusive.
+     *
+     * <p>To create a {@code Set} of a specific size, use {@link #ofSet(Class)}.
+     *
+     * @param elementType class to generate as set elements
+     * @param <T>         element type
+     * @return API builder reference
+     * @since 3.0.1
+     */
+    public static <T> Set<T> createSet(final Class<T> elementType) {
+        return ofSet(elementType).create();
+    }
+
+    /**
+     * Creates a {@link Map} of random size.
+     *
+     * <p>Unless configured otherwise, the generated size will be between
+     * {@link Keys#MAP_MIN_SIZE} and {@link Keys#MAP_MAX_SIZE}, inclusive.
+     *
+     * <p>To create a {@code Map} of a specific size, use {@link #ofMap(Class, Class)}.
+     *
+     * @param keyType   class to generate as map keys
+     * @param valueType class to generate as map values
+     * @param <K>       key type
+     * @param <V>       value type
+     * @return API builder reference
+     * @since 3.0.1
+     */
+    public static <K, V> Map<K, V> createMap(final Class<K> keyType, final Class<V> valueType) {
+        return ofMap(keyType, valueType).create();
     }
 
     /**
@@ -322,7 +378,7 @@ public final class Instancio {
     }
 
     /**
-     * Builder API for generating a {@link List} that allows customisation of generated values.
+     * Builder API for generating a {@link List} that allows customising generated values.
      *
      * @param elementType class to generate as list elements
      * @param <T>         element type

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateListTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateListTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.create;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class CreateListTest {
+
+    @Test
+    void createList() {
+        final List<String> result = Instancio.createList(String.class);
+
+        assertThat(result).hasSizeBetween(
+                Keys.COLLECTION_MIN_SIZE.defaultValue(),
+                Keys.COLLECTION_MAX_SIZE.defaultValue());
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateMapTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateMapTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.create;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class CreateMapTest {
+
+    @Test
+    void createMap() {
+        final Map<String, Long> result = Instancio.createMap(String.class, Long.class);
+
+        assertThat(result).hasSizeBetween(
+                Keys.MAP_MIN_SIZE.defaultValue(),
+                Keys.MAP_MAX_SIZE.defaultValue());
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateSetTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/create/CreateSetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.create;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class CreateSetTest {
+
+    @Test
+    void createSet() {
+        final Set<String> result = Instancio.createSet(String.class);
+
+        assertThat(result).hasSizeBetween(
+                Keys.COLLECTION_MIN_SIZE.defaultValue(),
+                Keys.COLLECTION_MAX_SIZE.defaultValue());
+    }
+}


### PR DESCRIPTION
New public API methods:

- `createList`
- `createSet`
- `createMap`