### PR TITLE
Big fix: generate null for unsupported types

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorResolverMaps.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/GeneratorResolverMaps.java
@@ -29,6 +29,7 @@ import org.instancio.internal.generator.lang.StringBuilderGenerator;
 import org.instancio.internal.generator.lang.StringGenerator;
 import org.instancio.internal.generator.math.BigDecimalGenerator;
 import org.instancio.internal.generator.math.BigIntegerGenerator;
+import org.instancio.internal.generator.misc.NullGenerator;
 import org.instancio.internal.generator.net.InetAddressGenerator;
 import org.instancio.internal.generator.net.URIGenerator;
 import org.instancio.internal.generator.net.URLGenerator;
@@ -267,6 +268,20 @@ final class GeneratorResolverMaps {
         map.put(AtomicBoolean.class, AtomicBooleanGenerator.class);
         map.put(AtomicInteger.class, AtomicIntegerGenerator.class);
         map.put(AtomicLong.class, AtomicLongGenerator.class);
+
+        // unsupported
+        map.put(java.lang.reflect.Field.class, NullGenerator.class);
+        map.put(java.net.Inet6Address.class, NullGenerator.class);
+        map.put(java.net.InetSocketAddress.class, NullGenerator.class);
+        map.put(java.util.concurrent.CompletableFuture.class, NullGenerator.class);
+        map.put(java.util.concurrent.Semaphore.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicIntegerArray.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicLongArray.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicMarkableReference.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicReference.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicReferenceArray.class, NullGenerator.class);
+        map.put(java.util.concurrent.atomic.AtomicStampedReference.class, NullGenerator.class);
+
         return Collections.unmodifiableMap(map);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/misc/NullGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/misc/NullGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.misc;
+
+import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.generator.AbstractGenerator;
+
+public class NullGenerator extends AbstractGenerator<Object> {
+
+    public NullGenerator(final GeneratorContext context) {
+        super(context);
+    }
+
+    @Override
+    public String apiMethod() {
+        return null;
+    }
+
+    @Override
+    protected Object tryGenerateNonNull(final Random random) {
+        return null;
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/basic/UnsupportedJdkTypesCreationTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/creation/basic/UnsupportedJdkTypesCreationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.creation.basic;
+
+import org.instancio.test.support.pojo.basic.UnsupportedJdkTypes;
+import org.instancio.testsupport.templates.AutoVerificationDisabled;
+import org.instancio.testsupport.templates.CreationTestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoVerificationDisabled
+public class UnsupportedJdkTypesCreationTest extends CreationTestTemplate<UnsupportedJdkTypes> {
+
+    @Override
+    protected void verify(final UnsupportedJdkTypes result) {
+        assertThat(result).hasAllNullFieldsOrProperties();
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/misc/NullGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/misc/NullGeneratorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.misc;
+
+import org.instancio.internal.generator.AbstractGeneratorTestTemplate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NullGeneratorTest extends AbstractGeneratorTestTemplate<Object, NullGenerator> {
+
+    private final NullGenerator generator = new NullGenerator(getGeneratorContext());
+
+    @Override
+    protected String getApiMethod() {
+        return null;
+    }
+
+    @Override
+    protected NullGenerator generator() {
+        return generator;
+    }
+
+    @Test
+    @Override
+    protected void tryGenerateNonNull() {
+        assertThat(generator.tryGenerateNonNull(random)).isNull();
+    }
+
+    @Test
+    void generate() {
+        assertThat(generator.generate(random)).isNull();
+    }
+}

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/basic/UnsupportedJdkTypes.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/basic/UnsupportedJdkTypes.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.support.pojo.basic;
+
+import lombok.Data;
+
+@Data
+public class UnsupportedJdkTypes {
+
+    private java.lang.reflect.Field field;
+    private java.net.Inet6Address inet6Address;
+    private java.net.InetSocketAddress inetSocketAddress;
+    private java.util.concurrent.CompletableFuture<String> completableFuture;
+    private java.util.concurrent.Semaphore semaphore;
+    private java.util.concurrent.atomic.AtomicIntegerArray atomicIntegerArray;
+    private java.util.concurrent.atomic.AtomicLongArray atomicLongArray;
+    private java.util.concurrent.atomic.AtomicMarkableReference<String> atomicMarkableReference;
+    private java.util.concurrent.atomic.AtomicReference<String> atomicReference;
+    private java.util.concurrent.atomic.AtomicReferenceArray<String> atomicReferenceArray;
+    private java.util.concurrent.atomic.AtomicStampedReference<String> atomicStampedReference;
+
+}


### PR DESCRIPTION
This commit adds a null generator for unsupported JDK types to avoid instantiating them via internal constructors which can lead to runtime errors.