### PR TITLE
Added Luhn generator spec

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/LuhnAsGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LuhnAsGeneratorSpec.java
@@ -13,19 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.generator.checksum;
+package org.instancio.generator.specs;
 
-class LuhnGeneratorTest extends AbstractVariableLengthModCheckGeneratorTest<LuhnGenerator> {
-
-    private final LuhnGenerator generator = new LuhnGenerator(getGeneratorContext());
+/**
+ * A spec for generating numbers that pass the Luhn checksum algorithm.
+ * This spec supports {@link AsGeneratorSpec}.
+ *
+ * @since 3.1.0
+ */
+public interface LuhnAsGeneratorSpec extends LuhnGeneratorSpec, AsGeneratorSpec<String> {
 
     @Override
-    protected String getApiMethod() {
-        return "luhn()";
-    }
+    LuhnAsGeneratorSpec length(int length);
 
     @Override
-    protected LuhnGenerator generator() {
-        return generator;
-    }
+    LuhnAsGeneratorSpec length(int min, int max);
+
+    @Override
+    LuhnAsGeneratorSpec startIndex(int startIndex);
+
+    @Override
+    LuhnAsGeneratorSpec endIndex(int endIndex);
+
+    @Override
+    LuhnAsGeneratorSpec checkDigitIndex(int checkDigitIndex);
+
+    @Override
+    LuhnAsGeneratorSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LuhnGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LuhnGeneratorSpec.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.GeneratorSpec;
+
+/**
+ * A spec for generating numbers that pass the Luhn checksum algorithm.
+ *
+ * <p>The following methods:
+ *
+ * <ul>
+ *   <li>{@link #checkDigitIndex(int)}</li>
+ *   <li>{@link #startIndex(int)}</li>
+ *   <li>{@link #endIndex(int)}</li>
+ * </ul>
+ *
+ * <p>provided by this interface (as well as their Javadocs)
+ * were copied from the {@code org.hibernate.validator.constraints.LuhnCheck}
+ * annotation attributes.
+ *
+ * @since 3.1.0
+ */
+public interface LuhnGeneratorSpec extends GeneratorSpec<String>, NullableGeneratorSpec<String> {
+
+    /**
+     * Length of the number to generate (default value is {@code 16}).
+     *
+     * @param length of the value to generate
+     * @return spec builder
+     * @since 3.1.0
+     */
+    LuhnGeneratorSpec length(int length);
+
+    /**
+     * Generate a number of random length within the specified range.
+     *
+     * @param min minimum length (inclusive)
+     * @param max maximum length (inclusive)
+     * @return spec builder
+     * @since 3.1.0
+     */
+    LuhnGeneratorSpec length(int min, int max);
+
+    /**
+     * The start index for calculating the checksum
+     * (default value is {@code 0}).
+     *
+     * @param startIndex for calculating the checksum (inclusive)
+     * @return spec builder
+     * @since 3.1.0
+     */
+    LuhnGeneratorSpec startIndex(int startIndex);
+
+    /**
+     * The end index for calculating the checksum.
+     *
+     * @param endIndex for calculating the checksum (inclusive)
+     * @return spec builder
+     * @since 3.1.0
+     */
+    LuhnGeneratorSpec endIndex(int endIndex);
+
+    /**
+     * The index of the check digit in the input.
+     * If not specified, the last digit will be used as the check digit.
+     *
+     * <p>If set, the digit at the specified index is used. If set
+     * the following must hold true:<br>
+     * {@code checkDigitIndex >= 0 && (checkDigitIndex < startIndex || checkDigitIndex >= endIndex)}.
+     *
+     * @param checkDigitIndex index of the check digit
+     * @return spec builder
+     * @since 3.1.0
+     */
+    LuhnGeneratorSpec checkDigitIndex(int checkDigitIndex);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 3.1.0
+     */
+    @Override
+    LuhnGeneratorSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LuhnSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LuhnSpec.java
@@ -13,19 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.generator.checksum;
+package org.instancio.generator.specs;
 
-class LuhnGeneratorTest extends AbstractVariableLengthModCheckGeneratorTest<LuhnGenerator> {
+import org.instancio.generator.ValueSpec;
 
-    private final LuhnGenerator generator = new LuhnGenerator(getGeneratorContext());
+/**
+ * A spec for generating numbers that pass the Luhn checksum algorithm.
+ *
+ * @since 3.1.0
+ */
+public interface LuhnSpec extends LuhnGeneratorSpec, ValueSpec<String> {
 
     @Override
-    protected String getApiMethod() {
-        return "luhn()";
-    }
+    LuhnSpec length(int length);
 
     @Override
-    protected LuhnGenerator generator() {
-        return generator;
-    }
+    LuhnSpec length(int min, int max);
+
+    @Override
+    LuhnSpec startIndex(int startIndex);
+
+    @Override
+    LuhnSpec endIndex(int endIndex);
+
+    @Override
+    LuhnSpec checkDigitIndex(int checkDigitIndex);
+
+    @Override
+    LuhnSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generators/ChecksumGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/ChecksumGenerators.java
@@ -17,8 +17,10 @@
 package org.instancio.generators;
 
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.LuhnAsGeneratorSpec;
 import org.instancio.generator.specs.Mod10AsGeneratorSpec;
 import org.instancio.generator.specs.Mod11AsGeneratorSpec;
+import org.instancio.internal.generator.checksum.LuhnGenerator;
 import org.instancio.internal.generator.checksum.Mod10Generator;
 import org.instancio.internal.generator.checksum.Mod11Generator;
 
@@ -33,6 +35,16 @@ public class ChecksumGenerators {
 
     public ChecksumGenerators(final GeneratorContext context) {
         this.context = context;
+    }
+
+    /**
+     * Generates numbers that pass the Luhn checksum algorithm.
+     *
+     * @return API builder reference
+     * @since 3.1.0
+     */
+    public LuhnAsGeneratorSpec luhn() {
+        return new LuhnGenerator(context);
     }
 
     /**

--- a/instancio-core/src/main/java/org/instancio/generators/ChecksumSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/ChecksumSpecs.java
@@ -15,8 +15,10 @@
  */
 package org.instancio.generators;
 
+import org.instancio.generator.specs.LuhnSpec;
 import org.instancio.generator.specs.Mod10Spec;
 import org.instancio.generator.specs.Mod11Spec;
+import org.instancio.internal.generator.checksum.LuhnGenerator;
 import org.instancio.internal.generator.checksum.Mod10Generator;
 import org.instancio.internal.generator.checksum.Mod11Generator;
 
@@ -26,6 +28,16 @@ import org.instancio.internal.generator.checksum.Mod11Generator;
  * @since 2.16.0
  */
 public final class ChecksumSpecs {
+
+    /**
+     * Generates numbers that pass the Luhn checksum algorithm.
+     *
+     * @return API builder reference
+     * @since 3.1.0
+     */
+    public LuhnSpec luhn() {
+        return new LuhnGenerator();
+    }
 
     /**
      * Generates numbers that pass the Mod11 checksum algorithm.

--- a/instancio-core/src/main/java/org/instancio/internal/generator/checksum/LuhnGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/checksum/LuhnGenerator.java
@@ -16,8 +16,16 @@
 package org.instancio.internal.generator.checksum;
 
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.LuhnAsGeneratorSpec;
+import org.instancio.generator.specs.LuhnSpec;
+import org.instancio.support.Global;
 
-public class LuhnGenerator extends VariableLengthModCheckGenerator {
+public class LuhnGenerator extends VariableLengthModCheckGenerator
+        implements LuhnAsGeneratorSpec, LuhnSpec {
+
+    public LuhnGenerator() {
+        this(Global.generatorContext());
+    }
 
     public LuhnGenerator(final GeneratorContext context) {
         super(context);
@@ -25,7 +33,7 @@ public class LuhnGenerator extends VariableLengthModCheckGenerator {
 
     @Override
     public String apiMethod() {
-        return null;
+        return "luhn()";
     }
 
     @Override
@@ -37,6 +45,24 @@ public class LuhnGenerator extends VariableLengthModCheckGenerator {
     @Override
     public LuhnGenerator nullable(final boolean isNullable) {
         super.nullable(isNullable);
+        return this;
+    }
+
+    @Override
+    public LuhnGenerator length(final int length) {
+        super.length(length);
+        return this;
+    }
+
+    @Override
+    public LuhnGenerator length(final int min, final int max) {
+        super.length(min, max);
+        return this;
+    }
+
+    @Override
+    public LuhnGenerator checkDigitIndex(final int idx) {
+        super.checkDigitIndex(idx);
         return this;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalLengthGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalLengthGeneratorSpec.java
@@ -21,5 +21,12 @@ import org.instancio.generator.GeneratorSpec;
 @InternalApi
 public interface InternalLengthGeneratorSpec<T> extends GeneratorSpec<T> {
 
+    /**
+     * Length of the value to generate.
+     *
+     * @param min minimum length (inclusive)
+     * @param max maximum length (inclusive)
+     * @return spec builder
+     */
     InternalLengthGeneratorSpec<T> length(int min, int max);
 }

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/LuhnCheckBVTest.java
@@ -15,22 +15,25 @@
  */
 package org.instancio.test.beanvalidation;
 
+import org.instancio.Gen;
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithDefaults;
-import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithStartEndAndCheckDigitIndices;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithEndAndCheckDigitIndicesEqual;
+import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithStartEndAndCheckDigitIndices;
 import org.instancio.test.pojo.beanvalidation.LuhnCheckBV.WithStartEndIndices;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.util.HibernateValidatorUtil;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
 import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DDD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
@@ -72,5 +75,181 @@ class LuhnCheckBVTest {
                 .limit(SAMPLE_SIZE_DDD);
 
         assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+    }
+
+    @Nested
+    class LuhnGeneratorSpecTest {
+
+        @Test
+        void withDefaults() {
+            final Stream<WithDefaults> results = Instancio.of(WithDefaults.class)
+                    .generate(field(WithDefaults::getValue), gen -> gen.checksum().luhn())
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
+
+        @Test
+        void withStartEndIndices() {
+            final Stream<WithStartEndIndices> results = Instancio.of(WithStartEndIndices.class)
+                    .generate(field(WithStartEndIndices::getValue0), gen -> gen.checksum().luhn()
+                            .startIndex(0).endIndex(7))
+
+                    .generate(field(WithStartEndIndices::getValue1), gen -> gen.checksum().luhn()
+                            .startIndex(5).endIndex(10))
+
+                    .generate(field(WithStartEndIndices::getValue2), gen -> gen.checksum().luhn()
+                            .startIndex(1).endIndex(21))
+
+                    .generate(field(WithStartEndIndices::getValue3), gen -> gen.checksum().luhn()
+                            .startIndex(100).endIndex(105))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
+
+        @Test
+        void withStartEndIndicesAndLength() {
+            final Stream<WithStartEndIndices> results = Instancio.of(WithStartEndIndices.class)
+                    .generate(field(WithStartEndIndices::getValue0), gen -> gen.checksum().luhn()
+                            .length(10)
+                            .startIndex(0).endIndex(7))
+
+                    .generate(field(WithStartEndIndices::getValue1), gen -> gen.checksum().luhn()
+                            .length(15, 20)
+                            .startIndex(5).endIndex(10))
+
+                    .generate(field(WithStartEndIndices::getValue2), gen -> gen.checksum().luhn()
+                            .length(25)
+                            .startIndex(1).endIndex(21))
+
+                    .generate(field(WithStartEndIndices::getValue3), gen -> gen.checksum().luhn()
+                            .length(106)
+                            .startIndex(100).endIndex(105))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(result -> {
+                HibernateValidatorUtil.assertValid(result);
+
+                assertThat(result.getValue0()).hasSize(10);
+                assertThat(result.getValue1()).hasSizeBetween(15, 20);
+                assertThat(result.getValue2()).hasSize(25);
+                assertThat(result.getValue3()).hasSize(106);
+            });
+        }
+
+        @Test
+        void withStartEndAndCheckDigitIndices() {
+            final Stream<WithStartEndAndCheckDigitIndices> results = Instancio.of(WithStartEndAndCheckDigitIndices.class)
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue0), gen -> gen.checksum().luhn()
+                            .startIndex(0).endIndex(7).checkDigitIndex(8))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue1), gen -> gen.checksum().luhn()
+                            .startIndex(5).endIndex(10).checkDigitIndex(3))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue2), gen -> gen.checksum().luhn()
+                            .startIndex(1).endIndex(21).checkDigitIndex(0))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue3), gen -> gen.checksum().luhn()
+                            .startIndex(100).endIndex(105).checkDigitIndex(150))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
+    }
+
+    @Nested
+    class LuhnSpecTest {
+
+        @Test
+        void withDefaults() {
+            final Stream<WithDefaults> results = Instancio.of(WithDefaults.class)
+                    .generate(field(WithDefaults::getValue), Gen.checksum().luhn())
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
+
+        @Test
+        void withStartEndIndices() {
+            final Stream<WithStartEndIndices> results = Instancio.of(WithStartEndIndices.class)
+                    .generate(field(WithStartEndIndices::getValue0), Gen.checksum().luhn()
+                            .startIndex(0).endIndex(7))
+
+                    .generate(field(WithStartEndIndices::getValue1), Gen.checksum().luhn()
+                            .startIndex(5).endIndex(10))
+
+                    .generate(field(WithStartEndIndices::getValue2), Gen.checksum().luhn()
+                            .startIndex(1).endIndex(21))
+
+                    .generate(field(WithStartEndIndices::getValue3), Gen.checksum().luhn()
+                            .startIndex(100).endIndex(105))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
+
+        @Test
+        void withStartEndIndicesAndLength() {
+            final Stream<WithStartEndIndices> results = Instancio.of(WithStartEndIndices.class)
+                    .generate(field(WithStartEndIndices::getValue0), Gen.checksum().luhn()
+                            .length(10)
+                            .startIndex(0).endIndex(7))
+
+                    .generate(field(WithStartEndIndices::getValue1), Gen.checksum().luhn()
+                            .length(15, 20)
+                            .startIndex(5).endIndex(10))
+
+                    .generate(field(WithStartEndIndices::getValue2), Gen.checksum().luhn()
+                            .length(25)
+                            .startIndex(1).endIndex(21))
+
+                    .generate(field(WithStartEndIndices::getValue3), Gen.checksum().luhn()
+                            .length(106)
+                            .startIndex(100).endIndex(105))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(result -> {
+                HibernateValidatorUtil.assertValid(result);
+
+                assertThat(result.getValue0()).hasSize(10);
+                assertThat(result.getValue1()).hasSizeBetween(15, 20);
+                assertThat(result.getValue2()).hasSize(25);
+                assertThat(result.getValue3()).hasSize(106);
+            });
+        }
+
+        @Test
+        void withStartEndAndCheckDigitIndices() {
+            final Stream<WithStartEndAndCheckDigitIndices> results = Instancio.of(WithStartEndAndCheckDigitIndices.class)
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue0), Gen.checksum().luhn()
+                            .startIndex(0).endIndex(7).checkDigitIndex(8))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue1), Gen.checksum().luhn()
+                            .startIndex(5).endIndex(10).checkDigitIndex(3))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue2), Gen.checksum().luhn()
+                            .startIndex(1).endIndex(21).checkDigitIndex(0))
+
+                    .generate(field(WithStartEndAndCheckDigitIndices::getValue3), Gen.checksum().luhn()
+                            .startIndex(100).endIndex(105).checkDigitIndex(150))
+
+                    .stream()
+                    .limit(SAMPLE_SIZE_DDD);
+
+            assertThat(results).hasSize(SAMPLE_SIZE_DDD).allSatisfy(HibernateValidatorUtil::assertValid);
+        }
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/checksum/LuhnGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/checksum/LuhnGeneratorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.checksum;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class LuhnGeneratorTest {
+
+    @Test
+    void createWithDefaults() {
+        final String result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.checksum().luhn())
+                .create();
+
+        assertThat(result).as("default length").hasSize(16);
+    }
+
+    @Test
+    void createCustomised() {
+        final String result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.checksum().luhn()
+                        .startIndex(3)
+                        .endIndex(10)
+                        .checkDigitIndex(20))
+                .create();
+
+        assertThat(result).hasSize(21);
+    }
+
+    @Test
+    void createAsNumber() {
+        final int length = 5;
+        final Long result = Instancio.of(Long.class)
+                .generate(root(), gen -> gen.checksum().luhn().length(length)
+                        .as(Long::valueOf))
+                .create();
+
+        assertThat(result).isPositive();
+        assertThat(result.toString()).hasSize(length);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
@@ -142,6 +142,7 @@ class GeneratorMismatchTest {
 
     @Test
     void assertChecksumGenerators() {
+        assertMessageContains("luhn()", gen -> gen.checksum().luhn());
         assertMessageContains("mod10()", gen -> gen.checksum().mod10());
         assertMessageContains("mod11()", gen -> gen.checksum().mod11());
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/checksum/LuhnSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/checksum/LuhnSpecTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.checksum;
+
+import org.instancio.Gen;
+import org.instancio.generator.specs.LuhnSpec;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+class LuhnSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected LuhnSpec spec() {
+        return Gen.checksum().luhn();
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).containsOnlyDigits().hasSize(16);
+    }
+
+    @Test
+    void customised() {
+        assertThat(spec().startIndex(2).endIndex(5).length(6).get())
+                .containsOnlyDigits()
+                .hasSize(6);
+    }
+}

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -856,6 +856,7 @@ Generators
 ├── optional()
 │
 ├── checksum()
+│   └── luhn()
 │   └── mod10()
 │   └── mod11()
 │


### PR DESCRIPTION
This commit exposes Luhn generator via public API.

Examples:

```java
String luhn = Gen.checksum().luhn().length(12).get();

SamplePojo pojo = Instancio.of(SamplePojo.class)
    .generate(field(SamplePojo::getFoo), gen -> gen.checksum().luhn().length(16).startIndex(5).endIndex(15))
    .create();
```