### PR TITLE
Throw an exception if root is abstract and no subtype is provided

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -177,23 +177,24 @@ public class ApiImpl<T> implements InstancioApi<T> {
 
     @Override
     public T create() {
-        final InstancioEngine engine = new InstancioEngine(createModel());
-        return engine.createRootObject();
+        return createRootObject(createModel());
     }
-
 
     @Override
     public Result<T> asResult() {
         final InternalModel<T> model = createModel();
-        final InstancioEngine engine = new InstancioEngine(model);
-        return new Result<>(engine.createRootObject(), model.getModelContext().getRandom().getSeed());
+        final long seed = model.getModelContext().getRandom().getSeed();
+        return new Result<>(createRootObject(model), seed);
     }
-
 
     @Override
     public Stream<T> stream() {
         final InternalModel<T> model = createModel();
-        return Stream.generate(() -> new InstancioEngine(model).createRootObject());
+        return Stream.generate(() -> createRootObject(model));
+    }
+
+    private T createRootObject(final InternalModel<T> model) {
+        return new InstancioEngine(model).createRootObject();
     }
 
     private InternalModel<T> createModel() {

--- a/instancio-core/src/main/java/org/instancio/internal/util/ErrorMessageUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/ErrorMessageUtils.java
@@ -71,6 +71,36 @@ public final class ErrorMessageUtils {
         return sb.toString();
     }
 
+    public static String abstractRootWithoutSubtype(final Class<?> klass) {
+        //noinspection StringBufferReplaceableByString
+        return new StringBuilder(1024)
+                .append("could not create an instance of ").append(klass).append(NL)
+                .append(NL)
+                .append("Cause:").append(NL)
+                .append(NL)
+                .append(" -> It is an abstract class and no subtype was provided").append(NL)
+                .append(NL)
+                .append("To resolve this error:").append(NL)
+                .append(NL)
+                .append(" -> Specify the subtype using the builder API:").append(NL)
+                .append(NL)
+                .append("    AbstractPojo pojo = Instancio.of(AbstractPojo.class)").append(NL)
+                .append("        .subtype(all(AbstractPojo.class), ConcretePojo.class)").append(NL)
+                .append("        .create();").append(NL)
+                .append(NL)
+                .append(" -> Or alternatively, specify the subtype using Settings:").append(NL)
+                .append(NL)
+                .append("    Settings settings = Settings.create()").append(NL)
+                .append("        .mapType(AbstractPojo.class, ConcretePojo.class);").append(NL)
+                .append(NL)
+                .append("    AbstractPojo pojo = Instancio.of(AbstractPojo.class)").append(NL)
+                .append("        .withSettings(settings)").append(NL)
+                .append("        .create();").append(NL)
+                .append(NL)
+                .append("For more information see: https://www.instancio.org/user-guide/#subtype-mapping")
+                .toString();
+    }
+
     /**
      * @see #mapCouldNotBePopulated(ModelContext, InternalNode, int)
      */

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/AbstractRootTypeWithoutSubtypeErrorMessageTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/AbstractRootTypeWithoutSubtypeErrorMessageTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.interfaces.StringHolderInterface;
+
+class AbstractRootTypeWithoutSubtypeErrorMessageTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.create(StringHolderInterface.class);
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.AbstractRootTypeWithoutSubtypeErrorMessageTest.methodUnderTest(AbstractRootTypeWithoutSubtypeErrorMessageTest.java:25)
+
+                Reason: could not create an instance of interface org.instancio.test.support.pojo.interfaces.StringHolderInterface
+
+                Cause:
+
+                 -> It is an abstract class and no subtype was provided
+
+                To resolve this error:
+
+                 -> Specify the subtype using the builder API:
+
+                    AbstractPojo pojo = Instancio.of(AbstractPojo.class)
+                        .subtype(all(AbstractPojo.class), ConcretePojo.class)
+                        .create();
+
+                 -> Or alternatively, specify the subtype using Settings:
+
+                    Settings settings = Settings.create()
+                        .mapType(AbstractPojo.class, ConcretePojo.class);
+
+                    AbstractPojo pojo = Instancio.of(AbstractPojo.class)
+                        .withSettings(settings)
+                        .create();
+
+                For more information see: https://www.instancio.org/user-guide/#subtype-mapping
+
+                """;
+    }
+}

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -1436,6 +1436,7 @@ If not specified:
 
 - a `null` value will be generated where the abstract type is a field
 - an empty collection will be generated where the abstract type is collection element
+- an exception will be thrown if root type is abstract and no subtype is specified
 
 ### Specifying Subtypes
 


### PR DESCRIPTION
Previously null was returned, which might be confusing to users