### PR TITLE
Support for specifying precision when generating `BigDecimal` values

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalAsGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalAsGeneratorSpec.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.generator.specs;
 
+import org.instancio.documentation.ExperimentalApi;
+
 import java.math.BigDecimal;
 
 /**
@@ -40,4 +42,13 @@ public interface BigDecimalAsGeneratorSpec
 
     @Override
     BigDecimalAsGeneratorSpec scale(int scale);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 3.3.0
+     */
+    @Override
+    @ExperimentalApi
+    BigDecimalAsGeneratorSpec precision(int precision);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalGeneratorSpec.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.generator.specs;
 
+import org.instancio.documentation.ExperimentalApi;
+
 import java.math.BigDecimal;
 
 /**
@@ -24,12 +26,38 @@ import java.math.BigDecimal;
  */
 public interface BigDecimalGeneratorSpec extends NumberGeneratorSpec<BigDecimal> {
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note that if {@link #precision(int)} is specified, then
+     * invoking {@link #min(BigDecimal)} or {@link #max(BigDecimal)}
+     * will have no effect on generated values.
+     *
+     * @see #precision(int)
+     */
     @Override
     BigDecimalGeneratorSpec min(BigDecimal min);
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note that if {@link #precision(int)} is specified, then
+     * invoking {@link #min(BigDecimal)} or {@link #max(BigDecimal)}
+     * will have no effect on generated values.
+     *
+     * @see #precision(int)
+     */
     @Override
     BigDecimalGeneratorSpec max(BigDecimal max);
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note that if {@link #precision(int)} is specified, then
+     * invoking this method will have no effect on generated values.
+     *
+     * @see #precision(int)
+     */
     @Override
     BigDecimalGeneratorSpec range(BigDecimal min, BigDecimal max);
 
@@ -38,11 +66,33 @@ public interface BigDecimalGeneratorSpec extends NumberGeneratorSpec<BigDecimal>
 
     /**
      * Scale of the generated {@link BigDecimal}.
+     * Generated values will have given {@code scale}
+     * as returned by {@link BigDecimal#scale()}
      *
-     * @param scale to set
+     * @param scale the scale of generated {@code BigDecimal} values
      * @return spec builder
      * @since 1.5.4
      */
     BigDecimalGeneratorSpec scale(int scale);
 
+    /**
+     * Precision of the generated {@link BigDecimal}.
+     * Generated values will have given {@code precision}
+     * as returned by {@link BigDecimal#precision()}
+     *
+     * <p>Note that if this method is invoked, then the following
+     * methods will have no effect on generated values:
+     *
+     * <ul>
+     *   <li>{@link #min(BigDecimal)}</li>
+     *   <li>{@link #min(BigDecimal)}</li>
+     *   <li>{@link #range(BigDecimal, BigDecimal)}</li>
+     * </ul>
+     *
+     * @param precision the precision of generated {@code BigDecimal} values
+     * @return spec builder
+     * @since 3.3.0
+     */
+    @ExperimentalApi
+    BigDecimalGeneratorSpec precision(int precision);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/BigDecimalSpec.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.generator.specs;
 
+import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.ValueSpec;
 
 import java.math.BigDecimal;
@@ -40,4 +41,13 @@ public interface BigDecimalSpec extends ValueSpec<BigDecimal>, BigDecimalGenerat
 
     @Override
     BigDecimalSpec scale(int scale);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 3.3.0
+     */
+    @Override
+    @ExperimentalApi
+    BigDecimalSpec precision(int precision);
 }

--- a/instancio-core/src/main/java/org/instancio/generators/MathGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/MathGenerators.java
@@ -48,6 +48,17 @@ public class MathGenerators {
     /**
      * Customises generated {@link BigDecimal} values.
      *
+     * <p>The spec provides two options for customising generated values:
+     *
+     * <ul>
+     *   <li>Using the {@code min(BigDecimal)}, {@code max(BigDecimal}}, or
+     *       {@code range(BigDecimal, BigDecimal)} methods</li>
+     *   <li>Using the {@code precision(int)} method</li>
+     * </ul>
+     *
+     * <p>If precision is specified, then specifying the range
+     * will have no effect on generated values.
+     *
      * @return customised generator
      */
     public BigDecimalAsGeneratorSpec bigDecimal() {

--- a/instancio-core/src/main/java/org/instancio/generators/MathSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/MathSpecs.java
@@ -33,6 +33,17 @@ public final class MathSpecs {
     /**
      * Generates {@link BigDecimal} values.
      *
+     * <p>The spec provides two options for customising generated values:
+     *
+     * <ul>
+     *   <li>Using the {@code min(BigDecimal)}, {@code max(BigDecimal}}, or
+     *       {@code range(BigDecimal, BigDecimal)} methods</li>
+     *   <li>Using the {@code precision(int)} method</li>
+     * </ul>
+     *
+     * <p>If precision is specified, then specifying the range
+     * will have no effect on generated values.
+     *
      * @return API builder reference
      * @since 2.6.0
      */

--- a/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
@@ -19,10 +19,12 @@ import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.BigDecimalAsGeneratorSpec;
 import org.instancio.generator.specs.BigDecimalSpec;
+import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.lang.AbstractRandomComparableNumberGeneratorSpec;
 import org.instancio.support.Global;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 
 public class BigDecimalGenerator extends AbstractRandomComparableNumberGeneratorSpec<BigDecimal>
@@ -31,8 +33,10 @@ public class BigDecimalGenerator extends AbstractRandomComparableNumberGenerator
     private static final BigDecimal DEFAULT_MIN = BigDecimal.valueOf(0.000_01d);
     private static final BigDecimal DEFAULT_MAX = BigDecimal.valueOf(10_000);
     private static final int DEFAULT_SCALE = 5;
+    private static final int PRECISION_NOT_SET = -1;
 
     private int scale = DEFAULT_SCALE;
+    private int precision = PRECISION_NOT_SET;
 
     public BigDecimalGenerator() {
         this(Global.generatorContext());
@@ -55,6 +59,13 @@ public class BigDecimalGenerator extends AbstractRandomComparableNumberGenerator
     @Override
     public BigDecimalGenerator scale(final int scale) {
         this.scale = scale;
+        return this;
+    }
+
+    @Override
+    public BigDecimalGenerator precision(final int precision) {
+        ApiValidator.isTrue(precision > 0, "'precision' must be positive: %s", precision);
+        this.precision = precision;
         return this;
     }
 
@@ -90,8 +101,99 @@ public class BigDecimalGenerator extends AbstractRandomComparableNumberGenerator
 
     @Override
     protected BigDecimal tryGenerateNonNull(final Random random) {
-        final BigDecimal delta = getMax().subtract(getMin());
-        final BigDecimal rndDelta = delta.multiply(BigDecimal.valueOf(random.doubleRange(0.01, 1)));
-        return getMin().add(rndDelta).setScale(scale, RoundingMode.HALF_UP);
+        // Generate value in the [min, max] range
+        if (precision == PRECISION_NOT_SET) {
+            final BigDecimal delta = getMax().subtract(getMin());
+            final BigDecimal rndDelta = delta.multiply(BigDecimal.valueOf(random.doubleRange(0.01, 1)));
+            return getMin().add(rndDelta).setScale(scale, RoundingMode.HALF_UP);
+        }
+
+        // Generate value based on specified precision
+
+        ApiValidator.isTrue(precision >= scale,
+                "'precision' (%s) must be greater than or equal to 'scale' (%s)", precision, scale);
+
+        final char[] result;
+
+        if (scale == 0) {
+            result = generateInteger(random);
+            // result: '[1-9][0-9]{precision - 1}'
+        } else if (scale < 0) {
+            result = generateWithNegativeScale(random);
+            // result: '[1-9][0-9]{precision - 1}0{abs(scale)}'
+        } else if (precision == scale) {
+            result = generateWithEqualPrecisionAndScale(random);
+            // result: '0.[1-9][0-9]{scale}'
+        } else {
+            result = generateFractionalWithPrecisionGreaterThanScale(random);
+            // result: '[1-9]{integerSize}.[0-9]{scale}'
+            // where 'integerSize = precision - scale'
+        }
+
+        return new BigDecimal(
+                new String(result),
+                new MathContext(precision, RoundingMode.UNNECESSARY));
+    }
+
+    private char[] generateFractionalWithPrecisionGreaterThanScale(final Random random) {
+        final char[] digits = new char[precision + 1];
+        int i = 0;
+        digits[i++] = oneToNine(random);
+
+        while (i < precision - scale) {
+            digits[i++] = zeroToNine(random);
+        }
+
+        digits[i++] = '.';
+
+        while (i < digits.length) {
+            digits[i++] = zeroToNine(random);
+        }
+        return digits;
+    }
+
+    private char[] generateWithEqualPrecisionAndScale(final Random random) {
+        final char[] digits = new char[1 + scale];
+        int i = 0;
+        digits[i++] = '.';
+        digits[i++] = oneToNine(random);
+
+        while (i < digits.length) {
+            digits[i++] = zeroToNine(random);
+        }
+        return digits;
+    }
+
+    private char[] generateWithNegativeScale(final Random random) {
+        final char[] digits = new char[precision + Math.abs(scale)];
+        int i = 0;
+        digits[i++] = oneToNine(random);
+
+        while (i < precision) {
+            digits[i++] = zeroToNine(random);
+        }
+        while (i < digits.length) {
+            digits[i++] = '0';
+        }
+        return digits;
+    }
+
+    private char[] generateInteger(final Random random) {
+        final char[] digits = new char[precision];
+        int i = 0;
+        digits[i++] = oneToNine(random);
+
+        while (i < digits.length) {
+            digits[i++] = zeroToNine(random);
+        }
+        return digits;
+    }
+
+    private static char zeroToNine(final Random random) {
+        return random.characterRange('0', '9');
+    }
+
+    private static char oneToNine(final Random random) {
+        return random.characterRange('1', '9');
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/math/MathGeneratorsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/math/MathGeneratorsTest.java
@@ -59,4 +59,22 @@ class MathGeneratorsTest {
                 .isBetween(BigDecimal.ZERO, BigDecimal.ONE)
                 .hasScaleOf(expectedScale);
     }
+
+    @Test
+    void bigDecimalWithPrecision() {
+        final int expectedPrecision = 20;
+        final int expectedScale = 9;
+
+        final SupportedMathTypes result = Instancio.of(SupportedMathTypes.class)
+                .generate(all(BigDecimal.class), gen -> gen.math().bigDecimal()
+                        .precision(expectedPrecision)
+                        .scale(expectedScale)
+                        // also verify that range() is ignored when precision is specified
+                        .range(BigDecimal.ZERO, BigDecimal.ONE))
+                .create();
+
+        assertThat(result.getBigDecimal()).hasScaleOf(expectedScale);
+        assertThat(result.getBigDecimal().precision()).isEqualTo(expectedPrecision);
+        assertThat(result.getBigDecimal()).isGreaterThan(BigDecimal.ONE);
+    }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigDecimalSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/math/BigDecimalSpecTest.java
@@ -41,6 +41,12 @@ class BigDecimalSpecTest extends AbstractValueSpecTestTemplate<BigDecimal> {
     }
 
     @Test
+    void precision() {
+        final BigDecimal result = spec().precision(15).get();
+        assertThat(result.precision()).isEqualTo(15);
+    }
+
+    @Test
     void min() {
         final BigDecimal result = spec().min(new BigDecimal(Integer.MAX_VALUE)).get();
         assertThat(result).isGreaterThanOrEqualTo(new BigDecimal(Integer.MAX_VALUE));


### PR DESCRIPTION
This PR adds support for generating `BigDecimal` values with a given precision, as returned by `BigDecimal.precision()` method.

#### Sample usage

```java
record Sample(BigDecimal value) {}

Sample sample = Instancio.of(Sample.class)
    .generate(field(Sample::getValue), gen -> gen.math().bigDecimal().precision(5).scale(3))
    .create();
```

Or using `Gen`:

```java
BigDecimal value = Gen.math().bigDecimal().precision(5).scale(3).get();

assertThat(value.precision()).isEqualTo(5);
assertThat(value).hasScaleOf(3);
```
