### PR TITLE
Fix for an enum-related bug introduced in the previous commit

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -150,7 +150,7 @@ class InstancioEngine {
 
         if (context.getRandom().diceRoll(isNullable)) {
             generatorResult = GeneratorResult.nullResult();
-        } else if (node.getChildren().isEmpty()) { // leaf - generate a value
+        } else if (node.is(NodeKind.JDK) || node.getChildren().isEmpty()) { // leaf - generate a value
             generatorResult = generateValue(node);
         } else if (node.is(NodeKind.ARRAY)) {
             generatorResult = generateArray(node);

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeFactory.java
@@ -101,7 +101,10 @@ public final class NodeFactory {
 
         final Type type = node.getType();
         if (type instanceof Class) {
-            children = createChildrenOfClass(node);
+            // do not reflect on JDK classes
+            children = node.is(NodeKind.JDK)
+                    ? Collections.emptyList()
+                    : createChildrenOfClass(node);
         } else if (type instanceof ParameterizedType) {
             children = createChildrenOfParameterizedType(node);
         } else if (type instanceof GenericArrayType) {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectWithGenerateTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectWithGenerateTest.java
@@ -41,7 +41,8 @@ import static org.instancio.Select.field;
 @FeatureTag(Feature.SELECTOR)
 class SelectWithGenerateTest {
 
-    private static final long EXPECTED_VALUE = 2L;
+    // Use a negative number since randomly generated value are positive
+    private static final long EXPECTED_VALUE = -2L;
 
     @Test
     @DisplayName("Should select primitive but not wrapper")

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/person/Gender.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/pojo/person/Gender.java
@@ -16,5 +16,20 @@
 package org.instancio.test.support.pojo.person;
 
 public enum Gender {
-    MALE, FEMALE, OTHER
+    MALE("Male"),
+    FEMALE("Female"),
+    OTHER("Other");
+
+    // When creating a node that represents an enum,
+    // the node should not have children,
+    // i.e. enum fields should be ignored
+    private final String description;
+
+    Gender(final String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }


### PR DESCRIPTION
When creating a node that represents an enum, the enum's fields should be ignored. The test for this already exists, but it was used with an enum without fields, and therefore passed.