### PR TITLE
Bug fix: `subtype()` and `Selector.scope(Class)` where `Class` is the subtype

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorMapImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorMapImpl.java
@@ -252,7 +252,7 @@ final class SelectorMapImpl<V> implements SelectorMap<V> {
         return results;
     }
 
-    @SuppressWarnings(Sonar.COGNITIVE_COMPLEXITY_OF_METHOD)
+    @SuppressWarnings({Sonar.COGNITIVE_COMPLEXITY_OF_METHOD, "PMD.CyclomaticComplexity"})
     private static boolean selectorScopesMatchNodeHierarchy(
             final SelectorImpl candidate,
             final InternalNode targetNode) {
@@ -286,7 +286,9 @@ final class SelectorMapImpl<V> implements SelectorMap<V> {
                     if (scope.resolveField().equals(node.getField())) {
                         scope = (ScopeImpl) deq.pollLast();
                     }
-                } else if (node.getRawType().equals(scope.getTargetClass())) {
+                } else if (node.getRawType().equals(scope.getTargetClass())
+                        || node.getTargetClass().equals(scope.getTargetClass())) {
+
                     scope = (ScopeImpl) deq.pollLast();
                 }
             }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/scope/ScopeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/scope/ScopeTest.java
@@ -19,11 +19,16 @@ import org.instancio.Instancio;
 import org.instancio.test.support.pojo.misc.StringFields;
 import org.instancio.test.support.pojo.person.PersonHolder;
 import org.instancio.test.support.pojo.person.Phone;
+import org.instancio.test.support.pojo.person.PhoneType;
+import org.instancio.test.support.pojo.person.PhoneWithType;
 import org.instancio.test.support.pojo.person.RichPerson;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.all;
@@ -74,6 +79,21 @@ class ScopeTest {
                 .isEqualTo(result.getFour())
                 .isNotEqualTo(result.getTwo())
                 .isNotEqualTo(result.getThree());
+    }
 
+    @Test
+    void scopeWithSubtype() {
+        final List<Phone> results = Instancio.ofList(Phone.class)
+                .size(Constants.SAMPLE_SIZE_DD)
+                .subtype(all(Phone.class), PhoneWithType.class)
+                .set(all(PhoneType.class).within(scope(PhoneWithType.class)), PhoneType.OTHER)
+                .create();
+
+        assertThat(results)
+                .hasOnlyElementsOfType(PhoneWithType.class)
+                .allSatisfy(result -> {
+                    PhoneWithType phoneWithType = (PhoneWithType) result;
+                    assertThat(phoneWithType.getPhoneType()).isEqualTo(PhoneType.OTHER);
+                });
     }
 }


### PR DESCRIPTION
This commit fixes a bug where a selector has a class scope, and the class in question is the subtype class specified via the `subtype()` method.