### PR TITLE
Add support for `as(Function)` to the text pattern generator

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/TextPatternAsGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TextPatternAsGeneratorSpec.java
@@ -18,7 +18,7 @@ package org.instancio.generator.specs;
 /**
  * Generator spec for text patterns that supports {@link AsGeneratorSpec}.
  *
- * @since 3.4.2
+ * @since 3.6.1
  */
 public interface TextPatternAsGeneratorSpec
         extends TextPatternGeneratorSpec, AsGeneratorSpec<String> {

--- a/instancio-core/src/main/java/org/instancio/generators/TextGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/TextGenerators.java
@@ -20,7 +20,7 @@ import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.CsvGeneratorSpec;
 import org.instancio.generator.specs.LoremIpsumGeneratorSpec;
-import org.instancio.generator.specs.TextPatternGeneratorSpec;
+import org.instancio.generator.specs.TextPatternAsGeneratorSpec;
 import org.instancio.generator.specs.UUIDStringGeneratorSpec;
 import org.instancio.internal.generator.text.CsvGenerator;
 import org.instancio.internal.generator.text.LoremIpsumGenerator;
@@ -85,7 +85,7 @@ public class TextGenerators {
      * @return string pattern generator
      * @since 1.1.9
      */
-    public TextPatternGeneratorSpec pattern(final String pattern) {
+    public TextPatternAsGeneratorSpec pattern(final String pattern) {
         return new TextPatternGenerator(context, pattern);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/TextPatternGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/TextPatternGenerator.java
@@ -17,6 +17,7 @@ package org.instancio.internal.generator.text;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.TextPatternAsGeneratorSpec;
 import org.instancio.generator.specs.TextPatternSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.AbstractGenerator;
@@ -24,7 +25,7 @@ import org.instancio.internal.util.Fail;
 import org.instancio.support.Global;
 
 public class TextPatternGenerator extends AbstractGenerator<String>
-        implements TextPatternSpec {
+        implements TextPatternSpec, TextPatternAsGeneratorSpec {
 
     private static final String ALLOWED_HASHTAGS_MESSAGE = String.format("%nAllowed hashtags:"
             + "%n\t#a - alphanumeric character [a-z, A-Z, 0-9]"

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/text/TextPatternGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/text/TextPatternGeneratorTest.java
@@ -18,6 +18,7 @@ package org.instancio.test.features.generator.text;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.basic.IntegerHolder;
 import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.allInts;
 import static org.instancio.Select.allStrings;
 
 @FeatureTag({Feature.GENERATE, Feature.TEXT_PATTERN_GENERATOR})
@@ -41,6 +43,16 @@ class TextPatternGeneratorTest {
                 .create();
 
         assertThat(result.getValue()).matches("^Foo: [A-Z][a-z][0-9].$");
+    }
+
+    @Test
+    void patternAs() {
+        final IntegerHolder result = Instancio.of(IntegerHolder.class)
+                .generate(allInts(), gen -> gen.text().pattern("1#d").as(Integer::valueOf))
+                .create();
+
+        assertThat(result.getPrimitive()).isBetween(10, 19);
+        assertThat(result.getWrapper()).isBetween(10, 19);
     }
 
     @Test


### PR DESCRIPTION
Note: the interface was defined in 3.4.2 but was mistakenly left unused.

Sample usage:

```java
record IntegerHolder(int value) {}

IntegerHolder result = Instancio.of(IntegerHolder.class)
        .generate(allInts(), gen -> gen.text().pattern("1#d").as(Integer::valueOf))
        .create();

assertThat(result.value()).isBetween(10, 19);
```
