### PR TITLE
Breaking change: `stream()` semantics when used with stateful generators

### DIFF
--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -66,12 +66,15 @@ public interface InstancioApi<T> extends
      * <p>Example:
      * <pre>{@code
      * List<Person> persons = Instancio.of(Person.class)
+     *     .generate(field(Person::getAge), gen -> gen.ints().range(18, 100))
      *     .stream()
      *     .limit(5)
      *     .collect(Collectors.toList());
      * }</pre>
      *
      * <p><b>Warning:</b> {@code limit()} must be called to avoid an infinite loop.
+     *
+     * <p>All objects in the stream are independent of each other.
      *
      * @return an infinite stream of distinct object instances
      * @since 1.1.9

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
@@ -175,9 +175,7 @@ class EmitGeneratorTest {
 
         final List<Integer> result = Instancio.ofList(Integer.class)
                 .size(values.size())
-                .generate(all(Integer.class), gen -> gen.emit()
-                        .items(values.toArray(new Integer[0]))
-                        .shuffle())
+                .generate(all(Integer.class), gen -> gen.emit().items(values).shuffle())
                 .create();
 
         assertThat(result)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitModelTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.misc;
+
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.allStrings;
+
+@FeatureTag({Feature.EMIT_GENERATOR, Feature.MODEL})
+@ExtendWith(InstancioExtension.class)
+class EmitModelTest {
+
+    @Test
+    void emitWithTwoModels() {
+        final String expected = "foo";
+
+        final Model<String> model = Instancio.of(String.class)
+                .generate(allStrings(), gen -> gen.emit().items(expected))
+                .toModel();
+
+        // Each root object should have its own copy of items to emit
+        // even though they share the same instance of a model
+        final String result1 = Instancio.create(model);
+        final String result2 = Instancio.create(model);
+
+        assertThat(result1).isEqualTo(result2).isEqualTo(expected);
+    }
+
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitStreamTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitStreamTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.misc;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.all;
+
+/**
+ * {@code stream()} creates a new root object each time.
+ * Therefore, each root object gets its own copy of values to emit.
+ */
+@FeatureTag({Feature.EMIT_GENERATOR, Feature.STREAM})
+@ExtendWith(InstancioExtension.class)
+class EmitStreamTest {
+
+    @Test
+    void throwsAnExceptionOnUnusedItems() {
+        final String[] items = {"foo", "bar", "baz"};
+
+        final Stream<String> stream = Instancio.of(String.class)
+                .generate(all(String.class), gen -> gen.emit().items(items))
+                .stream()
+                .limit(items.length);
+
+        assertThatThrownBy(() -> stream.collect(toList())) // NOSONAR
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContainingAll(
+                        "not all the items provided via the 'emit()' method have been consumed",
+                        "Remaining items: [bar, baz]");
+    }
+
+    @Test
+    void ignoreUnusedItems() {
+        final String[] items = {"foo", "bar", "baz"};
+
+        final Stream<String> results = Instancio.of(String.class)
+                .generate(all(String.class), gen -> gen.emit().items(items).ignoreUnused())
+                .stream()
+                .limit(items.length);
+
+        assertThat(results)
+                .as("Should pick the first value from items for each root objectm and ignore the rest")
+                .containsExactly("foo", "foo", "foo");
+    }
+
+    @Test
+    void withMultipleItems() {
+        final String[] items = {"foo", "bar", "baz"};
+
+        final int outerListSize = 10;
+
+        final List<List<String>> results = Instancio.of(new TypeToken<List<String>>() {})
+                .generate(all(List.class), gen -> gen.collection().size(items.length)) // inner list
+                .generate(all(String.class), gen -> gen.emit().items(items))
+                .stream()
+                .limit(outerListSize)
+                .collect(toList());
+
+        assertThat(results)
+                .hasSize(outerListSize)
+                .allMatch(r -> r.equals(Arrays.asList(items)));
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamTest.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.allStrings;
 import static org.instancio.Select.field;
@@ -134,18 +134,19 @@ class CreateStreamTest {
     void withSeed() {
         final long seed = Instancio.create(long.class);
 
-        final List<UUID> list1 = Instancio.of(UUID.class)
+        // Should produce distinct UUIDs
+        final Set<UUID> set1 = Instancio.of(UUID.class)
                 .withSeed(seed)
                 .stream()
                 .limit(LIMIT)
-                .collect(toList());
+                .collect(toSet());
 
-        final List<UUID> list2 = Instancio.of(UUID.class)
+        final Set<UUID> set2 = Instancio.of(UUID.class)
                 .withSeed(seed)
                 .stream()
                 .limit(LIMIT)
-                .collect(toList());
+                .collect(toSet());
 
-        assertThat(list1).isEqualTo(list2).hasSize(LIMIT);
+        assertThat(set1).isEqualTo(set2).hasSize(LIMIT);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamVerboseTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/CreateStreamVerboseTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright 2022-2023 the original author or authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.instancio.test.features.stream;
+
+import org.instancio.Gen;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.STREAM)
+@ExtendWith(InstancioExtension.class)
+class CreateStreamVerboseTest {
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @BeforeEach
+    void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(standardOut);
+    }
+
+    /**
+     * Should output only once per stream, not per each root object created.
+     */
+    @Test
+    void verbose() {
+        final long seed = Gen.longs().get();
+
+        final List<Integer> results = Instancio.of(Integer.class)
+                .withSeed(seed)
+                .verbose()
+                .stream()
+                .limit(3)
+                .collect(Collectors.toList());
+
+        assertThat(results)
+                .hasSize(3)
+                .doesNotContainNull();
+
+        assertThat(outputStreamCaptor)
+                .asString()
+                .containsOnlyOnce("<0:Integer>")
+                .containsOnlyOnce("Seed ..................: " + seed);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/StreamSeedTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/stream/StreamSeedTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.stream;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.Seed;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag({Feature.STREAM, Feature.WITH_SEED, Feature.WITH_SEED_ANNOTATION})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(InstancioExtension.class)
+class StreamSeedTest {
+    private static final long SEED = 123;
+    private static final int SAMPLE_SIZE = 10;
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private static Set<UUID> first;
+
+    @Seed(SEED)
+    @Order(1)
+    @Test
+    @DisplayName("1. Seed via @Seed annotation - create reference object")
+    void first() {
+        first = Instancio.of(UUID.class)
+                .stream()
+                .limit(SAMPLE_SIZE)
+                .collect(toSet());
+
+        assertThat(first)
+                .as("stream() should generate distinct objects")
+                .hasSize(SAMPLE_SIZE);
+    }
+
+    @Seed(SEED)
+    @Order(2)
+    @Test
+    @DisplayName("2. Seed via @Seed annotation")
+    void second() {
+        final Set<UUID> result = Instancio.of(UUID.class)
+                .stream()
+                .limit(SAMPLE_SIZE)
+                .collect(toSet());
+
+        assertThat(result).isEqualTo(first);
+    }
+
+    @Order(3)
+    @Test
+    @DisplayName("3. Seed via API builder")
+    void third() {
+        final Set<UUID> result = Instancio.of(UUID.class)
+                .withSeed(SEED)
+                .stream()
+                .limit(SAMPLE_SIZE)
+                .collect(toSet());
+
+        assertThat(result).isEqualTo(first);
+    }
+
+    @Order(4)
+    @Test
+    @DisplayName("4. Seed via Settings")
+    void fourth() {
+        final Set<UUID> result = Instancio.of(UUID.class)
+                .withSettings(Settings.create().set(Keys.SEED, SEED))
+                .stream()
+                .limit(SAMPLE_SIZE)
+                .collect(toSet());
+
+        assertThat(result).isEqualTo(first);
+    }
+}


### PR DESCRIPTION
With this commit, all root objects created by `stream()` are independent of each other. This affects the behaviour of `stream()` when used with stateful generators such as `emit()`, `intSeq()`, `longSeq()`.

**Example:**

```java
List<String> results = Instancio.of(String.class)
    .generate(allStrings(), gen -> gen.emit().items("foo", "bar", "baz").ignoreUnused())
    .stream()
    .limit(3)
    .toList();

// Original behaviour
assertThat(results).containsExactly("foo", "bar", "baz");

// New behaviour
assertThat(results).containsExactly("foo", "foo", "foo");
```