### PR TITLE
Predicate selectors: support for `within(Scope)`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/PredicateSelector.java
+++ b/instancio-core/src/main/java/org/instancio/PredicateSelector.java
@@ -15,11 +15,23 @@
  */
 package org.instancio;
 
+import org.instancio.documentation.ExperimentalApi;
+
 /**
  * A selector for matching targets using predicates.
  *
  * @see Select
  * @since 1.6.0
  */
-public interface PredicateSelector extends GroupableSelector, DepthSelector, DepthPredicateSelector {
+public interface PredicateSelector
+        extends GroupableSelector, DepthSelector, DepthPredicateSelector, WithinScope {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.1.0
+     */
+    @Override
+    @ExperimentalApi
+    GroupableSelector within(Scope... scopes);
 }

--- a/instancio-core/src/main/java/org/instancio/ScopeableSelector.java
+++ b/instancio-core/src/main/java/org/instancio/ScopeableSelector.java
@@ -21,41 +21,13 @@ package org.instancio;
  *
  * @since 3.0.0
  */
-public interface ScopeableSelector extends GroupableSelector, ConvertibleToScope {
+public interface ScopeableSelector extends GroupableSelector, ConvertibleToScope, WithinScope {
 
     /**
-     * Specifies the scope for this selector in order to narrow
-     * down its target.
+     * {@inheritDoc}
      *
-     * <p>For example, given the following classes:
-     *
-     * <pre>{@code
-     * record Phone(String countryCode, String number) {}
-     *
-     * record Person(Phone home, Phone cell) {}
-     * }</pre>
-     *
-     * <p>setting {@code home} and {@code cell} phone numbers to different
-     * values would require differentiating between two
-     * {@code field(Phone::number)}  selectors. This can be achieved using
-     * scopes as follows:
-     *
-     * <pre>{@code
-     * Scope homePhone = field(Person::home).toScope();
-     * Scope cellPhone = field(Person::cell).toScope();
-     *
-     * Person person = Instancio.of(Person.class)
-     *     .set(field(Phone::number).within(homePhone), "777-88-99")
-     *     .set(field(Phone::number).within(cellPhone), "123-45-67")
-     *     .create();
-     * }</pre>
-     *
-     * <p>See <a href="https://instancio.org/user-guide/#selector-scopes">Selector Scopes</a>
-     * section of the user guide for details.
-     *
-     * @param scopes one or more scopes to apply
-     * @return a selector with the specified scope
      * @since 3.0.0
      */
+    @Override
     GroupableSelector within(Scope... scopes);
 }

--- a/instancio-core/src/main/java/org/instancio/Select.java
+++ b/instancio-core/src/main/java/org/instancio/Select.java
@@ -550,16 +550,6 @@ public final class Select {
      *     .create();
      * }</pre>
      *
-     * <p><b>Note:</b> scopes can only be applied to regular selectors.
-     * Predicate selectors, listed below, cannot be scoped.
-     *
-     * <ul>
-     *   <li>{@link #types()}</li>
-     *   <li>{@link #fields()}</li>
-     *   <li>{@link #types(Predicate)}</li>
-     *   <li>{@link #fields(Predicate)}</li>
-     * </ul>
-     *
      * @param targetClass of the scope
      * @return a scope for fine-tuning a selector
      * @since 1.3.0

--- a/instancio-core/src/main/java/org/instancio/WithinScope.java
+++ b/instancio-core/src/main/java/org/instancio/WithinScope.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+/**
+ * Adds ability to narrow down selector targets using {@link Scope}.
+ *
+ * @see Scope
+ * @since 4.1.0
+ */
+public interface WithinScope {
+
+    /**
+     * Specifies the scope for this selector in order to narrow
+     * down its target.
+     *
+     * <p>For example, given the following classes:
+     *
+     * <pre>{@code
+     * record Phone(String countryCode, String number) {}
+     *
+     * record Person(Phone home, Phone cell) {}
+     * }</pre>
+     *
+     * <p>setting {@code home} and {@code cell} phone numbers to different
+     * values would require differentiating between two
+     * {@code field(Phone::number)}  selectors. This can be achieved using
+     * scopes as follows:
+     *
+     * <pre>{@code
+     * Scope homePhone = field(Person::home).toScope();
+     * Scope cellPhone = field(Person::cell).toScope();
+     *
+     * Person person = Instancio.of(Person.class)
+     *     .set(field(Phone::number).within(homePhone), "777-88-99")
+     *     .set(field(Phone::number).within(cellPhone), "123-45-67")
+     *     .create();
+     * }</pre>
+     *
+     * <p>See <a href="https://instancio.org/user-guide/#selector-scopes">Selector Scopes</a>
+     * section of the user guide for details.
+     *
+     * @param scopes one or more scopes to apply
+     * @return a selector with the specified scope
+     * @since 4.1.0
+     */
+    TargetSelector within(Scope... scopes);
+}

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
@@ -175,7 +175,7 @@ public final class SelectorImpl
             sb.append(".atDepth(").append(depth).append(')');
         }
         if (!scopes.isEmpty()) {
-            sb.append(", ").append(Format.formatScopes(scopes));
+            sb.append(".within(").append(Format.formatScopes(scopes)).append(')');
         }
         return sb.toString();
     }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorProcessor.java
@@ -90,10 +90,12 @@ public final class SelectorProcessor {
             return Arrays.asList(ps.getPrimitive(), ps.getWrapper());
 
         } else if (selector instanceof PredicateSelectorImpl) {
-            // No processing required for predicate selectors.
-            // They don't support scopes and root class is not applicable to predicates.
-            return Collections.singletonList(selector);
+            final PredicateSelectorImpl ps = (PredicateSelectorImpl) selector;
+            final PredicateSelectorImpl processed = PredicateSelectorImpl.builder(ps)
+                    .scopes(createScopeWithRootClass(ps.getScopes()))
+                    .build();
 
+            return Collections.singletonList(processed);
         } else {
             // only remaining option is SelectorBuilder
             final SelectorBuilder builder = (SelectorBuilder) selector;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Collections;
 import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +64,7 @@ class CustomPredicateNodeSelectorTest {
         private static final int PRIORITY = Integer.MAX_VALUE; // lowest priority
 
         AddressStringSelector(final Predicate<InternalNode> nodePredicate, final String apiInvocationDescription) {
-            super(PRIORITY, nodePredicate, /* depth = */ null, apiInvocationDescription, new Throwable());
+            super(PRIORITY, nodePredicate, Collections.emptyList(), /* depth = */ null, apiInvocationDescription, new Throwable());
         }
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorWithinScopeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/PredicateSelectorWithinScopeTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.selector;
+
+import org.instancio.Instancio;
+import org.instancio.TargetSelector;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.pojo.misc.StringsDef;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.scope;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.PREDICATE_SELECTOR, Feature.SCOPE})
+@ExtendWith(InstancioExtension.class)
+class PredicateSelectorWithinScopeTest {
+
+    private static Stream<Arguments> selectors() {
+        return Stream.of(
+                // types
+                Arguments.of(types(t -> t == String.class).within(scope(StringsDef.class))),
+                Arguments.of(types(t -> t == String.class).within(all(StringsDef.class).toScope())),
+                Arguments.of(types(t -> t == String.class).within(scope(StringsAbc::getDef))),
+                Arguments.of(types(t -> t == String.class).within(scope(StringsAbc.class), scope(StringsAbc::getDef))),
+                Arguments.of(types(t -> t == String.class).within(scope(StringsAbc.class), scope(StringsDef.class))),
+                // fields
+                Arguments.of(fields(f -> f.getType() == String.class).within(scope(StringsAbc::getDef))),
+                Arguments.of(fields(f -> f.getType() == String.class).within(all(StringsDef.class).toScope())),
+                Arguments.of(fields(f -> f.getType() == String.class).within(field("def").toScope())),
+                Arguments.of(fields(f -> f.getType() == String.class).within(field(StringsAbc::getDef).toScope()))
+        );
+    }
+
+    @MethodSource("selectors")
+    @ParameterizedTest
+    void withinScope(final TargetSelector selector) {
+        final StringsAbc result = Instancio.of(StringsAbc.class)
+                .set(selector, "foo")
+                .create();
+
+        assertThat(result.getA()).isNotEqualTo("foo");
+        assertThat(result.getB()).isNotEqualTo("foo");
+        assertThat(result.getC()).isNotEqualTo("foo");
+
+        assertThatObject(result.getDef()).hasAllFieldsOfTypeEqualTo(String.class, "foo");
+        assertThatObject(result.getDef().getGhi()).hasAllFieldsOfTypeEqualTo(String.class, "foo");
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/UnresolvedAssignmentErrorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/UnresolvedAssignmentErrorTest.java
@@ -53,7 +53,7 @@ class UnresolvedAssignmentErrorTest extends AbstractErrorMessageTestTemplate {
 
                  -> from [field(StringsAbc, "c")] to [field(StringsAbc, "a")]
                  -> from [field(StringsAbc, "a")] to [field(StringsAbc, "b")]
-                 -> from [field(StringsAbc, "b"), scope(StringsAbc)] to [field(StringsAbc, "c")]
+                 -> from [field(StringsAbc, "b").within(scope(StringsAbc))] to [field(StringsAbc, "c")]
 
                 As a result, the following targets could not be assigned a value:
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/ApiContractTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/ApiContractTest.java
@@ -103,14 +103,10 @@ class ApiContractTest {
         assertThatClass(TypeSelectorBuilder.class).hasNoMethodsNamed("toScope");
     }
 
-    /**
-     * {@code Select.fields(p -> true).toScope()}
-     * {@code Select.types(p -> true).toScope()}
-     */
     @Test
-    @DisplayName("Predicate selector cannot be converted to scope")
-    void fieldsPredicateSelectorCannotBeConvertedToScope() {
-        assertThatClass(PredicateSelector.class).hasNoMethodsNamed("toScope");
+    @DisplayName("Methods supported by predicate selector")
+    void predicateSelectorSupportedMethods() {
+        assertThatClass(PredicateSelector.class).hasOnlyMethodsNamed("atDepth", "within");
     }
 
     /**

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/PredicateSelectorImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/PredicateSelectorImplTest.java
@@ -20,7 +20,9 @@ import org.instancio.PredicateSelector;
 import org.instancio.Select;
 import org.instancio.TypeSelectorBuilder;
 import org.instancio.exception.InstancioApiException;
+import org.instancio.test.support.pojo.person.Person;
 import org.instancio.test.support.pojo.person.PersonName;
+import org.instancio.test.support.pojo.person.Phone;
 import org.instancio.test.support.pojo.person.Pojo;
 import org.instancio.testsupport.fixtures.Throwables;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +31,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -243,6 +247,30 @@ class PredicateSelectorImplTest {
                     .build();
 
             assertThat(selector).hasToString("types(Predicate<Class>).atDepth(Predicate<Integer>)");
+        }
+
+        @Test
+        void withinSingleScope() {
+            final PredicateSelectorImpl selector = PredicateSelectorImpl.builder()
+                    .typePredicate(o -> true)
+                    .scopes(Collections.singletonList(Select.scope(Phone.class)))
+                    .build();
+
+            assertThat(selector).hasToString(
+                    "types(Predicate<Class>).within(scope(Phone))");
+        }
+
+        @Test
+        void withinMultipleScopes() {
+            final PredicateSelectorImpl selector = PredicateSelectorImpl.builder()
+                    .typePredicate(o -> true)
+                    .scopes(Arrays.asList(
+                            Select.scope(Person.class),
+                            Select.scope(Phone.class)))
+                    .build();
+
+            assertThat(selector).hasToString(
+                    "types(Predicate<Class>).within(scope(Person), scope(Phone))");
         }
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
@@ -122,17 +122,17 @@ class SelectorImplTest {
                 .hasToString("field(Phone, \"number\").atDepth(3)");
 
         assertThat(Select.field(Phone.class, "number").within(scope(Address.class)))
-                .hasToString("field(Phone, \"number\"), scope(Address)");
+                .hasToString("field(Phone, \"number\").within(scope(Address))");
 
         assertThat(Select.field(Phone.class, "number").atDepth(3).within(
                 scope(Person.class), scope(Address.class)))
-                .hasToString("field(Phone, \"number\").atDepth(3), scope(Person), scope(Address)");
+                .hasToString("field(Phone, \"number\").atDepth(3).within(scope(Person), scope(Address))");
 
         assertThat(Select.field(Phone.class, "number").within(
                 scope(Person.class, "address"),
                 scope(Address.class)))
                 .hasToString(
-                        "field(Phone, \"number\"), scope(Person, \"address\"), scope(Address)");
+                        "field(Phone, \"number\").within(scope(Person, \"address\"), scope(Address))");
 
         assertThat(Select.setter("setName"))
                 .hasToString("setter(\"setName\")");

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/asserts/ClassAssert.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/asserts/ClassAssert.java
@@ -19,7 +19,9 @@ import org.assertj.core.api.AbstractAssert;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +40,16 @@ public class ClassAssert extends AbstractAssert<ClassAssert, Class<?>> {
         assertThat(actual.getMethods())
                 .extracting(Method::getName)
                 .doesNotContain(methodNames);
+
+        return this;
+    }
+
+    public ClassAssert hasOnlyMethodsNamed(final String... methodNames) {
+        final Set<String> actualMethods = Arrays.stream(actual.getMethods())
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+
+        assertThat(actualMethods).containsOnly(methodNames);
 
         return this;
     }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -463,7 +463,7 @@ therefore  `lenient()` mode must be enabled to prevent unused selector error
 
 ### Selector Scopes
 
-Regular selectors provide the `within(Scope... scopes)` method for fine-tuning the targets selectors should be applied to.
+Selectors provide the `within(Scope... scopes)` method for fine-tuning the targets selectors should be applied to.
 Instancio supports two types of scope:
 
 - Class-level scope: narrows down a selector to the specified class.


### PR DESCRIPTION
Regular selectors can be narrowed down using `within(Scope...)`. This PR adds support for scopes to predicate selectors.

#### Example

```java
record Widget(String name, String type) {}

record WidgetHolder(Widget widgetA, Widget widgetB) {}

WidgetHolder person = Instancio.of(WidgetHolder.class)
    .set(fields(f -> f.getType() == String.class).within(scope(WidgetHolder::widgetB)), "foo")
    .create();

// Sample output:
// WidgetHolder[widgetA=Widget[name=DGGM, type=MVCNQICSHC], widgetB=Widget[name=foo, type=foo]]
```