### PR TITLE
Bug fix: unconditional assignment with records

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/handlers/AssignmentNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/AssignmentNodeHandler.java
@@ -62,6 +62,14 @@ public class AssignmentNodeHandler implements NodeHandler {
         // loop from the end so that the last matching assignment wins
         for (int i = assignments.size() - 1; i >= 0; i--) {
             final InternalAssignment assignment = assignments.get(i);
+            final Predicate<Object> predicate = assignment.getOriginPredicate();
+
+            // unconditional assignment
+            if (predicate == null && assignment.getGenerator() != null) {
+                final Generator<?> generator = assignment.getGenerator();
+                return userSuppliedGeneratorProcessor.getGeneratorResult(node, generator);
+            }
+
             final GeneratorResult candidateResult = generatedObjectStore.getValue(assignment.getDestination());
 
             if (candidateResult == null) {
@@ -73,8 +81,6 @@ public class AssignmentNodeHandler implements NodeHandler {
             unresolvedAssignments.remove(assignment);
 
             LOG.trace("Value for destination {}: {}", assignment.getDestination(), candidateResult.getValue());
-
-            final Predicate<Object> predicate = assignment.getOriginPredicate();
 
             if (predicate == null || isSatisfied(candidateResult.getValue(), predicate)) {
 

--- a/instancio-core/src/main/java/org/instancio/internal/handlers/UserSuppliedGeneratorProcessor.java
+++ b/instancio-core/src/main/java/org/instancio/internal/handlers/UserSuppliedGeneratorProcessor.java
@@ -56,6 +56,7 @@ final class UserSuppliedGeneratorProcessor {
         this.emitGeneratorHelper = new EmitGeneratorHelper(context);
     }
 
+    @NotNull
     GeneratorResult getGeneratorResult(final @NotNull InternalNode node, final Generator<?> g) {
         final Generator<?> generator = processGenerator(g, node);
 

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignValueOfRecordsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignValueOfRecordsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16.assign;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.StringsAbcRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Assign.valueOf;
+
+@FeatureTag(Feature.ASSIGN)
+@ExtendWith(InstancioExtension.class)
+class AssignValueOfRecordsTest {
+
+    @Test
+    @DisplayName("Without a predicate")
+    void unconditional() {
+        final StringsAbcRecord result = Instancio.of(StringsAbcRecord.class)
+                .assign(valueOf(StringsAbcRecord::a).set("A"))
+                .create();
+
+        assertThat(result.a()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("With null predicate")
+    void nullPredicate() {
+        final StringsAbcRecord result = Instancio.of(StringsAbcRecord.class)
+                .assign(valueOf(StringsAbcRecord::a).set("A"))
+                .assign(valueOf(StringsAbcRecord::a).to(StringsAbcRecord::b).when(null))
+                .create();
+
+        assertThat(result.a())
+                .isEqualTo("A")
+                .isEqualTo(result.b());
+    }
+
+    @Test
+    @DisplayName("With true predicate")
+    void truePredicate() {
+        final StringsAbcRecord result = Instancio.of(StringsAbcRecord.class)
+                .assign(valueOf(StringsAbcRecord::a).set("A"))
+                .assign(valueOf(StringsAbcRecord::a).to(StringsAbcRecord::b).when(o -> true))
+                .create();
+
+        assertThat(result.a())
+                .isEqualTo("A")
+                .isEqualTo(result.b());
+    }
+
+    @Test
+    @DisplayName("With false predicate")
+    void falsePredicate() {
+        final StringsAbcRecord result = Instancio.of(StringsAbcRecord.class)
+                .assign(valueOf(StringsAbcRecord::a).set("A"))
+                .assign(valueOf(StringsAbcRecord::a).to(StringsAbcRecord::b).when(o -> false))
+                .create();
+
+        assertThat(result.a())
+                .isEqualTo("A")
+                .isNotEqualTo(result.b());
+    }
+
+}


### PR DESCRIPTION
Fix unresolved assignment error when an unconditional assignment is used with records, e.g.

```java
record Foo(String value) {}

Foo foo = Instancio.of(Foo.class)
    .assign(Assign.valueOf(Foo::value).set("foo"))
    .create();
```

