### PR TITLE
Add support for `truncatedTo()` to applicable `java.time` specs (#881)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/InstantGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/InstantGeneratorAsSpec.java
@@ -19,45 +19,41 @@ import java.time.Instant;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link java.time.Instant}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
+public interface InstantGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<Instant>,
         TruncatableTemporalSpec<Instant> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    InstantGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    InstantGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    InstantGeneratorAsSpec range(Instant start, Instant end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    InstantGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    InstantGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateSpec.java
@@ -24,12 +24,21 @@ import java.time.LocalDate;
  */
 public interface LocalDateSpec extends TemporalSpec<LocalDate> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateSpec range(LocalDate start, LocalDate end);
 

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateTimeGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateTimeGeneratorAsSpec.java
@@ -15,49 +15,45 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link LocalDateTime}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface LocalDateTimeGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<LocalDateTime>,
+        TruncatableTemporalSpec<LocalDateTime> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    LocalDateTimeGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    LocalDateTimeGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    LocalDateTimeGeneratorAsSpec range(LocalDateTime start, LocalDateTime end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    LocalDateTimeGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    LocalDateTimeGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateTimeSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LocalDateTimeSpec.java
@@ -16,22 +16,42 @@
 package org.instancio.generator.specs;
 
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalUnit;
 
 /**
  * Spec for generating {@link LocalDateTime} values.
  *
  * @since 2.6.0
  */
-public interface LocalDateTimeSpec extends TemporalSpec<LocalDateTime> {
+public interface LocalDateTimeSpec extends
+        TemporalSpec<LocalDateTime>,
+        TruncatableTemporalSpec<LocalDateTime> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateTimeSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateTimeSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalDateTimeSpec range(LocalDateTime start, LocalDateTime end);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.2.0
+     */
+    @Override
+    LocalDateTimeSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LocalTimeGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LocalTimeGeneratorAsSpec.java
@@ -15,49 +15,45 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import java.time.LocalTime;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link LocalTime}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface LocalTimeGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<LocalTime>,
+        TruncatableTemporalSpec<LocalTime> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    LocalTimeGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    LocalTimeGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    LocalTimeGeneratorAsSpec range(LocalTime start, LocalTime end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    LocalTimeGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    LocalTimeGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/LocalTimeSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/LocalTimeSpec.java
@@ -16,22 +16,42 @@
 package org.instancio.generator.specs;
 
 import java.time.LocalTime;
+import java.time.temporal.TemporalUnit;
 
 /**
  * Spec for generating {@link LocalTime} values.
  *
  * @since 2.6.0
  */
-public interface LocalTimeSpec extends TemporalSpec<LocalTime> {
+public interface LocalTimeSpec extends
+        TemporalSpec<LocalTime>,
+        TruncatableTemporalSpec<LocalTime> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalTimeSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalTimeSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     LocalTimeSpec range(LocalTime start, LocalTime end);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.2.0
+     */
+    @Override
+    LocalTimeSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OffsetDateTimeGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OffsetDateTimeGeneratorAsSpec.java
@@ -15,49 +15,45 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link OffsetDateTime}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface OffsetDateTimeGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<OffsetDateTime>,
+        TruncatableTemporalSpec<OffsetDateTime> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    OffsetDateTimeGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    OffsetDateTimeGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    OffsetDateTimeGeneratorAsSpec range(OffsetDateTime start, OffsetDateTime end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    OffsetDateTimeGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    OffsetDateTimeGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OffsetDateTimeSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OffsetDateTimeSpec.java
@@ -16,22 +16,42 @@
 package org.instancio.generator.specs;
 
 import java.time.OffsetDateTime;
+import java.time.temporal.TemporalUnit;
 
 /**
  * Spec for generating {@link OffsetDateTime} values.
  *
  * @since 2.6.0
  */
-public interface OffsetDateTimeSpec extends TemporalSpec<OffsetDateTime> {
+public interface OffsetDateTimeSpec extends
+        TemporalSpec<OffsetDateTime>,
+        TruncatableTemporalSpec<OffsetDateTime> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetDateTimeSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetDateTimeSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetDateTimeSpec range(OffsetDateTime start, OffsetDateTime end);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.2.0
+     */
+    @Override
+    OffsetDateTimeSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OffsetTimeGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OffsetTimeGeneratorAsSpec.java
@@ -15,49 +15,45 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import java.time.OffsetTime;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link OffsetTime}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface OffsetTimeGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<OffsetTime>,
+        TruncatableTemporalSpec<OffsetTime> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    OffsetTimeGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    OffsetTimeGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    OffsetTimeGeneratorAsSpec range(OffsetTime start, OffsetTime end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    OffsetTimeGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    OffsetTimeGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OffsetTimeSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OffsetTimeSpec.java
@@ -16,22 +16,42 @@
 package org.instancio.generator.specs;
 
 import java.time.OffsetTime;
+import java.time.temporal.TemporalUnit;
 
 /**
  * Spec for generating {@link OffsetTime} values.
  *
  * @since 2.6.0
  */
-public interface OffsetTimeSpec extends TemporalSpec<OffsetTime> {
+public interface OffsetTimeSpec extends
+        TemporalSpec<OffsetTime>,
+        TruncatableTemporalSpec<OffsetTime> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetTimeSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetTimeSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     OffsetTimeSpec range(OffsetTime start, OffsetTime end);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.2.0
+     */
+    @Override
+    OffsetTimeSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/PeriodSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/PeriodSpec.java
@@ -26,12 +26,21 @@ import java.time.Period;
  */
 public interface PeriodSpec extends ValueSpec<Period>, PeriodGeneratorSpec {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     PeriodSpec days(int min, int max);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     PeriodSpec months(int min, int max);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     PeriodSpec years(int min, int max);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/TemporalAsGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TemporalAsGeneratorSpec.java
@@ -23,12 +23,21 @@ package org.instancio.generator.specs;
 public interface TemporalAsGeneratorSpec<T>
         extends TemporalGeneratorSpec<T>, AsGeneratorSpec<T> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalAsGeneratorSpec<T> past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalAsGeneratorSpec<T> future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalAsGeneratorSpec<T> range(T start, T end);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/TemporalGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TemporalGeneratorSpec.java
@@ -52,5 +52,5 @@ public interface TemporalGeneratorSpec<T> extends NullableGeneratorSpec<T> {
      * @since 2.7.0
      */
     @Override
-    NullableGeneratorSpec<T> nullable();
+    TemporalGeneratorSpec<T> nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/TemporalSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TemporalSpec.java
@@ -26,12 +26,21 @@ import java.time.temporal.Temporal;
  */
 public interface TemporalSpec<T> extends ValueSpec<T>, TemporalGeneratorSpec<T> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalSpec<T> past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalSpec<T> future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     TemporalSpec<T> range(T start, T end);
 

--- a/instancio-core/src/main/java/org/instancio/generator/specs/TruncatableTemporalSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TruncatableTemporalSpec.java
@@ -15,49 +15,24 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import org.instancio.generator.GeneratorSpec;
+
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * A spec for truncating temporal values.
  *
- * @since 2.6.0
+ * @param <T> temporal type
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface TruncatableTemporalSpec<T> extends GeneratorSpec<T> {
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    InstantSpec past();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    InstantSpec future();
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    InstantSpec range(Instant start, Instant end);
-
-    /**
-     * {@inheritDoc}
+     * Truncates generated values to the specified unit.
      *
+     * @param unit to truncate to
+     * @return spec builder
      * @since 4.2.0
      */
-    @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
-
-    /**
-     * {@inheritDoc}
-     *
-     * @since 2.7.0
-     */
-    @Override
-    InstantSpec nullable();
+    GeneratorSpec<T> truncatedTo(TemporalUnit unit);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/YearMonthSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/YearMonthSpec.java
@@ -24,12 +24,21 @@ import java.time.YearMonth;
  */
 public interface YearMonthSpec extends TemporalSpec<YearMonth> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearMonthSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearMonthSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearMonthSpec range(YearMonth start, YearMonth end);
 

--- a/instancio-core/src/main/java/org/instancio/generator/specs/YearSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/YearSpec.java
@@ -24,12 +24,21 @@ import java.time.Year;
  */
 public interface YearSpec extends TemporalSpec<Year> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     YearSpec range(Year start, Year end);
 

--- a/instancio-core/src/main/java/org/instancio/generator/specs/ZonedDateTimeGeneratorAsSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/ZonedDateTimeGeneratorAsSpec.java
@@ -15,49 +15,45 @@
  */
 package org.instancio.generator.specs;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.temporal.TemporalUnit;
 
 /**
- * Spec for generating {@link Instant} values.
+ * Generator spec for {@link ZonedDateTime}.
  *
- * @since 2.6.0
+ * @since 4.2.0
  */
-public interface InstantSpec extends
-        TemporalSpec<Instant>,
-        TruncatableTemporalSpec<Instant> {
+public interface ZonedDateTimeGeneratorAsSpec extends
+        TemporalAsGeneratorSpec<ZonedDateTime>,
+        TruncatableTemporalSpec<ZonedDateTime> {
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec past();
+    ZonedDateTimeGeneratorAsSpec past();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec future();
+    ZonedDateTimeGeneratorAsSpec future();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    InstantSpec range(Instant start, Instant end);
+    ZonedDateTimeGeneratorAsSpec range(ZonedDateTime start, ZonedDateTime end);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 4.2.0
      */
     @Override
-    InstantSpec truncatedTo(TemporalUnit unit);
+    ZonedDateTimeGeneratorAsSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}
-     *
-     * @since 2.7.0
      */
     @Override
-    InstantSpec nullable();
+    ZonedDateTimeGeneratorAsSpec nullable();
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/ZonedDateTimeSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/ZonedDateTimeSpec.java
@@ -16,22 +16,42 @@
 package org.instancio.generator.specs;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalUnit;
 
 /**
  * Spec for generating {@link ZonedDateTime} values.
  *
  * @since 2.6.0
  */
-public interface ZonedDateTimeSpec extends TemporalSpec<ZonedDateTime> {
+public interface ZonedDateTimeSpec extends
+        TemporalSpec<ZonedDateTime>,
+        TruncatableTemporalSpec<ZonedDateTime> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     ZonedDateTimeSpec past();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     ZonedDateTimeSpec future();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     ZonedDateTimeSpec range(ZonedDateTime start, ZonedDateTime end);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.2.0
+     */
+    @Override
+    ZonedDateTimeSpec truncatedTo(TemporalUnit unit);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/generators/TemporalGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/TemporalGenerators.java
@@ -18,10 +18,16 @@ package org.instancio.generators;
 
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.DurationGeneratorSpec;
+import org.instancio.generator.specs.InstantGeneratorAsSpec;
+import org.instancio.generator.specs.LocalDateTimeGeneratorAsSpec;
+import org.instancio.generator.specs.LocalTimeGeneratorAsSpec;
 import org.instancio.generator.specs.MonthDayGeneratorSpec;
+import org.instancio.generator.specs.OffsetDateTimeGeneratorAsSpec;
+import org.instancio.generator.specs.OffsetTimeGeneratorAsSpec;
 import org.instancio.generator.specs.PeriodGeneratorSpec;
 import org.instancio.generator.specs.TemporalAsGeneratorSpec;
 import org.instancio.generator.specs.TemporalGeneratorSpec;
+import org.instancio.generator.specs.ZonedDateTimeGeneratorAsSpec;
 import org.instancio.internal.generator.sql.SqlDateGenerator;
 import org.instancio.internal.generator.sql.TimestampGenerator;
 import org.instancio.internal.generator.time.DurationGenerator;
@@ -73,7 +79,7 @@ public class TemporalGenerators {
      *
      * @return customised generator
      */
-    public TemporalAsGeneratorSpec<Instant> instant() {
+    public InstantGeneratorAsSpec instant() {
         return new InstantGenerator(context);
     }
 
@@ -91,7 +97,7 @@ public class TemporalGenerators {
      *
      * @return customised generator
      */
-    public TemporalAsGeneratorSpec<LocalTime> localTime() {
+    public LocalTimeGeneratorAsSpec localTime() {
         return new LocalTimeGenerator(context);
     }
 
@@ -100,7 +106,7 @@ public class TemporalGenerators {
      *
      * @return customised generator
      */
-    public TemporalAsGeneratorSpec<LocalDateTime> localDateTime() {
+    public LocalDateTimeGeneratorAsSpec localDateTime() {
         return new LocalDateTimeGenerator(context);
     }
 
@@ -120,7 +126,7 @@ public class TemporalGenerators {
      * @return customised generator
      * @since 2.4.0
      */
-    public TemporalAsGeneratorSpec<OffsetTime> offsetTime() {
+    public OffsetTimeGeneratorAsSpec offsetTime() {
         return new OffsetTimeGenerator(context);
     }
 
@@ -130,7 +136,7 @@ public class TemporalGenerators {
      * @return customised generator
      * @since 2.4.0
      */
-    public TemporalAsGeneratorSpec<OffsetDateTime> offsetDateTime() {
+    public OffsetDateTimeGeneratorAsSpec offsetDateTime() {
         return new OffsetDateTimeGenerator(context);
     }
 
@@ -139,7 +145,7 @@ public class TemporalGenerators {
      *
      * @return customised generator
      */
-    public TemporalAsGeneratorSpec<ZonedDateTime> zonedDateTime() {
+    public ZonedDateTimeGeneratorAsSpec zonedDateTime() {
         return new ZonedDateTimeGenerator(context);
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/InstantGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/InstantGenerator.java
@@ -17,15 +17,17 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.InstantGeneratorAsSpec;
 import org.instancio.generator.specs.InstantSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Constants;
 import org.instancio.support.Global;
 
 import java.time.Instant;
+import java.time.temporal.TemporalUnit;
 
 public class InstantGenerator extends JavaTimeTemporalGenerator<Instant>
-        implements InstantSpec {
+        implements InstantGeneratorAsSpec, InstantSpec {
 
     private static final int MAX_NANO = 999_999_999;
     static final Instant DEFAULT_MIN = Constants.DEFAULT_MIN.atZone(Constants.ZONE_OFFSET).toInstant();
@@ -59,6 +61,12 @@ public class InstantGenerator extends JavaTimeTemporalGenerator<Instant>
     @Override
     public InstantGenerator range(final Instant start, final Instant end) {
         super.range(start, end);
+        return this;
+    }
+
+    @Override
+    public InstantGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
         return this;
     }
 
@@ -98,6 +106,7 @@ public class InstantGenerator extends JavaTimeTemporalGenerator<Instant>
             nano = random.intRange(0, MAX_NANO);
         }
 
-        return Instant.ofEpochSecond(sec, nano);
+        final Instant result = Instant.ofEpochSecond(sec, nano);
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/JavaTimeTemporalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/JavaTimeTemporalGenerator.java
@@ -21,6 +21,7 @@ import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.AbstractGenerator;
 
 import java.time.temporal.Temporal;
+import java.time.temporal.TemporalUnit;
 
 abstract class JavaTimeTemporalGenerator<T extends Temporal> extends AbstractGenerator<T>
         implements TemporalAsGeneratorSpec<T> {
@@ -30,6 +31,7 @@ abstract class JavaTimeTemporalGenerator<T extends Temporal> extends AbstractGen
 
     protected T min;
     protected T max;
+    protected TemporalUnit truncateTo;
 
     JavaTimeTemporalGenerator(final GeneratorContext context, final T min, final T max) {
         super(context);
@@ -64,6 +66,17 @@ abstract class JavaTimeTemporalGenerator<T extends Temporal> extends AbstractGen
         min = ApiValidator.notNull(start, "Start parameter must not be null");
         max = ApiValidator.notNull(end, "End parameter must not be null");
         validateRange();
+        return this;
+    }
+
+    @Override
+    public TemporalAsGeneratorSpec<T> nullable() {
+        super.nullable();
+        return this;
+    }
+
+    TemporalAsGeneratorSpec<T> truncatedTo(final TemporalUnit unit) {
+        this.truncateTo = unit;
         return this;
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalDateTimeGenerator.java
@@ -17,17 +17,19 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.LocalDateTimeGeneratorAsSpec;
 import org.instancio.generator.specs.LocalDateTimeSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Constants;
 import org.instancio.support.Global;
 
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalUnit;
 
 import static org.instancio.internal.util.Constants.ZONE_OFFSET;
 
 public class LocalDateTimeGenerator extends JavaTimeTemporalGenerator<LocalDateTime>
-        implements LocalDateTimeSpec {
+        implements LocalDateTimeSpec, LocalDateTimeGeneratorAsSpec {
 
     static final LocalDateTime DEFAULT_MIN = Constants.DEFAULT_MIN;
     static final LocalDateTime DEFAULT_MAX = Constants.DEFAULT_MAX;
@@ -68,6 +70,12 @@ public class LocalDateTimeGenerator extends JavaTimeTemporalGenerator<LocalDateT
     }
 
     @Override
+    public LocalDateTimeGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
+        return this;
+    }
+
+    @Override
     public LocalDateTimeGenerator nullable() {
         super.nullable();
         return this;
@@ -91,6 +99,7 @@ public class LocalDateTimeGenerator extends JavaTimeTemporalGenerator<LocalDateT
     @Override
     protected LocalDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toInstant(ZONE_OFFSET), max.toInstant(ZONE_OFFSET));
-        return LocalDateTime.ofInstant(delegate.generate(random), ZONE_OFFSET);
+        final LocalDateTime result = LocalDateTime.ofInstant(delegate.generate(random), ZONE_OFFSET);
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/LocalTimeGenerator.java
@@ -17,15 +17,17 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.LocalTimeGeneratorAsSpec;
 import org.instancio.generator.specs.LocalTimeSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.support.Global;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.time.LocalTime;
+import java.time.temporal.TemporalUnit;
 
 public class LocalTimeGenerator extends JavaTimeTemporalGenerator<LocalTime>
-        implements LocalTimeSpec {
+        implements LocalTimeSpec, LocalTimeGeneratorAsSpec {
 
     private static final int CUT_OFF_BUFFER_MINUTES = 1;
 
@@ -57,6 +59,12 @@ public class LocalTimeGenerator extends JavaTimeTemporalGenerator<LocalTime>
     @Override
     public LocalTimeGenerator range(final LocalTime start, final LocalTime end) {
         super.range(start, end);
+        return this;
+    }
+
+    @Override
+    public LocalTimeGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
         return this;
     }
 
@@ -96,8 +104,10 @@ public class LocalTimeGenerator extends JavaTimeTemporalGenerator<LocalTime>
 
     @Override
     protected LocalTime tryGenerateNonNull(final Random random) {
-        return LocalTime.ofNanoOfDay(random.longRange(
+        final LocalTime result = LocalTime.ofNanoOfDay(random.longRange(
                 min.toNanoOfDay(),
                 max.toNanoOfDay()));
+
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetDateTimeGenerator.java
@@ -17,6 +17,7 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.OffsetDateTimeGeneratorAsSpec;
 import org.instancio.generator.specs.OffsetDateTimeSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Constants;
@@ -25,9 +26,10 @@ import org.instancio.support.Global;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.TemporalUnit;
 
 public class OffsetDateTimeGenerator extends JavaTimeTemporalGenerator<OffsetDateTime>
-        implements OffsetDateTimeSpec {
+        implements OffsetDateTimeSpec, OffsetDateTimeGeneratorAsSpec {
 
     private static final ZoneOffset ZONE_OFFSET = Constants.ZONE_OFFSET;
     static final OffsetDateTime DEFAULT_MIN = Constants.DEFAULT_MIN.atOffset(ZONE_OFFSET);
@@ -68,6 +70,12 @@ public class OffsetDateTimeGenerator extends JavaTimeTemporalGenerator<OffsetDat
     }
 
     @Override
+    public OffsetDateTimeGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
+        return this;
+    }
+
+    @Override
     public OffsetDateTimeGenerator nullable() {
         super.nullable();
         return this;
@@ -91,7 +99,8 @@ public class OffsetDateTimeGenerator extends JavaTimeTemporalGenerator<OffsetDat
     @Override
     protected OffsetDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toLocalDateTime(), max.toLocalDateTime());
-        final LocalDateTime ldt = delegate.generate(random);
-        return ldt == null ? null : OffsetDateTime.of(ldt, ZONE_OFFSET);
+        final LocalDateTime ldt = delegate.tryGenerateNonNull(random);
+        final OffsetDateTime result = OffsetDateTime.of(ldt, ZONE_OFFSET);
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/OffsetTimeGenerator.java
@@ -17,6 +17,7 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.OffsetTimeGeneratorAsSpec;
 import org.instancio.generator.specs.OffsetTimeSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Constants;
@@ -25,9 +26,10 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
+import java.time.temporal.TemporalUnit;
 
 public class OffsetTimeGenerator extends JavaTimeTemporalGenerator<OffsetTime>
-        implements OffsetTimeSpec {
+        implements OffsetTimeSpec, OffsetTimeGeneratorAsSpec {
 
     private static final int CUT_OFF_BUFFER_MINUTES = 1;
     private static final ZoneOffset ZONE_OFFSET = Constants.ZONE_OFFSET;
@@ -60,6 +62,12 @@ public class OffsetTimeGenerator extends JavaTimeTemporalGenerator<OffsetTime>
     @Override
     public OffsetTimeGenerator range(final OffsetTime start, final OffsetTime end) {
         super.range(start, end);
+        return this;
+    }
+
+    @Override
+    public OffsetTimeGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
         return this;
     }
 
@@ -103,6 +111,7 @@ public class OffsetTimeGenerator extends JavaTimeTemporalGenerator<OffsetTime>
         int minute = random.intRange(min.getMinute(), max.getMinute());
         int second = random.intRange(min.getSecond(), max.getSecond());
         int nano = random.intRange(min.getNano(), max.getNano());
-        return OffsetTime.of(hour, minute, second, nano, ZONE_OFFSET);
+        final OffsetTime result = OffsetTime.of(hour, minute, second, nano, ZONE_OFFSET);
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/ZonedDateTimeGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/ZonedDateTimeGenerator.java
@@ -17,17 +17,19 @@ package org.instancio.internal.generator.time;
 
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.ZonedDateTimeGeneratorAsSpec;
 import org.instancio.generator.specs.ZonedDateTimeSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.util.Constants;
 import org.instancio.support.Global;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.TemporalUnit;
 
 import static org.instancio.internal.util.Constants.ZONE_OFFSET;
 
 public class ZonedDateTimeGenerator extends JavaTimeTemporalGenerator<ZonedDateTime>
-        implements ZonedDateTimeSpec {
+        implements ZonedDateTimeSpec, ZonedDateTimeGeneratorAsSpec {
 
     static final ZonedDateTime DEFAULT_MIN = Constants.DEFAULT_MIN.atZone(ZONE_OFFSET);
     static final ZonedDateTime DEFAULT_MAX = Constants.DEFAULT_MAX.atZone(ZONE_OFFSET);
@@ -68,6 +70,12 @@ public class ZonedDateTimeGenerator extends JavaTimeTemporalGenerator<ZonedDateT
     }
 
     @Override
+    public ZonedDateTimeGenerator truncatedTo(final TemporalUnit unit) {
+        super.truncatedTo(unit);
+        return this;
+    }
+
+    @Override
     public ZonedDateTimeGenerator nullable() {
         super.nullable();
         return this;
@@ -91,6 +99,7 @@ public class ZonedDateTimeGenerator extends JavaTimeTemporalGenerator<ZonedDateT
     @Override
     public ZonedDateTime tryGenerateNonNull(final Random random) {
         delegate.range(min.toInstant(), max.toInstant());
-        return ZonedDateTime.ofInstant(delegate.tryGenerateNonNull(random), ZONE_OFFSET);
+        final ZonedDateTime result = ZonedDateTime.ofInstant(delegate.tryGenerateNonNull(random), ZONE_OFFSET);
+        return truncateTo == null ? result : result.truncatedTo(truncateTo);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/InstantGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/InstantGeneratorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class InstantGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final Instant result = Instancio.of(Instant.class)
+                .generate(root(), gen -> gen.temporal().instant().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        final ZonedDateTime zdt = result.atZone(ZoneOffset.UTC);
+        assertThat(zdt.getMinute()).isZero();
+        assertThat(zdt.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().instant()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(r -> r.atZone(ZoneOffset.UTC).getMinute()))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/LocalDateTimeGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/LocalDateTimeGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class LocalDateTimeGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final LocalDateTime result = Instancio.of(LocalDateTime.class)
+                .generate(root(), gen -> gen.temporal().localDateTime().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        assertThat(result.getMinute()).isZero();
+        assertThat(result.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().localDateTime()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(LocalDateTime::getMinute))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/LocalTimeGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/LocalTimeGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class LocalTimeGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final LocalTime result = Instancio.of(LocalTime.class)
+                .generate(root(), gen -> gen.temporal().localTime().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        assertThat(result.getMinute()).isZero();
+        assertThat(result.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().localTime()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(LocalTime::getMinute))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/OffsetDateTimeGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/OffsetDateTimeGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class OffsetDateTimeGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final OffsetDateTime result = Instancio.of(OffsetDateTime.class)
+                .generate(root(), gen -> gen.temporal().offsetDateTime().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        assertThat(result.getMinute()).isZero();
+        assertThat(result.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().offsetDateTime()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(OffsetDateTime::getMinute))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/OffsetTimeGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/OffsetTimeGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.OffsetTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class OffsetTimeGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final OffsetTime result = Instancio.of(OffsetTime.class)
+                .generate(root(), gen -> gen.temporal().offsetTime().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        assertThat(result.getMinute()).isZero();
+        assertThat(result.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().offsetTime()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(OffsetTime::getMinute))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/ZonedDateTimeGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/temporal/ZonedDateTimeGeneratorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.instancio.test.features.generator.temporal;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.GENERATE, Feature.TEMPORAL_GENERATOR})
+@ExtendWith(InstancioExtension.class)
+class ZonedDateTimeGeneratorTest {
+
+    @Test
+    void truncatedTo() {
+        final ZonedDateTime result = Instancio.of(ZonedDateTime.class)
+                .generate(root(), gen -> gen.temporal().zonedDateTime().truncatedTo(ChronoUnit.HOURS))
+                .create();
+
+        assertThat(result.getMinute()).isZero();
+        assertThat(result.getSecond()).isZero();
+    }
+
+    @Test
+    void truncatedToAs() {
+        final Integer result = Instancio.of(Integer.class)
+                .generate(root(), gen -> gen.temporal().zonedDateTime()
+                        .truncatedTo(ChronoUnit.HOURS)
+                        .as(ZonedDateTime::getMinute))
+                .create();
+
+        assertThat(result).isZero();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/TemporalSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/temporal/TemporalSpecTest.java
@@ -16,10 +16,17 @@
 package org.instancio.test.features.values.temporal;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.instancio.generator.specs.InstantSpec;
+import org.instancio.generator.specs.LocalDateTimeSpec;
+import org.instancio.generator.specs.LocalTimeSpec;
+import org.instancio.generator.specs.OffsetDateTimeSpec;
+import org.instancio.generator.specs.OffsetTimeSpec;
 import org.instancio.generator.specs.TemporalSpec;
+import org.instancio.generator.specs.ZonedDateTimeSpec;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -31,7 +38,9 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Gen.temporal;
 
 @FeatureTag(Feature.VALUE_SPEC)
@@ -40,7 +49,7 @@ class TemporalSpecTest {
     @Nested
     class InstantValueSpecTest extends AbstractTemporalSpecTestTemplate<Instant> {
         @Override
-        protected TemporalSpec<Instant> spec() {
+        protected InstantSpec spec() {
             return temporal().instant();
         }
 
@@ -48,6 +57,15 @@ class TemporalSpecTest {
         Pair<Instant, Instant> getRangeFromNow() {
             final Instant now = Instant.now();
             return Pair.of(now, now.plusNanos(6000));
+        }
+
+        @Test
+        void truncatedTo() {
+            final Instant result = spec().truncatedTo(ChronoUnit.HOURS).get();
+            final ZonedDateTime zdt = result.atZone(ZoneOffset.UTC);
+
+            assertThat(zdt.getMinute()).isZero();
+            assertThat(zdt.getSecond()).isZero();
         }
     }
 
@@ -68,7 +86,7 @@ class TemporalSpecTest {
     @Nested
     class LocalDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<LocalDateTime> {
         @Override
-        protected TemporalSpec<LocalDateTime> spec() {
+        protected LocalDateTimeSpec spec() {
             return temporal().localDateTime();
         }
 
@@ -77,12 +95,20 @@ class TemporalSpecTest {
             final LocalDateTime now = LocalDateTime.now();
             return Pair.of(now, now.plusDays(400));
         }
+
+        @Test
+        void truncatedTo() {
+            final LocalDateTime result = spec().truncatedTo(ChronoUnit.HOURS).get();
+
+            assertThat(result.getMinute()).isZero();
+            assertThat(result.getSecond()).isZero();
+        }
     }
 
     @Nested
     class LocalTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<LocalTime> {
         @Override
-        protected TemporalSpec<LocalTime> spec() {
+        protected LocalTimeSpec spec() {
             return temporal().localTime();
         }
 
@@ -91,12 +117,20 @@ class TemporalSpecTest {
             final LocalTime now = LocalTime.now();
             return Pair.of(now, LocalTime.MAX);
         }
+
+        @Test
+        void truncatedTo() {
+            final LocalTime result = spec().truncatedTo(ChronoUnit.HOURS).get();
+
+            assertThat(result.getMinute()).isZero();
+            assertThat(result.getSecond()).isZero();
+        }
     }
 
     @Nested
     class OffsetDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<OffsetDateTime> {
         @Override
-        protected TemporalSpec<OffsetDateTime> spec() {
+        protected OffsetDateTimeSpec spec() {
             return temporal().offsetDateTime();
         }
 
@@ -105,12 +139,20 @@ class TemporalSpecTest {
             final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
             return Pair.of(now, now.plusDays(400));
         }
+
+        @Test
+        void truncatedTo() {
+            final OffsetDateTime result = spec().truncatedTo(ChronoUnit.HOURS).get();
+
+            assertThat(result.getMinute()).isZero();
+            assertThat(result.getSecond()).isZero();
+        }
     }
 
     @Nested
     class OffsetTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<OffsetTime> {
         @Override
-        protected TemporalSpec<OffsetTime> spec() {
+        protected OffsetTimeSpec spec() {
             return temporal().offsetTime();
         }
 
@@ -118,6 +160,14 @@ class TemporalSpecTest {
         Pair<OffsetTime, OffsetTime> getRangeFromNow() {
             final OffsetTime now = OffsetTime.now(ZoneOffset.UTC);
             return Pair.of(now, OffsetTime.MAX);
+        }
+
+        @Test
+        void truncatedTo() {
+            final OffsetTime result = spec().truncatedTo(ChronoUnit.HOURS).get();
+
+            assertThat(result.getMinute()).isZero();
+            assertThat(result.getSecond()).isZero();
         }
     }
 
@@ -152,7 +202,7 @@ class TemporalSpecTest {
     @Nested
     class ZonedDateTimeValueSpecTest extends AbstractTemporalSpecTestTemplate<ZonedDateTime> {
         @Override
-        protected TemporalSpec<ZonedDateTime> spec() {
+        protected ZonedDateTimeSpec spec() {
             return temporal().zonedDateTime();
         }
 
@@ -160,6 +210,14 @@ class TemporalSpecTest {
         Pair<ZonedDateTime, ZonedDateTime> getRangeFromNow() {
             final ZonedDateTime now = ZonedDateTime.now();
             return Pair.of(now, now.plusDays(400));
+        }
+
+        @Test
+        void truncatedTo() {
+            final ZonedDateTime result = spec().truncatedTo(ChronoUnit.HOURS).get();
+
+            assertThat(result.getMinute()).isZero();
+            assertThat(result.getSecond()).isZero();
         }
     }
 }


### PR DESCRIPTION
#### Examples

```java
record Venue(LocalTime openingTime) {}

Venue venue = Instancio.of(Venue.class)
    .generate(field(Venue::openingTime), gen -> gen.temporal().localTime().truncatedTo(ChronoUnit.HOURS))
    .create();

// Sample output:
// Venue[openingTime=18:00]
```

Using `Gen`:

```java
List<Instant> list = Gen.temporal().instant()
    .truncatedTo(ChronoUnit.HOURS)
    .list(3);

// Sample output:
// 1990-06-10T16:00:00Z
// 2031-02-10T10:00:00Z
// 2037-12-12T06:00:00Z
```
