### PR TITLE
Bug fix: propagate Map/Collection generator errors conditionally (#900)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/ErrorHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ErrorHandler.java
@@ -22,6 +22,7 @@ import org.instancio.internal.util.Format;
 import org.instancio.internal.util.Sonar;
 import org.instancio.internal.util.SystemProperties;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 @SuppressWarnings(Sonar.CATCH_EXCEPTION_INSTEAD_OF_THROWABLE)
-final class ErrorHandler {
+public final class ErrorHandler {
     private static final Logger LOG = LoggerFactory.getLogger(ErrorHandler.class);
 
     private static final String SUPPRESSION_REASON = String.format("" +
@@ -66,7 +67,7 @@ final class ErrorHandler {
         } catch (AssertionError | InstancioTerminatingException ex) {
             throw ex;
         } catch (Throwable ex) { //NOPMD
-            if (isShouldFailOnError()) {
+            if (shouldFailOnError()) {
                 throw Fail.withInternalError(ex);
             }
             logSuppressed(ex);
@@ -74,7 +75,11 @@ final class ErrorHandler {
         return Optional.empty();
     }
 
-    private boolean isShouldFailOnError() {
+    public static boolean shouldFailOnError(final Settings settings) {
+        return settings.get(Keys.FAIL_ON_ERROR) || SystemProperties.isFailOnErrorEnabled();
+    }
+
+    private boolean shouldFailOnError() {
         return isFailOnErrorSettingEnabled || SystemProperties.isFailOnErrorEnabled();
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/CollectionGenerator.java
@@ -22,9 +22,11 @@ import org.instancio.generator.Hints;
 import org.instancio.generator.hints.CollectionHint;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.internal.ApiValidator;
+import org.instancio.internal.ErrorHandler;
 import org.instancio.internal.generator.AbstractGenerator;
 import org.instancio.internal.generator.InternalGeneratorHint;
 import org.instancio.internal.util.CollectionUtils;
+import org.instancio.internal.util.ExceptionUtils;
 import org.instancio.internal.util.Fail;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.internal.util.Sonar;
@@ -127,7 +129,13 @@ public class CollectionGenerator<T> extends AbstractGenerator<Collection<T>> imp
         try {
             return (Collection<T>) collectionType.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
-            throw Fail.withFataInternalError("Error creating instance of: %s", collectionType, ex);
+            final String msg = String.format("Error creating instance of: %s", collectionType);
+
+            if (ErrorHandler.shouldFailOnError(getContext().getSettings())) {
+                throw Fail.withFataInternalError(msg, ex);
+            }
+            ExceptionUtils.logException(msg, ex);
+            return null; //NOPMD
         }
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/MapGenerator.java
@@ -22,8 +22,10 @@ import org.instancio.generator.Hints;
 import org.instancio.generator.hints.MapHint;
 import org.instancio.generator.specs.MapGeneratorSpec;
 import org.instancio.internal.ApiValidator;
+import org.instancio.internal.ErrorHandler;
 import org.instancio.internal.generator.AbstractGenerator;
 import org.instancio.internal.generator.InternalGeneratorHint;
+import org.instancio.internal.util.ExceptionUtils;
 import org.instancio.internal.util.Fail;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.internal.util.Sonar;
@@ -138,7 +140,13 @@ public class MapGenerator<K, V> extends AbstractGenerator<Map<K, V>> implements 
         try {
             return (Map<K, V>) mapType.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
-            throw Fail.withFataInternalError("Error creating instance of: %s", mapType, ex);
+            final String msg = String.format("Error creating instance of: %s", mapType);
+
+            if (ErrorHandler.shouldFailOnError(getContext().getSettings())) {
+                throw Fail.withFataInternalError(msg, ex);
+            }
+            ExceptionUtils.logException(msg, ex);
+            return null; //NOPMD
         }
     }
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/util/CollectionGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/util/CollectionGeneratorTest.java
@@ -95,7 +95,16 @@ class CollectionGeneratorTest {
     }
 
     @Test
-    void shouldFailOnInstantiationError() {
+    void shouldNotFailOnInstantiationErrorByDefault() {
+        final CollectionGenerator<?> generator = generator().subtype(List.class);
+
+        assertThat(generator.generate(random)).isNull();
+    }
+
+    @Test
+    void shouldFailOnInstantiationErrorWhenFailOnErrorIsEnabled() {
+        settings.set(Keys.FAIL_ON_ERROR, true);
+
         final CollectionGenerator<?> generator = generator().subtype(List.class);
 
         assertThatThrownBy(() -> generator.generate(random))

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/util/MapGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/util/MapGeneratorTest.java
@@ -96,7 +96,16 @@ class MapGeneratorTest {
     }
 
     @Test
-    void shouldFailOnInstantiationError() {
+    void shouldNotFailOnInstantiationErrorByDefault() {
+        final MapGenerator<?, ?> generator = generator().subtype(Map.class);
+
+        assertThat(generator.generate(random)).isNull();
+    }
+
+    @Test
+    void shouldFailOnInstantiationErrorWhenFailOnErrorIsEnabled() {
+        settings.set(Keys.FAIL_ON_ERROR, true);
+
         final MapGenerator<?, ?> generator = generator().subtype(Map.class);
 
         assertThatThrownBy(() -> generator.generate(random))


### PR DESCRIPTION
`4.1.0` introduced a change where the generator propagates an error if it fails to instantiate a map or collection (instead of returning null, which was the original behaviour). This causes a regression for some users This commit modifies the behaviour to propagates the error only if `Keys.FAIL_ON_ERROR` is enabled.

Resolves #900