### PR TITLE
Support for `ElementType.TYPE_USE` bean validation annotations (#911)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/util/CollectionUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/CollectionUtils.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.util;
 
 import org.instancio.Random;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -80,6 +81,17 @@ public final class CollectionUtils {
         final List<T> result = new ArrayList<>(list);
         Collections.addAll(result, values);
         return Collections.unmodifiableList(result);
+    }
+
+    // same as List.indexOf() but using '==' instead of equals()
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    public static int identityIndexOf(final Object obj, @NotNull final List<?> list) {
+        for (int i = 0; i < list.size(); i++) {
+            if (list.get(i) == obj) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     public static <T> void shuffle(final Collection<T> collection, final Random random) {

--- a/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CollectionBV.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CollectionBV.java
@@ -15,8 +15,9 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -26,7 +27,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
-public class CollectionSizeBV {
+public class CollectionBV {
 
     @Data
     public static class WithMinSize {
@@ -68,5 +69,12 @@ public class CollectionSizeBV {
         @NotNull
         @Size(min = 5, max = 5)
         private Queue<String> value;
+    }
+
+    @Data
+    public static class TypeUse {
+        @NotNull
+        @Size(min = 3, max = 3)
+        private Collection<@NotNull @Digits(integer = 7, fraction = 5) CharSequence> value;
     }
 }

--- a/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/MapBV.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/main/java/org/instancio/test/pojo/beanvalidation/MapBV.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
@@ -27,7 +28,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 
-public class MapSizeBV {
+public class MapBV {
 
     @Data
     public static class WithMinSize {
@@ -69,5 +70,13 @@ public class MapSizeBV {
         @NotNull
         @Size(min = 5, max = 5)
         private Map<Long, Double> value;
+    }
+
+    @Data
+    public static class TypeUse {
+        @NotNull
+        private Map<
+                @NotNull @Digits(integer = 7, fraction = 5) CharSequence,
+                @NotNull @Digits(integer = 3, fraction = 2) CharSequence> value;
     }
 }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
@@ -20,60 +20,67 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.test.pojo.beanvalidation.MapSizeBV;
+import org.instancio.test.pojo.beanvalidation.CollectionBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
-class MapSizeBVTest {
+class CollectionBVTest {
 
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
-            .set(Keys.STRING_ALLOW_EMPTY, false)
-            .set(Keys.LONG_NULLABLE, false)
-            .set(Keys.CHARACTER_NULLABLE, false)
-            .set(Keys.DOUBLE_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
-        final MapSizeBV.WithMinSize result = Instancio.create(MapSizeBV.WithMinSize.class);
+        final CollectionBV.WithMinSize result = Instancio.create(CollectionBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSizeZeo() {
-        final MapSizeBV.WithMinSizeZero result = Instancio.create(MapSizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
+        final CollectionBV.WithMinSizeZero result = Instancio.create(CollectionBV.WithMinSizeZero.class);
+        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
     }
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMaxSize() {
-        final MapSizeBV.WithMaxSize result = Instancio.create(MapSizeBV.WithMaxSize.class);
+        final CollectionBV.WithMaxSize result = Instancio.create(CollectionBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMaxSizeZero() {
-        final MapSizeBV.WithMaxSizeZero result = Instancio.create(MapSizeBV.WithMaxSizeZero.class);
+        final CollectionBV.WithMaxSizeZero result = Instancio.create(CollectionBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinMaxSize() {
-        final MapSizeBV.WithMinMaxSize result = Instancio.create(MapSizeBV.WithMinMaxSize.class);
+        final CollectionBV.WithMinMaxSize result = Instancio.create(CollectionBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @Test
+    @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinMaxEqual() {
-        final MapSizeBV.WithMinMaxEqual result = Instancio.create(MapSizeBV.WithMinMaxEqual.class);
+        final CollectionBV.WithMinMaxEqual result = Instancio.create(CollectionBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);
+    }
+
+    @RepeatedTest(SAMPLE_SIZE_D)
+    void typeUse() {
+        final CollectionBV.TypeUse result = Instancio.create(CollectionBV.TypeUse.class);
+
+        assertThat(result.getValue())
+                .hasSize(3)
+                .allSatisfy(v -> assertThat(v).matches("\\d{7}\\.\\d{5}"));
     }
 }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
@@ -20,57 +20,72 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.test.pojo.beanvalidation.CollectionSizeBV;
+import org.instancio.test.pojo.beanvalidation.MapBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
-class CollectionSizeBVTest {
+class MapBVTest {
 
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
+            .set(Keys.STRING_ALLOW_EMPTY, false)
+            .set(Keys.LONG_NULLABLE, false)
+            .set(Keys.CHARACTER_NULLABLE, false)
+            .set(Keys.DOUBLE_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
-        final CollectionSizeBV.WithMinSize result = Instancio.create(CollectionSizeBV.WithMinSize.class);
+        final MapBV.WithMinSize result = Instancio.create(MapBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSizeZeo() {
-        final CollectionSizeBV.WithMinSizeZero result = Instancio.create(CollectionSizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
+        final MapBV.WithMinSizeZero result = Instancio.create(MapBV.WithMinSizeZero.class);
+        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMaxSize() {
-        final CollectionSizeBV.WithMaxSize result = Instancio.create(CollectionSizeBV.WithMaxSize.class);
+        final MapBV.WithMaxSize result = Instancio.create(MapBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMaxSizeZero() {
-        final CollectionSizeBV.WithMaxSizeZero result = Instancio.create(CollectionSizeBV.WithMaxSizeZero.class);
+        final MapBV.WithMaxSizeZero result = Instancio.create(MapBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinMaxSize() {
-        final CollectionSizeBV.WithMinMaxSize result = Instancio.create(CollectionSizeBV.WithMinMaxSize.class);
+        final MapBV.WithMinMaxSize result = Instancio.create(MapBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinMaxEqual() {
-        final CollectionSizeBV.WithMinMaxEqual result = Instancio.create(CollectionSizeBV.WithMinMaxEqual.class);
+        final MapBV.WithMinMaxEqual result = Instancio.create(MapBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);
+    }
+
+    @RepeatedTest(SAMPLE_SIZE_D)
+    void typeUse() {
+        final MapBV.TypeUse result = Instancio.create(MapBV.TypeUse.class);
+
+        assertThat(result.getValue()).allSatisfy((k, v) -> {
+            assertThat(k).matches("\\d{7}\\.\\d{5}");
+            assertThat(v).matches("\\d{3}\\.\\d{2}");
+        });
     }
 }

--- a/instancio-tests/bean-validation-javax-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CollectionBV.java
+++ b/instancio-tests/bean-validation-javax-tests/src/main/java/org/instancio/test/pojo/beanvalidation/CollectionBV.java
@@ -15,59 +15,66 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import lombok.Data;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.UUID;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
 
-public class MapSizeBV {
+public class CollectionBV {
 
     @Data
     public static class WithMinSize {
         @NotNull
         @Size(min = 8)
-        private Map<String, Long> value;
+        private Collection<String> value;
     }
 
     @Data
     public static class WithMinSizeZero {
         @NotNull
         @Size
-        private SortedMap<Integer, String> value;
+        private List<String> value;
     }
 
     @Data
     public static class WithMaxSize {
         @NotNull
         @Size(max = 1)
-        private HashMap<UUID, BigDecimal> value;
+        private Set<String> value;
     }
 
     @Data
     public static class WithMaxSizeZero {
         @NotNull
         @Size(max = 0)
-        private NavigableMap<Integer, String> value;
+        private ArrayList<String> value;
     }
 
     @Data
     public static class WithMinMaxSize {
         @NotNull
         @Size(min = 19, max = 20)
-        private TreeMap<String, Character> value;
+        private Deque<String> value;
     }
 
     @Data
     public static class WithMinMaxEqual {
         @NotNull
         @Size(min = 5, max = 5)
-        private Map<Long, Double> value;
+        private Queue<String> value;
+    }
+
+    @Data
+    public static class TypeUse {
+        @NotNull
+        @Size(min = 3, max = 3)
+        private Collection<@NotNull @Digits(integer = 7, fraction = 5) CharSequence> value;
     }
 }

--- a/instancio-tests/bean-validation-javax-tests/src/main/java/org/instancio/test/pojo/beanvalidation/MapBV.java
+++ b/instancio-tests/bean-validation-javax-tests/src/main/java/org/instancio/test/pojo/beanvalidation/MapBV.java
@@ -15,58 +15,68 @@
  */
 package org.instancio.test.pojo.beanvalidation;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Data;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
 
-public class CollectionSizeBV {
+public class MapBV {
 
     @Data
     public static class WithMinSize {
         @NotNull
         @Size(min = 8)
-        private Collection<String> value;
+        private Map<String, Long> value;
     }
 
     @Data
     public static class WithMinSizeZero {
         @NotNull
         @Size
-        private List<String> value;
+        private SortedMap<Integer, String> value;
     }
 
     @Data
     public static class WithMaxSize {
         @NotNull
         @Size(max = 1)
-        private Set<String> value;
+        private HashMap<UUID, BigDecimal> value;
     }
 
     @Data
     public static class WithMaxSizeZero {
         @NotNull
         @Size(max = 0)
-        private ArrayList<String> value;
+        private NavigableMap<Integer, String> value;
     }
 
     @Data
     public static class WithMinMaxSize {
         @NotNull
         @Size(min = 19, max = 20)
-        private Deque<String> value;
+        private TreeMap<String, Character> value;
     }
 
     @Data
     public static class WithMinMaxEqual {
         @NotNull
         @Size(min = 5, max = 5)
-        private Queue<String> value;
+        private Map<Long, Double> value;
+    }
+
+    @Data
+    public static class TypeUse {
+        @NotNull
+        private Map<
+                @NotNull @Digits(integer = 7, fraction = 5) CharSequence,
+                @NotNull @Digits(integer = 3, fraction = 2) CharSequence> value;
     }
 }

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
@@ -20,61 +20,67 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.test.pojo.beanvalidation.MapSizeBV;
+import org.instancio.test.pojo.beanvalidation.CollectionBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
-class MapSizeBVTest {
+class CollectionBVTest {
 
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
-            .set(Keys.STRING_ALLOW_EMPTY, false)
-            .set(Keys.LONG_NULLABLE, false)
-            .set(Keys.CHARACTER_NULLABLE, false)
-            .set(Keys.DOUBLE_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSize() {
-        final MapSizeBV.WithMinSize result = Instancio.create(MapSizeBV.WithMinSize.class);
+        final CollectionBV.WithMinSize result = Instancio.create(CollectionBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinSizeZeo() {
-        final MapSizeBV.WithMinSizeZero result = Instancio.create(MapSizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
+        final CollectionBV.WithMinSizeZero result = Instancio.create(CollectionBV.WithMinSizeZero.class);
+        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSize() {
-        final MapSizeBV.WithMaxSize result = Instancio.create(MapSizeBV.WithMaxSize.class);
+        final CollectionBV.WithMaxSize result = Instancio.create(CollectionBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMaxSizeZero() {
-        final MapSizeBV.WithMaxSizeZero result = Instancio.create(MapSizeBV.WithMaxSizeZero.class);
+        final CollectionBV.WithMaxSizeZero result = Instancio.create(CollectionBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxSize() {
-        final MapSizeBV.WithMinMaxSize result = Instancio.create(MapSizeBV.WithMinMaxSize.class);
+        final CollectionBV.WithMinMaxSize result = Instancio.create(CollectionBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
-    @RepeatedTest(SAMPLE_SIZE_DD)
+    @Test
     void withMinMaxEqual() {
-        final MapSizeBV.WithMinMaxEqual result = Instancio.create(MapSizeBV.WithMinMaxEqual.class);
+        final CollectionBV.WithMinMaxEqual result = Instancio.create(CollectionBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);
+    }
+
+    @RepeatedTest(SAMPLE_SIZE_D)
+    void typeUse() {
+        final CollectionBV.TypeUse result = Instancio.create(CollectionBV.TypeUse.class);
+
+        assertThat(result.getValue())
+                .hasSize(3)
+                .allSatisfy(v -> assertThat(v).matches("\\d{7}\\.\\d{5}"));
     }
 }

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
@@ -20,56 +20,72 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.test.pojo.beanvalidation.CollectionSizeBV;
+import org.instancio.test.pojo.beanvalidation.MapBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_D;
 
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
-class CollectionSizeBVTest {
+class MapBVTest {
 
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
+            .set(Keys.STRING_ALLOW_EMPTY, false)
+            .set(Keys.LONG_NULLABLE, false)
+            .set(Keys.CHARACTER_NULLABLE, false)
+            .set(Keys.DOUBLE_NULLABLE, false)
             .set(Keys.STRING_MAX_LENGTH, 10);
 
     @Test
     void withMinSize() {
-        final CollectionSizeBV.WithMinSize result = Instancio.create(CollectionSizeBV.WithMinSize.class);
+        final MapBV.WithMinSize result = Instancio.create(MapBV.WithMinSize.class);
         assertThat(result.getValue()).hasSizeGreaterThanOrEqualTo(8);
     }
 
     @Test
     void withMinSizeZeo() {
-        final CollectionSizeBV.WithMinSizeZero result = Instancio.create(CollectionSizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
+        final MapBV.WithMinSizeZero result = Instancio.create(MapBV.WithMinSizeZero.class);
+        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
     }
 
     @Test
     void withMaxSize() {
-        final CollectionSizeBV.WithMaxSize result = Instancio.create(CollectionSizeBV.WithMaxSize.class);
+        final MapBV.WithMaxSize result = Instancio.create(MapBV.WithMaxSize.class);
         assertThat(result.getValue()).hasSizeLessThanOrEqualTo(1);
     }
 
     @Test
     void withMaxSizeZero() {
-        final CollectionSizeBV.WithMaxSizeZero result = Instancio.create(CollectionSizeBV.WithMaxSizeZero.class);
+        final MapBV.WithMaxSizeZero result = Instancio.create(MapBV.WithMaxSizeZero.class);
         assertThat(result.getValue()).isEmpty();
     }
 
     @Test
     void withMinMaxSize() {
-        final CollectionSizeBV.WithMinMaxSize result = Instancio.create(CollectionSizeBV.WithMinMaxSize.class);
+        final MapBV.WithMinMaxSize result = Instancio.create(MapBV.WithMinMaxSize.class);
         assertThat(result.getValue()).hasSizeBetween(19, 20);
     }
 
     @Test
     void withMinMaxEqual() {
-        final CollectionSizeBV.WithMinMaxEqual result = Instancio.create(CollectionSizeBV.WithMinMaxEqual.class);
+        final MapBV.WithMinMaxEqual result = Instancio.create(MapBV.WithMinMaxEqual.class);
         assertThat(result.getValue()).hasSize(5);
+    }
+
+    @RepeatedTest(SAMPLE_SIZE_D)
+    void typeUse() {
+        final MapBV.TypeUse result = Instancio.create(MapBV.TypeUse.class);
+
+        assertThat(result.getValue()).allSatisfy((k, v) -> {
+            assertThat(k).matches("\\d{7}\\.\\d{5}");
+            assertThat(v).matches("\\d{3}\\.\\d{2}");
+        });
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/CollectionUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/CollectionUtilsTest.java
@@ -18,6 +18,7 @@ package org.instancio.internal.util;
 import org.instancio.Instancio;
 import org.instancio.Random;
 import org.instancio.support.DefaultRandom;
+import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.pojo.person.Person;
 import org.instancio.test.support.tags.NonDeterministicTag;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -90,6 +92,24 @@ class CollectionUtilsTest {
         assertThat(CollectionUtils.combine(Arrays.asList(1, 2), 3)).containsExactly(1, 2, 3);
         assertThat(CollectionUtils.combine(Arrays.asList(1, 2))).containsExactly(1, 2);
         assertThat(CollectionUtils.combine(Collections.emptyList())).isEmpty();
+    }
+
+    @Test
+    void identityIndexOf() {
+        final StringHolder a = new StringHolder("x");
+        final StringHolder b = new StringHolder("x");
+        final StringHolder c = new StringHolder("x");
+        final StringHolder x = new StringHolder("x");
+        final List<StringHolder> list = Arrays.asList(c, a, null, b);
+
+        // precondition: all pass equals()
+        assertThat(a).isEqualTo(b).isEqualTo(c).isEqualTo(x);
+
+        assertThat(CollectionUtils.identityIndexOf(c, list)).isZero();
+        assertThat(CollectionUtils.identityIndexOf(a, list)).isOne();
+        assertThat(CollectionUtils.identityIndexOf(null, list)).isEqualTo(2);
+        assertThat(CollectionUtils.identityIndexOf(b, list)).isEqualTo(3);
+        assertThat(CollectionUtils.identityIndexOf(x, list)).isEqualTo(-1);
     }
 
     @Test


### PR DESCRIPTION
This PR adds basic support for `TYPE_USE` annotations.

#### Example

```java
class Pojo {
    @Size(min = 3, max = 3)
    private Map<@Email String, @Negative Integer> map;
    // ...
}

Pojo pojo = Instancio.of(Pojo.class)
    .withSettings(Settings.create().set(Keys.BEAN_VALIDATION_ENABLED, true))
    .create();

// Sample output:
// Pojo(map={vo4ira@zv5.com=-5809899, arhis@ktt2ricfw.net=-74162228, dpy99t@hdezns.org=-186211504})
```

#### Limitations

Nested annotations are not supported. In the following example, the `@Negative` annotation will be ignored:

``` java
Map<@Email String, List<@Negative Integer>> map;
```

