### PR TITLE
Add convenience method for overriding a setting key.

### DIFF
--- a/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
+++ b/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
@@ -18,6 +18,7 @@ package org.instancio;
 import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorSpec;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
 import java.util.List;
@@ -189,6 +190,14 @@ public interface CartesianProductApi<T> extends
      */
     @Override
     CartesianProductApi<T> withMaxDepth(int maxDepth);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.4.0
+     */
+    @Override
+    <V> CartesianProductApi<T> withSetting(SettingKey<V> key, V value);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -18,6 +18,7 @@ package org.instancio;
 import org.instancio.documentation.ExperimentalApi;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorSpec;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
 import java.util.function.Supplier;
@@ -200,6 +201,14 @@ public interface InstancioApi<T> extends
      */
     @Override
     InstancioApi<T> withMaxDepth(int maxDepth);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.4.0
+     */
+    @Override
+    <V> InstancioApi<T> withSetting(SettingKey<V> key, V value);
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/InstancioOperations.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioOperations.java
@@ -21,6 +21,7 @@ import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generators.Generators;
 import org.instancio.settings.Keys;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
 import java.util.ArrayList;
@@ -445,6 +446,19 @@ interface InstancioOperations<T> {
     InstancioOperations<T> withMaxDepth(int maxDepth);
 
     /**
+     * Override setting for the given {@code key} with the specified {@code value}.
+     *
+     * @param key   the setting key to override
+     * @param value the setting value
+     * @param <V>   the setting value type
+     * @return API builder reference
+     * @see Keys
+     * @see #withSettings(Settings)
+     * @since 4.4.0
+     */
+    <V> InstancioOperations<T> withSetting(SettingKey<V> key, V value);
+
+    /**
      * Override default {@link Settings} for generating values.
      * The {@link Settings} class supports various parameters, such as
      * collection sizes, string lengths, numeric ranges, and so on.
@@ -453,6 +467,7 @@ interface InstancioOperations<T> {
      * @param settings to use
      * @return API builder reference
      * @see Keys
+     * @see #withSetting(SettingKey, Object)
      * @since 4.0.0
      */
     InstancioOperations<T> withSettings(Settings settings);

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -27,6 +27,7 @@ import org.instancio.TypeTokenSupplier;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.internal.context.ModelContext;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
 import java.lang.reflect.Type;
@@ -146,6 +147,12 @@ public class ApiImpl<T> implements InstancioApi<T> {
     @Override
     public InstancioApi<T> withNullable(final TargetSelector selector) {
         modelContextBuilder.withNullable(selector);
+        return this;
+    }
+
+    @Override
+    public <V> InstancioApi<T> withSetting(final SettingKey<V> key, final V value) {
+        modelContextBuilder.withSetting(key, value);
         return this;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
@@ -28,6 +28,7 @@ import org.instancio.generator.GeneratorSpec;
 import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.reflect.ParameterizedTypeImpl;
 import org.instancio.internal.util.CartesianList;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
 import java.lang.reflect.Type;
@@ -153,6 +154,12 @@ public class CartesianProductApiImpl<T> implements CartesianProductApi<T> {
     @Override
     public CartesianProductApi<T> withNullable(final TargetSelector selector) {
         modelContextBuilder.withNullable(selector);
+        return this;
+    }
+
+    @Override
+    public <V> CartesianProductApi<T> withSetting(final SettingKey<V> key, final V value) {
+        modelContextBuilder.withSetting(key, value);
         return this;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -43,6 +43,7 @@ import org.instancio.internal.util.Verify;
 import org.instancio.settings.AssignmentType;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Mode;
+import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 import org.instancio.spi.InstancioServiceProvider;
 import org.instancio.support.Global;
@@ -395,6 +396,16 @@ public final class ModelContext<T> {
                             .add(processedAssignment);
                 }
             }
+        }
+
+        public <V> Builder<T> withSetting(final SettingKey<V> key, final V value) {
+            if (settings == null) {
+                settings = Settings.create();
+            } else if (settings.isLocked()) {
+                settings = Settings.from(settings);
+            }
+            settings.set(key, value);
+            return this;
         }
 
         public Builder<T> withSettings(final Settings arg) {

--- a/instancio-core/src/main/java/org/instancio/internal/settings/InternalSettings.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/InternalSettings.java
@@ -170,6 +170,11 @@ public final class InternalSettings implements Settings {
         return this;
     }
 
+    @Override
+    public boolean isLocked() {
+        return isLockedForModifications;
+    }
+
     private void checkLockedForModifications() {
         if (isLockedForModifications) {
             throw new UnsupportedOperationException("This instance of Settings has been locked and is read-only");

--- a/instancio-core/src/main/java/org/instancio/settings/Settings.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Settings.java
@@ -162,4 +162,13 @@ public interface Settings {
      */
     Settings lock();
 
+    /**
+     * Checks if this instance is locked for modifications.
+     *
+     * @return {@code true} if this instance is locked for modifications,
+     * {@code false} otherwise
+     * @see #lock()
+     * @since 4.4.0
+     */
+    boolean isLocked();
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignmenttype/OnSetMethodErrorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignmenttype/OnSetMethodErrorTest.java
@@ -47,8 +47,7 @@ class OnSetMethodErrorTest {
     @Test
     void assignViaField() {
         final SetterErrorPojo result = Instancio.of(SetterErrorPojo.class)
-                .withSettings(Settings.create()
-                        .set(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.ASSIGN_FIELD))
+                .withSetting(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.ASSIGN_FIELD)
                 .create();
 
         assertThat(result.getValue()).isNotZero();
@@ -57,8 +56,7 @@ class OnSetMethodErrorTest {
     @Test
     void ignoreError() {
         final SetterErrorPojo result = Instancio.of(SetterErrorPojo.class)
-                .withSettings(Settings.create()
-                        .set(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.IGNORE))
+                .withSetting(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.IGNORE)
                 .create();
 
         assertThat(result.getValue()).isZero();
@@ -68,8 +66,7 @@ class OnSetMethodErrorTest {
     void failOnError() {
         final InstancioApi<SetterErrorPojo> api = Instancio.of(SetterErrorPojo.class)
                 .set(allInts(), 123)
-                .withSettings(Settings.create()
-                        .set(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.FAIL));
+                .withSetting(Keys.ON_SET_METHOD_ERROR, OnSetMethodError.FAIL);
 
         assertThatThrownBy(api::create)
                 .isExactlyInstanceOf(InstancioApiException.class)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignmenttype/OnSetMethodNotFoundTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assignmenttype/OnSetMethodNotFoundTest.java
@@ -80,8 +80,7 @@ class OnSetMethodNotFoundTest {
     @Test
     void assignViaField() {
         final WithoutSetter result = Instancio.of(WithoutSetter.class)
-                .withSettings(Settings.create()
-                        .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.ASSIGN_FIELD))
+                .withSetting(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.ASSIGN_FIELD)
                 .create();
 
         assertThat(result.value).isNotZero();
@@ -100,8 +99,7 @@ class OnSetMethodNotFoundTest {
     @Test
     void failOnError() {
         final InstancioApi<WithoutSetter> api = Instancio.of(WithoutSetter.class)
-                .withSettings(Settings.create()
-                        .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL));
+                .withSetting(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL);
 
         assertThatThrownBy(api::create)
                 .isExactlyInstanceOf(InstancioApiException.class)
@@ -115,9 +113,8 @@ class OnSetMethodNotFoundTest {
     @Test
     void onSetMethodNotFoundWithFinalField() {
         final FinalFieldWithoutSetter result = Instancio.of(FinalFieldWithoutSetter.class)
-                .withSettings(Settings.create()
-                        .set(Keys.FAIL_ON_ERROR, true)
-                        .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL))
+                .withSetting(Keys.FAIL_ON_ERROR, true)
+                .withSetting(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.FAIL)
                 .create();
 
         assertThat(result.list).isEmpty();

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSettingsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSettingsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.cartesianproduct;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringAndPrimitiveFields;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.CARTESIAN_PRODUCT, Feature.SETTINGS})
+@ExtendWith(InstancioExtension.class)
+class CartesianProductSettingsTest {
+
+    private static final int INT_ONE = 10;
+    private static final int INT_TWO = 20;
+
+    @Test
+    void withSetting() {
+        List<StringAndPrimitiveFields> results = Instancio.ofCartesianProduct(StringAndPrimitiveFields.class)
+                .with(field(StringAndPrimitiveFields::getIntOne), INT_ONE)
+                .with(field(StringAndPrimitiveFields::getIntTwo), INT_TWO)
+                .withSetting(Keys.STRING_MAX_LENGTH, 1)
+                .list();
+
+        assertResults(results);
+    }
+
+    @Test
+    void withSettings() {
+        List<StringAndPrimitiveFields> results = Instancio.ofCartesianProduct(StringAndPrimitiveFields.class)
+                .with(field(StringAndPrimitiveFields::getIntOne), INT_ONE)
+                .with(field(StringAndPrimitiveFields::getIntTwo), INT_TWO)
+                .withSettings(Settings.create().set(Keys.STRING_MAX_LENGTH, 1))
+                .list();
+
+        assertResults(results);
+    }
+
+    private static void assertResults(final List<StringAndPrimitiveFields> results) {
+        assertThat(results)
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.getOne()).hasSize(1);
+                    assertThat(result.getTwo()).hasSize(1);
+                    assertThat(result.getIntOne()).isEqualTo(INT_ONE);
+                    assertThat(result.getIntTwo()).isEqualTo(INT_TWO);
+                });
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SetMethodSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SetMethodSelectorTest.java
@@ -148,12 +148,11 @@ class SetMethodSelectorTest {
         final SetMethodSelector<PropertyStylePojo, Boolean> hasGaz = PropertyStylePojo::hasGaz;
 
         final PropertyStylePojo expected = Instancio.of(PropertyStylePojo.class)
-                .withSettings(Settings.create()
-                        .set(Keys.SETTER_STYLE, SetterStyle.PROPERTY))
+                .withSetting(Keys.SETTER_STYLE, SetterStyle.PROPERTY)
                 .create();
 
         final PropertyStylePojo result = Instancio.of(PropertyStylePojo.class)
-                .withSettings(Settings.create().set(Keys.SETTER_STYLE, SetterStyle.PROPERTY))
+                .withSetting(Keys.SETTER_STYLE, SetterStyle.PROPERTY)
                 .set(foo, expected.foo())
                 .set(setter(bar), expected.bar())
                 .set(setter(isBaz), expected.isBaz())

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/WithSettingTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/WithSettingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.settings;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringAndPrimitiveFields;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.SETTINGS, Feature.WITH_SETTINGS_ANNOTATION})
+@ExtendWith(InstancioExtension.class)
+class WithSettingTest {
+
+    @WithSettings
+    private static final Settings settings = Settings.create()
+            .set(Keys.STRING_MIN_LENGTH, 9)
+            .set(Keys.STRING_MIN_LENGTH, 9);
+
+    @Test
+    void withSetting() {
+        final StringAndPrimitiveFields result = Instancio.of(StringAndPrimitiveFields.class)
+                .withSetting(Keys.STRING_MIN_LENGTH, 2)
+                .withSetting(Keys.STRING_MAX_LENGTH, 2)
+                .withSetting(Keys.INTEGER_MIN, -1)
+                .withSetting(Keys.INTEGER_MAX, -1)
+                .create();
+
+        assertThat(result.getOne()).hasSize(2);
+        assertThat(result.getTwo()).hasSize(2);
+        assertThatObject(result).hasAllFieldsOfTypeEqualTo(int.class, -1);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/ValueSpecWithGenerateAndSettingsSeedTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/ValueSpecWithGenerateAndSettingsSeedTest.java
@@ -19,7 +19,6 @@ import org.instancio.Gen;
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.settings.Keys;
-import org.instancio.settings.Settings;
 import org.instancio.test.support.pojo.misc.StringFields;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -43,7 +42,7 @@ class ValueSpecWithGenerateAndSettingsSeedTest {
     void withGenerate() {
         final StringFields stringFields = Instancio.of(StringFields.class)
                 .generate(allStrings(), Gen.string().alphaNumeric())
-                .withSettings(Settings.create().set(Keys.SEED, SEED))
+                .withSetting(Keys.SEED, SEED)
                 .create();
 
         results.add(stringFields.getOne());

--- a/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/SetterMethodResolverSpiTest.java
+++ b/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/SetterMethodResolverSpiTest.java
@@ -73,9 +73,7 @@ class SetterMethodResolverSpiTest {
         return Instancio.of(klass)
                 // These are used for verification; we don't want to generate values for these flags
                 .ignore(fields().matching("viaSetter.*"))
-                .withSettings(Settings.create()
-                        .set(Keys.ASSIGNMENT_TYPE, AssignmentType.METHOD)
-                        .lock())
+                .withSetting(Keys.ASSIGNMENT_TYPE, AssignmentType.METHOD)
                 .toModel();
     }
 
@@ -90,8 +88,7 @@ class SetterMethodResolverSpiTest {
     @Test
     void shouldNotUserPrivateSetterMethodWhenExcluded() {
         final PojoA result = Instancio.of(createModel(PojoA.class))
-                .withSettings(Settings.create()
-                        .set(Keys.SETTER_EXCLUDE_MODIFIER, MethodModifier.PRIVATE))
+                .withSetting(Keys.SETTER_EXCLUDE_MODIFIER, MethodModifier.PRIVATE)
                 .create();
 
         assertThat(result._values).isNull();
@@ -101,8 +98,7 @@ class SetterMethodResolverSpiTest {
     @Test
     void shouldFallbackToBuiltInMethodResolver() {
         final PojoB result = Instancio.of(createModel(PojoB.class))
-                .withSettings(Settings.create()
-                        .set(Keys.SETTER_STYLE, SetterStyle.WITH))
+                .withSetting(Keys.SETTER_STYLE, SetterStyle.WITH)
                 .create();
 
         assertThat(result.value).isPositive();


### PR DESCRIPTION
This allows the following usage:

```java
withSettings(Settings.create().set(Keys.SOME_KEY, someValue))
```

to be replaced with:

```java
withSetting(Keys.SOME_KEY, someValue)
```