### PR TITLE
Added JPMS module information

### DIFF
--- a/build-tools/src/main/resources/checkstyle.xml
+++ b/build-tools/src/main/resources/checkstyle.xml
@@ -88,4 +88,7 @@
         <property name="headerFile" value="build-tools/src/main/resources/LicenseHeader/apache-licence-java-header.txt"/>
         <property name="fileExtensions" value="java"/>
     </module>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
 </module>

--- a/instancio-core/instancio-library.marker
+++ b/instancio-core/instancio-library.marker
@@ -1,0 +1,1 @@
+The presence of this file activates the "instancio-library" Maven profile.

--- a/instancio-core/pom.xml
+++ b/instancio-core/pom.xml
@@ -113,18 +113,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Multi-Release>true</Multi-Release>
-                            <Automatic-Module-Name>org.instancio.core</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/instancio-core/src/main/java/module-info.java
+++ b/instancio-core/src/main/java/module-info.java
@@ -1,0 +1,42 @@
+module org.instancio.core {
+    requires org.slf4j;
+
+    requires static jakarta.persistence;
+    requires static jakarta.validation;
+    requires static java.persistence;
+    requires static java.validation;
+    requires static java.sql;
+    requires static java.xml;
+    requires static jdk.unsupported;
+    requires static org.jetbrains.annotations;
+    requires static org.hibernate.validator;
+
+    exports org.instancio;
+    exports org.instancio.documentation;
+    exports org.instancio.exception;
+    exports org.instancio.generator;
+    exports org.instancio.generator.hints;
+    exports org.instancio.generator.specs;
+    exports org.instancio.generator.specs.can;
+    exports org.instancio.generator.specs.pol;
+    exports org.instancio.generator.specs.usa;
+    exports org.instancio.generators;
+    exports org.instancio.generators.can;
+    exports org.instancio.generators.pol;
+    exports org.instancio.generators.usa;
+    exports org.instancio.settings;
+    exports org.instancio.spi;
+
+    exports org.instancio.internal to org.instancio.guava;
+    exports org.instancio.internal.generator to org.instancio.guava;
+    exports org.instancio.internal.generator.domain.internet to org.instancio.guava;
+    exports org.instancio.internal.generator.util to org.instancio.guava;
+    exports org.instancio.internal.spi to org.instancio.guava;
+    exports org.instancio.support to org.instancio.junit;
+    exports org.instancio.internal.util to org.instancio.guava, org.instancio.junit, org.instancio.quickcheck, org.instancio.test.contract;
+
+    uses org.instancio.spi.InstancioServiceProvider;
+
+    // only for other instancio modules
+    uses org.instancio.internal.spi.InternalServiceProvider;
+}

--- a/instancio-core/src/main/java/org/instancio/spi/InstancioServiceProvider.java
+++ b/instancio-core/src/main/java/org/instancio/spi/InstancioServiceProvider.java
@@ -45,10 +45,19 @@ import java.util.ServiceLoader;
  * these methods may contain initialisation logic.
  *
  * <p>This class uses the {@link ServiceLoader} mechanism. Therefore,
- * implementations must be registered by placing a file named
- * {@code org.instancio.spi.InstancioServiceProvider} under
- * {@code /META-INF/services}. The file must contain the fully-qualified name
- * of the implementing class.
+ * implementations must be registered explicitly.
+ * <ul>
+ *   <li>
+ *     for a module using the Java module system by adding
+ *     {@code provides org.instancio.spi.InstancioServiceProvider with fully.qualified.ImplementationName;}
+ *   </li>
+ *   <li>
+ *     otherwise in non-modular code or when read by non-modular code,
+ *     by placing a file named {@code org.instancio.spi.InstancioServiceProvider} under
+ *    {@code /META-INF/services}; The file must contain the fully-qualified name
+ *     of the implementing class.
+ *   </li>
+ * </ul>
  *
  * <p><b>Note:</b> only {@link InstancioServiceProvider} (and not the interfaces
  * defined within it) can be registered via the {@code ServiceLoader}.

--- a/instancio-guava/instancio-library.marker
+++ b/instancio-guava/instancio-library.marker
@@ -1,0 +1,1 @@
+The presence of this file activates the "instancio-library" Maven profile.

--- a/instancio-guava/pom.xml
+++ b/instancio-guava/pom.xml
@@ -30,17 +30,6 @@
                     </excludePackageNames>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.instancio.guava</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/instancio-guava/src/main/java/module-info.java
+++ b/instancio-guava/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+module org.instancio.guava {
+    requires transitive org.instancio.core;
+
+    requires com.google.common;
+
+    exports org.instancio.guava;
+    exports org.instancio.guava.generator.specs;
+
+    provides org.instancio.spi.InstancioServiceProvider with org.instancio.guava.internal.spi.GuavaProvider;
+    provides org.instancio.internal.spi.InternalServiceProvider with org.instancio.guava.internal.spi.GuavaInternalServiceProvider;
+}

--- a/instancio-junit/instancio-library.marker
+++ b/instancio-junit/instancio-library.marker
@@ -1,0 +1,1 @@
+The presence of this file activates the "instancio-library" Maven profile.

--- a/instancio-junit/pom.xml
+++ b/instancio-junit/pom.xml
@@ -50,17 +50,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.instancio.junit</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/instancio-junit/src/main/java/module-info.java
+++ b/instancio-junit/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+module org.instancio.junit {
+  requires transitive org.instancio.core;
+
+  requires org.junit.jupiter.api;
+  requires org.junit.jupiter.params;
+  requires org.slf4j;
+
+  exports org.instancio.junit;
+}

--- a/instancio-quickcheck/instancio-library.marker
+++ b/instancio-quickcheck/instancio-library.marker
@@ -1,0 +1,1 @@
+The presence of this file activates the "instancio-library" Maven profile.

--- a/instancio-quickcheck/pom.xml
+++ b/instancio-quickcheck/pom.xml
@@ -51,17 +51,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>org.instancio.quickcheck</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/instancio-quickcheck/src/main/java/module-info.java
+++ b/instancio-quickcheck/src/main/java/module-info.java
@@ -1,0 +1,13 @@
+module org.instancio.quickcheck {
+  requires transitive org.instancio.core;
+
+  requires org.junit.jupiter.api;
+  requires org.junit.jupiter.engine;
+  requires org.junit.platform.engine;
+  requires org.slf4j;
+
+  exports org.instancio.quickcheck.api;
+  exports org.instancio.quickcheck.api.artbitrary;
+
+  provides org.junit.platform.engine.TestEngine with org.instancio.quickcheck.internal.engine.InstancioQuickcheckTestEngine;
+}

--- a/instancio-tests/arch-tests/pom.xml
+++ b/instancio-tests/arch-tests/pom.xml
@@ -10,6 +10,23 @@
     <packaging>jar</packaging>
     <name>Instancio tests: Arch Tests</name>
 
+    <properties>
+        <maven.enforcer.require.java.version>[21,)</maven.enforcer.require.java.version>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.instancio</groupId>

--- a/instancio-tests/arch-tests/src/test/java/module-info.java
+++ b/instancio-tests/arch-tests/src/test/java/module-info.java
@@ -1,0 +1,8 @@
+open module org.instancio.test.contract {
+    requires org.assertj.core;
+    requires org.junit.jupiter;
+    requires com.tngtech.archunit;
+
+    requires org.instancio.core;
+    requires org.instancio.test.support;
+}

--- a/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/ApiPackageTest.java
+++ b/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/ApiPackageTest.java
@@ -19,6 +19,7 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.instancio.documentation.ExperimentalApi;
 import org.instancio.documentation.InternalApi;
+import org.instancio.test.contract.condition.UnconditionalModuleExportCondition;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -34,6 +35,8 @@ class ApiPackageTest {
     };
 
     private static final JavaClasses classes = new ClassFileImporter().importPackages("org.instancio");
+
+    private static final UnconditionalModuleExportCondition beUnconditionallyExported = new UnconditionalModuleExportCondition();
 
     @Test
     void internalApisShouldResideWithinInternalPackage() {
@@ -67,6 +70,20 @@ class ApiPackageTest {
         noClasses().that().resideInAnyPackage(NON_PUBLIC_PACKAGES)
                 .and().arePublic()
                 .should().haveSimpleNameStartingWith("Instancio")
+                .check(classes);
+    }
+
+    @Test
+    void allPublicPackagesShouldBeUnconditionallyExported() {
+        classes().that().resideOutsideOfPackages(NON_PUBLIC_PACKAGES)
+                .should(beUnconditionallyExported)
+                .check(classes);
+    }
+
+    @Test
+    void noInternalPackageShouldBeUnconditionallyExported() {
+        noClasses().that().resideInAnyPackage(NON_PUBLIC_PACKAGES)
+                .should(beUnconditionallyExported)
                 .check(classes);
     }
 }

--- a/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/condition/UnconditionalModuleExportCondition.java
+++ b/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/condition/UnconditionalModuleExportCondition.java
@@ -1,0 +1,24 @@
+package org.instancio.test.contract.condition;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+public class UnconditionalModuleExportCondition extends ArchCondition<JavaClass> {
+    public UnconditionalModuleExportCondition() {
+        super("be unconditionally exported");
+    }
+
+    @Override
+    public void check(final JavaClass javaClass, final ConditionEvents events) {
+        final Class<?> actualClass = javaClass.reflect();
+        final Module module = actualClass.getModule();
+
+        if (module.isExported(actualClass.getPackageName())) {
+            events.add(SimpleConditionEvent.satisfied(javaClass, "%s is unconditionally exported".formatted(javaClass.getName())));
+        } else {
+            events.add(SimpleConditionEvent.violated(javaClass, "%s is not unconditionally exported".formatted(javaClass.getName())));
+        }
+    }
+}

--- a/instancio-tests/instancio-test-support/pom.xml
+++ b/instancio-tests/instancio-test-support/pom.xml
@@ -30,6 +30,17 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.instancio.test.support</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
+++ b/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.fail;
 class ManifestFileTest {
 
     private static final String MANIFEST_MF_PATH = "META-INF/MANIFEST.MF";
-    private static final String AUTOMATIC_MODULE_NAME = "Automatic-Module-Name";
     private static final String BUNDLE_NAME = "Bundle-Name";
     private static final String BUNDLE_SYMBOLIC_NAME = "Bundle-SymbolicName";
     private static final String BUNDLE_DESCRIPTION = "Bundle-Description";
@@ -73,11 +72,9 @@ class ManifestFileTest {
 
     @Test
     void instancioCoreManifest() throws IOException {
-        final String moduleName = "org.instancio.core";
-        final Manifest manifest = getManifest(moduleName);
+        final String symbolicName = "org.instancio.core";
+        final Manifest manifest = getManifest(symbolicName);
         final Attributes attrs = manifest.getMainAttributes();
-
-        assertThat(attrs.getValue(BUNDLE_SYMBOLIC_NAME)).isEqualTo(moduleName);
 
         assertThat(attrs.getValue(BUNDLE_NAME))
                 .isEqualTo("Instancio Core");
@@ -111,11 +108,9 @@ class ManifestFileTest {
 
     @Test
     void instancioJUnitManifest() throws IOException {
-        final String moduleName = "org.instancio.junit";
-        final Manifest manifest = getManifest(moduleName);
+        final String symbolicName = "org.instancio.junit";
+        final Manifest manifest = getManifest(symbolicName);
         final Attributes attrs = manifest.getMainAttributes();
-
-        assertThat(attrs.getValue(BUNDLE_SYMBOLIC_NAME)).isEqualTo(moduleName);
 
         assertThat(attrs.getValue(BUNDLE_NAME))
                 .isEqualTo("Instancio JUnit 5 Support");
@@ -123,9 +118,7 @@ class ManifestFileTest {
         assertThat(attrs.getValue(BUNDLE_DESCRIPTION))
                 .isEqualTo("Instancio integration with JUnit 5");
 
-        assertThat(attrs.getValue(MULTI_RELEASE))
-                .as("instancio-junit is not a multi-release jar")
-                .isNull();
+        assertThat(attrs.getValue(MULTI_RELEASE)).isEqualTo("true");
 
         assertImports(attrs, INSTANCIO_JUNIT_EXPECTED_IMPORTS);
 
@@ -151,7 +144,7 @@ class ManifestFileTest {
                 .collect(Collectors.toSet());
     }
 
-    private Manifest getManifest(final String automaticModuleName) throws IOException {
+    private Manifest getManifest(final String symbolicName) throws IOException {
         final Enumeration<URL> resources = getClass().getClassLoader()
                 .getResources(MANIFEST_MF_PATH);
 
@@ -159,12 +152,12 @@ class ManifestFileTest {
             try (final InputStream is = resources.nextElement().openStream()) {
                 final Manifest manifest = new Manifest(is);
                 final Attributes attrs = manifest.getMainAttributes();
-                final String value = attrs.getValue(AUTOMATIC_MODULE_NAME);
-                if (automaticModuleName.equals(value)) {
+                final String value = attrs.getValue(BUNDLE_SYMBOLIC_NAME);
+                if (symbolicName.equals(value)) {
                     return manifest;
                 }
             }
         }
-        return fail("Manifest with module name '%s' not found", automaticModuleName);
+        return fail("Manifest with symbolic name '%s' not found", symbolicName);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,115 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>instancio-library</id>
+            <activation>
+                <file>
+                    <exists>${basedir}/instancio-library.marker</exists>
+                </file>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>3.11.0</version>
+                            <executions>
+                                <execution>
+                                    <id>default-compile</id>
+                                    <configuration>
+                                        <release>9</release>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>base-compile</id>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <excludes>
+                                            <exclude>module-info.java</exclude>
+                                        </excludes>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>java-16</id>
+                                    <phase>compile</phase>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <release>16</release>
+                                        <compileSourceRoots>
+                                            <compileSourceRoot>${project.basedir}/src/main/java16
+                                            </compileSourceRoot>
+                                        </compileSourceRoots>
+                                        <multiReleaseOutput>true</multiReleaseOutput>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>java-21</id>
+                                    <phase>compile</phase>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <release>21</release>
+                                        <compileSourceRoots>
+                                            <compileSourceRoot>${project.basedir}/src/main/java21
+                                            </compileSourceRoot>
+                                        </compileSourceRoots>
+                                        <multiReleaseOutput>true</multiReleaseOutput>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-antrun-plugin</artifactId>
+                            <version>3.0.0</version>
+                            <executions>
+                                <execution>
+                                    <id>move-module-info</id>
+                                    <phase>prepare-package</phase>
+                                    <goals>
+                                        <goal>run</goal>
+                                    </goals>
+                                    <configuration>
+                                        <target>
+                                            <move
+                                              file="${project.basedir}/target/classes/module-info.class"
+                                              todir="${project.basedir}/target/classes/META-INF/versions/9"
+                                              failonerror="false"
+                                              quiet="true"
+                                            />
+                                        </target>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -146,7 +255,7 @@
                             </goals>
                             <configuration>
                                 <rules>
-                                    <dependencyConvergence />
+                                    <dependencyConvergence/>
                                     <requireJavaVersion>
                                         <version>${maven.enforcer.require.java.version}</version>
                                     </requireJavaVersion>
@@ -159,36 +268,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
-                    <executions>
-                        <execution>
-                            <id>java-16</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <release>16</release>
-                                <compileSourceRoots>
-                                    <compileSourceRoot>${project.basedir}/src/main/java16</compileSourceRoot>
-                                </compileSourceRoots>
-                                <multiReleaseOutput>true</multiReleaseOutput>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>java-21</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                            <configuration>
-                                <release>21</release>
-                                <compileSourceRoots>
-                                    <compileSourceRoot>${project.basedir}/src/main/java21</compileSourceRoot>
-                                </compileSourceRoots>
-                                <multiReleaseOutput>true</multiReleaseOutput>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Resolves #895

This solution follows https://maven.apache.org/plugins/maven-compiler-plugin/examples/module-info.html for compiling in two passes: The first pass with Java 9 so `javac` can complain about missing `require` entries, the second pass compiles with Java 8 and overwrites the class files. Ant is used to place the `module-info.class` in the 9 release folder.

Unfortunately the Maven (OSGi) bundle plugin, unlike the jar plugin, does not allow excluding files, so I used `move` instead of `copy` in the ant config. This causes a problem when executing mvn multiple times without clean: Since the module-info.class vanished, the Java 9 compilation step notices a change and recompiles, while the Java 8 step sees no changes. As a result, the bytecode of all classes is now 9. Only a clean run is safe.

The alternative is just using a normal multirelease build, similar to how slf4j does it. This has the downside that the Java compiler does not see the classes of the main compilation unit and issues no errors for missing `require`, using internal packages like what happened with JUnit etc.

Note that currently this does not export all internal packages and will break modularized user code and extensions like [instancio-jpa](https://github.com/Mobe91/instancio-jpa).

It may also make sense to make the JMPS smoke tests part of this repository so they run with the build.