### PR TITLE
Refactor `Result` from class to interface

### DIFF
--- a/instancio-core/src/main/java/org/instancio/Result.java
+++ b/instancio-core/src/main/java/org/instancio/Result.java
@@ -15,8 +15,6 @@
  */
 package org.instancio;
 
-import org.jetbrains.annotations.Nullable;
-
 /**
  * A result containing a created object and seed that was used for populating its values.
  * A result can be obtained by calling the {@link InstancioApi#asResult()} method.
@@ -31,17 +29,10 @@ import org.jetbrains.annotations.Nullable;
  * long seed = result.getSeed();
  * }</pre>
  *
- * @param <T> result type
+ * @param <T> the result type
  * @since 1.5.1
  */
-public final class Result<T> {
-    private final T object;
-    private final long seed;
-
-    public Result(@Nullable final T object, final long seed) {
-        this.object = object;
-        this.seed = seed;
-    }
+public interface Result<T> {
 
     /**
      * Returns the created object.
@@ -49,9 +40,7 @@ public final class Result<T> {
      * @return created object
      * @since 1.5.1
      */
-    public T get() {
-        return object;
-    }
+    T get();
 
     /**
      * Returns the seed that was used to populate the created object.
@@ -59,12 +48,5 @@ public final class Result<T> {
      * @return the seed
      * @since 1.5.1
      */
-    public long getSeed() {
-        return seed;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("Result[seed=%s, object=%s]", seed, object);
-    }
+    long getSeed();
 }

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -188,7 +188,7 @@ public class ApiImpl<T> implements InstancioApi<T> {
     public Result<T> asResult() {
         final InternalModel<T> model = createModel();
         final long seed = model.getModelContext().getRandom().getSeed();
-        return new Result<>(createRootObject(model), seed);
+        return new InternalResult<>(createRootObject(model), seed);
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/InternalResult.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InternalResult.java
@@ -13,20 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio;
+package org.instancio.internal;
 
-import org.junit.jupiter.api.Test;
+import org.instancio.Result;
+import org.jetbrains.annotations.Nullable;
 
-import static org.assertj.core.api.Assertions.assertThat;
+public final class InternalResult<T> implements Result<T> {
+    private final T object;
+    private final long seed;
 
-class ResultTest {
+    public InternalResult(@Nullable final T object, final long seed) {
+        this.object = object;
+        this.seed = seed;
+    }
 
-    @Test
-    void verifyToString() {
-        assertThat(new Result<>("foo", 123L))
-                .hasToString("Result[seed=123, object=foo]");
+    @Override
+    public T get() {
+        return object;
+    }
 
-        assertThat(new Result<>(null, 123L))
-                .hasToString("Result[seed=123, object=null]");
+    @Override
+    public long getSeed() {
+        return seed;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Result[seed=%s, object=%s]", seed, object);
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/InternalResultTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/InternalResultTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InternalResultTest {
+
+    @Test
+    void verifyToString() {
+        assertThat(new InternalResult<>("foo", 123L))
+                .hasToString("Result[seed=123, object=foo]");
+
+        assertThat(new InternalResult<>(null, 123L))
+                .hasToString("Result[seed=123, object=null]");
+    }
+}


### PR DESCRIPTION
This removes the public constructor, but users should not need to instantiate this class.