### PR TITLE
Seed reporting improvements (#940)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/RandomHelper.java
+++ b/instancio-core/src/main/java/org/instancio/internal/RandomHelper.java
@@ -17,7 +17,6 @@ package org.instancio.internal;
 
 import org.instancio.Random;
 import org.instancio.documentation.InternalApi;
-import org.instancio.internal.util.ObjectUtils;
 import org.instancio.support.DefaultRandom;
 import org.instancio.support.Global;
 import org.instancio.support.Seeds;
@@ -48,14 +47,15 @@ public final class RandomHelper {
             @Nullable final Long withSeed) {
 
         if (withSeed != null) {
-            return new DefaultRandom(withSeed);
+            return new DefaultRandom(withSeed, Seeds.Source.MANUAL);
         }
 
+        // Based on instancio.properties seed, if defined
         final Random configuredRandom = Global.getConfiguredRandom();
 
         // This ensures we can override seed from the properties file using a custom Settings instance.
         if (settingsSeed != null && (configuredRandom == null || configuredRandom.getSeed() != settingsSeed)) {
-            return new DefaultRandom(settingsSeed);
+            return new DefaultRandom(settingsSeed, Seeds.Source.WITH_SETTINGS_BUILDER);
         }
 
         // If running under JUnit extension, use the Random instance supplied by the extension
@@ -63,7 +63,12 @@ public final class RandomHelper {
             return ThreadLocalRandom.getInstance().get();
         }
 
-        return ObjectUtils.defaultIfNull(configuredRandom, () -> new DefaultRandom(Seeds.randomSeed()));
+        if (configuredRandom != null) {
+            return configuredRandom;
+        }
+
+        // Random seed
+        return new DefaultRandom();
     }
 
     private RandomHelper() {

--- a/instancio-core/src/main/java/org/instancio/support/DefaultRandom.java
+++ b/instancio-core/src/main/java/org/instancio/support/DefaultRandom.java
@@ -29,12 +29,13 @@ public class DefaultRandom implements Random {
 
     private final long seed;
     private final java.util.Random random;
+    private final Seeds.Source source;
 
     /**
      * Create an instance with a random seed value.
      */
     public DefaultRandom() {
-        this(Seeds.randomSeed());
+        this(Seeds.randomSeed(), Seeds.Source.RANDOM);
     }
 
     /**
@@ -42,14 +43,19 @@ public class DefaultRandom implements Random {
      *
      * @param seed for the random generator
      */
-    public DefaultRandom(final long seed) {
+    public DefaultRandom(final long seed, final Seeds.Source source) {
         this.seed = seed;
         this.random = new java.util.Random(seed); // NOSONAR
+        this.source = source;
     }
 
     @Override
     public long getSeed() {
         return seed;
+    }
+
+    public Seeds.Source getSource() {
+        return source;
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/support/Global.java
+++ b/instancio-core/src/main/java/org/instancio/support/Global.java
@@ -32,7 +32,7 @@ public final class Global {
             .lock();
 
     private static final Random CONFIGURED_RANDOM = PROPERTIES_FILE_SETTINGS.get(Keys.SEED) == null
-            ? null : new DefaultRandom(PROPERTIES_FILE_SETTINGS.get(Keys.SEED));
+            ? null : new DefaultRandom(PROPERTIES_FILE_SETTINGS.get(Keys.SEED), Seeds.Source.GLOBAL);
 
     /**
      * Default settings overlaid with settings from {@code instancio.properties}.

--- a/instancio-core/src/main/java/org/instancio/support/Seeds.java
+++ b/instancio-core/src/main/java/org/instancio/support/Seeds.java
@@ -28,6 +28,25 @@ import java.security.SecureRandom;
 @InternalApi
 public final class Seeds {
 
+    public enum Source {
+        MANUAL(".withSeed()"),
+        WITH_SETTINGS_BUILDER(".withSettings()"),
+        WITH_SETTINGS_ANNOTATION("@WithSettings"),
+        SEED_ANNOTATION("@Seed"),
+        GLOBAL("instancio.properties"),
+        RANDOM("random seed");
+
+        private final String description;
+
+        Source(final String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+
     /**
      * Maximum bit length of the seed.
      *

--- a/instancio-junit/src/main/java/org/instancio/junit/InstancioExtension.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/InstancioExtension.java
@@ -16,6 +16,7 @@
 package org.instancio.junit;
 
 import org.instancio.junit.internal.ExtensionSupport;
+import org.instancio.support.DefaultRandom;
 import org.instancio.support.ThreadLocalRandom;
 import org.instancio.support.ThreadLocalSettings;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -107,12 +108,17 @@ public class InstancioExtension implements BeforeEachCallback, AfterEachCallback
                 return;
             }
 
-            final long seed = threadLocalRandom.get().getSeed();
-            final String msg = String.format("Test method '%s' failed with seed: %d%n",
-                    testMethod.get().getName(), seed);
+            context.getStore(ExtensionContext.Namespace.create("x"));
 
-            context.publishReportEntry("Instancio", msg);
-            LOG.debug(msg);
+            // Should be safe to case. We don't  expect any other implementations of Random.
+            final DefaultRandom random = (DefaultRandom) threadLocalRandom.get();
+            final long seed = random.getSeed();
+
+            final String seedMsg = String.format("Test method '%s' failed with seed: %d (seed source: %s)%n",
+                    testMethod.get().getName(), seed, random.getSource().getDescription());
+
+            context.publishReportEntry("Instancio", seedMsg);
+            LOG.debug(seedMsg);
         }
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/support/DefaultRandomTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/support/DefaultRandomTest.java
@@ -59,6 +59,11 @@ class DefaultRandomTest {
     }
 
     @Test
+    void defaultSourceShouldBeRandom() {
+        assertThat(((DefaultRandom) random).getSource()).isEqualTo(Seeds.Source.RANDOM);
+    }
+
+    @Test
     void bounds() {
         assertThat(random.byteRange((byte) 1, (byte) 1)).isEqualTo((byte) 1);
         assertThat(random.shortRange((short) 1, (short) 1)).isEqualTo((short) 1);

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
@@ -20,6 +20,7 @@ import org.instancio.Random;
 import org.instancio.exception.InstancioApiException;
 import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
+import org.instancio.support.Seeds;
 import org.instancio.support.ThreadLocalRandom;
 import org.instancio.support.ThreadLocalSettings;
 import org.junit.jupiter.api.DisplayName;
@@ -212,7 +213,7 @@ class InstancioExtensionTest {
 
         when(context.getExecutionException()).thenReturn(Optional.of(new Throwable()));
         when(context.getTestMethod()).thenReturn(Optional.of(method));
-        when(threadLocalRandom.get()).thenReturn(new DefaultRandom(expectedSeed));
+        when(threadLocalRandom.get()).thenReturn(new DefaultRandom(expectedSeed, Seeds.Source.SEED_ANNOTATION));
 
         // Method under test
         extension.afterTestExecution(context);

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionThreadLocalRandomTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionThreadLocalRandomTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit;
+
+import org.instancio.Instancio;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.support.DefaultRandom;
+import org.instancio.support.Seeds;
+import org.instancio.support.ThreadLocalRandom;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+@SuppressWarnings({"JUnitMalformedDeclaration", "NewClassNamingConvention"})
+class InstancioExtensionThreadLocalRandomTest {
+
+    private static final long SEED_WITH_SEED = -1; // .withSeed()
+    private static final long SEED_WITH_SETTINGS_BUILDER = -2; // .withSettings()
+    private static final long SEED_WITH_SETTINGS_ANNOTATION = -3; // @WithSettings
+    private static final long SEED_ANNOTATION = -4; // @Seed
+
+    @ValueSource(classes = {
+            RandomSeed.class,
+            SeedAnnotation.class,
+            SettingsAnnotation.class,
+            SettingsAnnotationAndWithSettingsBuilder.class,
+            SettingsAnnotationAndSeedFromWithSettingsAnnotation.class
+    })
+    @ParameterizedTest
+    void seedFromWithSettingsAnnotation(final Class<?> testClass) {
+        verifyTestClass(testClass);
+    }
+
+    private static void verifyTestClass(final Class<?> testClass) {
+        EngineTestKit.engine("junit-jupiter")
+                .selectors(selectClass(testClass))
+                .execute()
+                .testEvents()
+                .assertStatistics(stats -> stats.failed(1));
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    static class SettingsAnnotation {
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.SEED, SEED_WITH_SETTINGS_ANNOTATION);
+
+        @AfterEach
+        void tearDown() {
+            assertSeed(SEED_WITH_SETTINGS_ANNOTATION, Seeds.Source.WITH_SETTINGS_ANNOTATION);
+        }
+
+        @Test
+        void intentionallyFail() {
+            doFail();
+        }
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    static class SettingsAnnotationAndWithSettingsBuilder {
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.SEED, SEED_WITH_SETTINGS_ANNOTATION);
+
+        @AfterEach
+        void tearDown() {
+            assertSeed(SEED_WITH_SETTINGS_ANNOTATION, Seeds.Source.WITH_SETTINGS_ANNOTATION);
+        }
+
+        @Test
+        void intentionallyFail() {
+            Instancio.of(String.class)
+                    // Seeds specified directly via the Instancio builder API
+                    // should never be reported by the extension
+                    .withSetting(Keys.SEED, SEED_WITH_SETTINGS_BUILDER)
+                    .withSeed(SEED_WITH_SEED)
+                    .create();
+
+            doFail();
+        }
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    static class SettingsAnnotationAndSeedFromWithSettingsAnnotation {
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.SEED, SEED_WITH_SETTINGS_ANNOTATION);
+
+        @AfterEach
+        void tearDown() {
+            assertSeed(SEED_WITH_SETTINGS_ANNOTATION, Seeds.Source.WITH_SETTINGS_ANNOTATION);
+        }
+
+        @Seed(SEED_ANNOTATION)
+        @Test
+        void intentionallyFail() {
+            doFail();
+        }
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    static class SeedAnnotation {
+
+        @AfterEach
+        void tearDown() {
+            assertSeed(SEED_ANNOTATION, Seeds.Source.SEED_ANNOTATION);
+        }
+
+        @Seed(SEED_ANNOTATION)
+        @Test
+        void intentionallyFail() {
+            doFail();
+        }
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    static class RandomSeed {
+
+        @AfterEach
+        void tearDown() {
+            assertRandomSeed();
+        }
+
+        @Test
+        void intentionallyFail() {
+            doFail();
+        }
+    }
+
+    private static void doFail() {
+        fail("Intentional failure");
+    }
+
+    private static void assertSeed(long expectedSeed, Seeds.Source expectedSource) {
+        final DefaultRandom random = (DefaultRandom) ThreadLocalRandom.getInstance().get();
+
+        try {
+            assertThat(random.getSeed()).as("seed").isEqualTo(expectedSeed);
+            assertThat(random.getSource()).as("seed source").isEqualTo(expectedSource);
+        } catch (AssertionError e) {
+            printStackTraceAndExit(e);
+        }
+    }
+
+    private static void assertRandomSeed() {
+        final DefaultRandom random = (DefaultRandom) ThreadLocalRandom.getInstance().get();
+
+        try {
+            assertThat(random.getSeed()).as("expected a positive random seed").isPositive();
+            assertThat(random.getSource()).as("seed source").isEqualTo(Seeds.Source.RANDOM);
+        } catch (AssertionError e) {
+            printStackTraceAndExit(e);
+        }
+    }
+
+    /**
+     * AssertionError in {@link AfterEach} does not propagate up,
+     * therefore we print the stack trace and exit the VM.
+     * There must be a better way to do this!
+     */
+    @SuppressWarnings("CallToPrintStackTrace")
+    private static void printStackTraceAndExit(final AssertionError error) {
+        System.err.print("""
+                #############################################
+
+                 InstancioExtension test failure!
+                 Intentionally exiting the VM.
+
+                #############################################
+                """);
+
+        error.printStackTrace();
+        System.exit(-1);
+    }
+}

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignAbcNestedRecordsTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/assign/AssignAbcNestedRecordsTest.java
@@ -16,7 +16,6 @@
 package org.instancio.test.java16.assign;
 
 import org.instancio.Assignment;
-import org.instancio.Gen;
 import org.instancio.Instancio;
 import org.instancio.Model;
 import org.instancio.Selector;
@@ -111,8 +110,7 @@ class AssignAbcNestedRecordsTest {
     }
 
     private static Assignment[] shuffleArgs(final Assignment... assignments) {
-        final long seed = Gen.longs().get();
-        ArrayUtils.shuffle(assignments, new DefaultRandom(seed));
+        ArrayUtils.shuffle(assignments, new DefaultRandom());
         return assignments;
     }
 }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -3203,8 +3203,18 @@ void verifyShippingAddress() {
 The failed test output will include the following message:
 
 ```
-Test method 'verifyShippingAddress' failed with seed: 8532
+Test method 'verifyShippingAddress' failed with seed: 8532 (seed source: random seed)
 ```
+
+The _seed source_ indicates whether the Instancio extension generated a random seed
+or used a seed provided by the user. The possible seed sources are listed below
+(see also [Specifying seed value](#specifying-seed-value)):
+
+- seed specified via `Settings` annotated with `@WithSettings`
+- seed specified using the `@Seed` annotation
+- random seed (default behaviour when an explicit seed is not specified)
+
+!!! warning "Seeds specified using {{withSeed}} or {{withSettings}} methods are not reported by the Instancio extension."
 
 The failed test can be reproduced by using the seed reported in the failure message.
 This can be done by placing the {{Seed}} annotation on the test method:


### PR DESCRIPTION

```java
@ExtendWith(InstancioExtension.class)
class N1Test {
    @Test
    void example() {
        fail("fail to print seed");
    }
}
```
Output: `Test method 'example' failed with seed: 2418026050664435300 (seed source: random seed)`

-----

```java
@ExtendWith(InstancioExtension.class)
class N2Test {
    @Seed(456)
    @Test
    void example() {
        fail("fail to print seed");
    }
}
```
Output: `Test method 'example' failed with seed: 456 (seed source: @Seed)`

-----

```java
@ExtendWith(InstancioExtension.class)
class N3Test {
    @WithSettings
    private Settings settings = Settings.create().set(Keys.SEED, 123L);

    @Test
    void example() {
        fail("fail to print seed");
    }
}
```
Output: `Test method 'example' failed with seed: 123 (seed source: @WithSettings)`

-----

```java
@ExtendWith(InstancioExtension.class)
class N4Test {
    @WithSettings
    private Settings settings = Settings.create().set(Keys.SEED, 123L);

    @Seed(456)
    @Test
    void example() {
        fail("fail to print seed");
    }
}
```
Output: `Test method 'example' failed with seed: 123 (seed source: @WithSettings)`
