### PR TITLE
Fix typo in user-guide.md

### DIFF
--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -1154,10 +1154,10 @@ It is possible to create an assignment based on address `city` and fields `count
 ```java linenums="1"
 Person person = Instancio.of(Person.class)
     .generate(field(Address::getCountry), gen -> gen.oneOf("France", "Italy", "Spain"))
-    .assign(given(field(Address::getCountry), field(Address::getCity)
+    .assign(given(field(Address::getCountry), field(Address::getCity))
         .set(When.is("France"), "Paris")
         .set(When.is("Italy"), "Rome")
-        .set(When.is("Spain"), "Madrid")
+        .set(When.is("Spain"), "Madrid"))
     .create();
 ```
 


### PR DESCRIPTION
I found a typo in [using-assign](https://www.instancio.org/user-guide/#using-assign) section in user-guide.md.

