### PR TITLE
SPI for processing custom annotations

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/annotation/AbstractAnnotationConsumer.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/AbstractAnnotationConsumer.java
@@ -38,7 +38,7 @@ abstract class AbstractAnnotationConsumer implements AnnotationConsumer {
 
     protected abstract AnnotationHandlerMap getAnnotationHandlerMap();
 
-    final <A extends Annotation> void register(
+    final <A extends Annotation> void putPrimary(
             final Supplier<Class<A>> annotationTypeSupplier,
             final AnnotationGeneratorFn annotationGeneratorFn) {
 

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationAnnotationConsumer.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationAnnotationConsumer.java
@@ -34,47 +34,47 @@ import org.jetbrains.annotations.NotNull;
 final class HibernateBeanValidationAnnotationConsumer extends AbstractAnnotationConsumer {
 
     HibernateBeanValidationAnnotationConsumer() {
-        register(() -> org.hibernate.validator.constraints.EAN.class,
+        putPrimary(() -> org.hibernate.validator.constraints.EAN.class,
                 (annotation, context) -> getEanGenerator(
                         (org.hibernate.validator.constraints.EAN) annotation, context)
         );
         // Instancio aims to support Hibernate validator 5.x, in which Email is not deprecated
         //noinspection deprecation
-        register(() -> org.hibernate.validator.constraints.Email.class, // NOSONAR
+        putPrimary(() -> org.hibernate.validator.constraints.Email.class, // NOSONAR
                 (annotation, context) -> new EmailGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.LuhnCheck.class,
+        putPrimary(() -> org.hibernate.validator.constraints.LuhnCheck.class,
                 (annotation, context) -> getLuhnGenerator(
                         (org.hibernate.validator.constraints.LuhnCheck) annotation, context));
 
-        register(() -> org.hibernate.validator.constraints.Mod10Check.class,
+        putPrimary(() -> org.hibernate.validator.constraints.Mod10Check.class,
                 (annotation, context) -> getMod10Generator(
                         (org.hibernate.validator.constraints.Mod10Check) annotation, context));
 
-        register(() -> org.hibernate.validator.constraints.Mod11Check.class,
+        putPrimary(() -> org.hibernate.validator.constraints.Mod11Check.class,
                 (annotation, context) -> getMod11Generator(
                         (org.hibernate.validator.constraints.Mod11Check) annotation, context));
 
-        register(() -> org.hibernate.validator.constraints.CreditCardNumber.class,
+        putPrimary(() -> org.hibernate.validator.constraints.CreditCardNumber.class,
                 (annotation, context) -> new CreditCardNumberGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.ISBN.class,
+        putPrimary(() -> org.hibernate.validator.constraints.ISBN.class,
                 (annotation, context) -> new IsbnGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.UUID.class,
+        putPrimary(() -> org.hibernate.validator.constraints.UUID.class,
                 (annotation, context) -> new UUIDGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.URL.class,
+        putPrimary(() -> org.hibernate.validator.constraints.URL.class,
                 (annotation, context) -> getUrlGenerator(
                         (org.hibernate.validator.constraints.URL) annotation, context));
 
-        register(() -> org.hibernate.validator.constraints.pl.NIP.class,
+        putPrimary(() -> org.hibernate.validator.constraints.pl.NIP.class,
                 (annotation, context) -> new NipGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.pl.PESEL.class,
+        putPrimary(() -> org.hibernate.validator.constraints.pl.PESEL.class,
                 (annotation, context) -> new PeselGenerator(context));
 
-        register(() -> org.hibernate.validator.constraints.pl.REGON.class,
+        putPrimary(() -> org.hibernate.validator.constraints.pl.REGON.class,
                 (annotation, context) -> new RegonGenerator(context));
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/JavaxBeanValidationAnnotationConsumer.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/JavaxBeanValidationAnnotationConsumer.java
@@ -25,7 +25,7 @@ final class JavaxBeanValidationAnnotationConsumer extends AbstractAnnotationCons
     }
 
     JavaxBeanValidationAnnotationConsumer() {
-        register(() -> javax.validation.constraints.Email.class,
+        putPrimary(() -> javax.validation.constraints.Email.class,
                 (annotation, context) -> new EmailGenerator(context));
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generation/AnnotationNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generation/AnnotationNodeHandler.java
@@ -15,6 +15,8 @@
  */
 package org.instancio.internal.generation;
 
+import org.instancio.exception.InstancioException;
+import org.instancio.exception.InstancioTerminatingException;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.internal.PrimitiveWrapperBiLookup;
@@ -26,15 +28,29 @@ import org.instancio.internal.context.ModelContext;
 import org.instancio.internal.generator.GeneratorResolver;
 import org.instancio.internal.generator.GeneratorResult;
 import org.instancio.internal.nodes.InternalNode;
+import org.instancio.internal.spi.ProviderEntry;
+import org.instancio.internal.util.Fail;
+import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.settings.Keys;
+import org.instancio.spi.InstancioServiceProvider.AnnotationProcessor;
+import org.instancio.spi.InstancioServiceProvider.AnnotationProcessor.AnnotationHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.instancio.internal.util.ErrorMessageUtils.annotationHandlerInvalidNumberOfParameters;
+import static org.instancio.internal.util.ErrorMessageUtils.invalidAnnotationHandlerMethod;
 
 /**
- * Entry point for processing Bean Validation and JPA annotations.
+ * Entry point for processing Bean Validation and JPA annotations,
+ * as well as {@link AnnotationProcessor} SPI implementations.
  *
  * <p>The main goals of this implementation are:
  * <ul>
@@ -48,7 +64,8 @@ import java.util.List;
  *
  * @see AnnotationMap
  */
-class AnnotationNodeHandler implements NodeHandler {
+@SuppressWarnings("PMD.ExcessiveImports")
+final class AnnotationNodeHandler implements NodeHandler {
 
     private final List<AnnotationConsumer> annotationConsumers;
     private final AnnotationExtractor annotationExtractor;
@@ -56,8 +73,15 @@ class AnnotationNodeHandler implements NodeHandler {
     private final GeneratorContext generatorContext;
     private final GeneratorResolver generatorResolver;
     private final GeneratedValuePostProcessor stringPostProcessor;
+    private final Map<Class<?>, List<AnnotatedMethod>> annotatedMethodsMap;
+    private final boolean beanValidationOrJpaEnabled;
 
-    AnnotationNodeHandler(final ModelContext<?> modelContext, final GeneratorResolver generatorResolver) {
+    private AnnotationNodeHandler(
+            final ModelContext<?> modelContext,
+            final GeneratorResolver generatorResolver,
+            final List<ProviderEntry<AnnotationProcessor>> annotationProcessors,
+            final boolean beanValidationOrJpaEnabled) {
+
         this.modelContext = modelContext;
         this.generatorResolver = generatorResolver;
         this.annotationConsumers = AnnotationConsumers.get(modelContext);
@@ -65,6 +89,51 @@ class AnnotationNodeHandler implements NodeHandler {
         this.stringPostProcessor = new StringPrefixingPostProcessor(
                 modelContext.getSettings().get(Keys.STRING_FIELD_PREFIX_ENABLED));
         this.generatorContext = new GeneratorContext(modelContext.getSettings(), modelContext.getRandom());
+        this.annotatedMethodsMap = collectAnnotatedMethods(annotationProcessors);
+        this.beanValidationOrJpaEnabled = beanValidationOrJpaEnabled;
+    }
+
+    static NodeHandler create(final ModelContext<?> context, final GeneratorResolver generatorResolver) {
+        final boolean bvOrJpaEnabled = context.getSettings().get(Keys.BEAN_VALIDATION_ENABLED)
+                || context.getSettings().get(Keys.JPA_ENABLED);
+
+        final List<ProviderEntry<AnnotationProcessor>> annotationProcessors =
+                context.getServiceProviders().getAnnotationProcessors();
+
+        return bvOrJpaEnabled || !annotationProcessors.isEmpty()
+                ? new AnnotationNodeHandler(context, generatorResolver, annotationProcessors, bvOrJpaEnabled)
+                : NodeHandler.NOOP_HANDLER;
+    }
+
+    private static Map<Class<?>, List<AnnotatedMethod>> collectAnnotatedMethods(
+            final List<ProviderEntry<AnnotationProcessor>> annotationProcessors) {
+
+        if (annotationProcessors.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        final Map<Class<?>, List<AnnotatedMethod>> results = new LinkedHashMap<>();
+
+        for (ProviderEntry<AnnotationProcessor> entry : annotationProcessors) {
+            final AnnotationProcessor processor = entry.getProvider();
+
+            for (Method method : processor.getClass().getDeclaredMethods()) {
+                ReflectionUtils.setAccessible(method);
+
+                if (method.getDeclaredAnnotation(AnnotationHandler.class) != null) {
+                    final Class<?>[] paramTypes = method.getParameterTypes();
+                    final AnnotatedMethod annotatedMethod = new AnnotatedMethod(processor, method);
+
+                    // Allowed number of args for @AnnotationHandler methods is either 2 or 3.
+                    // The validation is deferred to just before the method is invoked.
+                    if (paramTypes.length > 0) {
+                        final Class<?> annotationType = paramTypes[0];
+                        results.computeIfAbsent(annotationType, v -> new ArrayList<>()).add(annotatedMethod);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableMap(results);
     }
 
     @NotNull
@@ -76,17 +145,27 @@ class AnnotationNodeHandler implements NodeHandler {
             return GeneratorResult.emptyResult();
         }
 
-        final AnnotationMap annotationMap = new AnnotationMap(annotations);
-        final Generator<?> generator = getGenerator(node, annotations, annotationMap);
+        Generator<?> generator;
+
+        // AnnotationProcessor SPI can be used with or without
+        // Bean Validation/JPA annotations
+        if (beanValidationOrJpaEnabled) {
+            final AnnotationMap annotationMap = new AnnotationMap(annotations);
+            generator = getGenerator(node, annotations, annotationMap);
+
+            for (AnnotationConsumer provider : annotationConsumers) {
+                provider.consumeAnnotations(annotationMap, generator, node.getTargetClass());
+            }
+        } else {
+            generator = generatorResolver.get(node);
+        }
 
         if (generator == null) {
             return GeneratorResult.emptyResult();
         }
 
-        // consume remaining annotations, if any
-        for (AnnotationConsumer provider : annotationConsumers) {
-            provider.consumeAnnotations(annotationMap, generator, node.getTargetClass());
-        }
+        // Invoke @AnnotationHandler methods defined via SPI
+        invokeAnnotationHandlerMethods(node, annotations, generator);
 
         Object obj = generator.generate(modelContext.getRandom());
 
@@ -110,6 +189,55 @@ class AnnotationNodeHandler implements NodeHandler {
         final Object processed = stringPostProcessor.process(obj, node, generator);
         return GeneratorResult.create(processed, generator.hints());
     }
+
+    private void invokeAnnotationHandlerMethods(
+            final InternalNode node,
+            final Annotation[] annotations,
+            final Generator<?> generator) {
+
+        for (Annotation annotation : annotations) {
+            final List<AnnotatedMethod> annotatedMethods = annotatedMethodsMap.getOrDefault(
+                    annotation.annotationType(), Collections.emptyList());
+
+            for (AnnotatedMethod method : annotatedMethods) {
+                method.invoke(annotation, generator, node);
+            }
+        }
+    }
+
+    private static final class AnnotatedMethod {
+        private final AnnotationProcessor processor;
+        private final Method method;
+        private final Class<?>[] params;
+
+        AnnotatedMethod(AnnotationProcessor processor, Method method) {
+            this.processor = processor;
+            this.method = method;
+            this.params = method.getParameterTypes();
+        }
+
+        void invoke(final Annotation annotation, final Generator<?> generator, final InternalNode node) {
+            try {
+                if (params.length == 2) {
+                    method.invoke(processor, annotation, generator);
+                } else if (params.length == 3) {
+                    method.invoke(processor, annotation, generator, node);
+                } else {
+                    throw Fail.withUsageError(annotationHandlerInvalidNumberOfParameters(processor.getClass(), method));
+                }
+            } catch (IllegalArgumentException ex) {
+                final String msg = invalidAnnotationHandlerMethod(
+                        processor.getClass(), method, annotation, generator, node);
+
+                throw Fail.withUsageError(msg, ex);
+            } catch (AssertionError | InstancioTerminatingException ex) {
+                throw ex;
+            } catch (Exception ex) {
+                throw new InstancioException("Failed invoking @AnnotationHandler method", ex);
+            }
+        }
+    }
+
 
     private static boolean isObjectAssignableToNode(final InternalNode node, final Object obj) {
         if (obj == null) {
@@ -136,8 +264,11 @@ class AnnotationNodeHandler implements NodeHandler {
                 }
             }
         }
-        // if no primary annotation present or no generator defined
-        // for the primary annotation, fallback to built-in generator
+        // If no primary annotation present or no generator defined
+        // for the primary annotation, fallback to a built-in generator.
+        // We ignore SPI generators (GeneratorProvider) here because
+        // if there was one defined, it would have been used to generate
+        // the value for this node (bypassing annotation processing).
         return generatorResolver.get(node);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/spi/ProviderEntry.java
+++ b/instancio-core/src/main/java/org/instancio/internal/spi/ProviderEntry.java
@@ -38,6 +38,10 @@ public final class ProviderEntry<P> {
             final List<InstancioServiceProvider> instancioServiceProviders,
             final Function<InstancioServiceProvider, P> fn) {
 
+        if (instancioServiceProviders.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         final List<ProviderEntry<P>> results = new ArrayList<>();
         for (InstancioServiceProvider it : instancioServiceProviders) {
 

--- a/instancio-core/src/main/java/org/instancio/internal/spi/Providers.java
+++ b/instancio-core/src/main/java/org/instancio/internal/spi/Providers.java
@@ -17,6 +17,7 @@ package org.instancio.internal.spi;
 
 import org.instancio.internal.util.ServiceLoaders;
 import org.instancio.spi.InstancioServiceProvider;
+import org.instancio.spi.InstancioServiceProvider.AnnotationProcessor;
 import org.instancio.spi.InstancioServiceProvider.GeneratorProvider;
 import org.instancio.spi.InstancioServiceProvider.SetterMethodResolver;
 import org.instancio.spi.InstancioServiceProvider.TypeInstantiator;
@@ -32,6 +33,7 @@ public final class Providers {
     private final List<ProviderEntry<TypeResolver>> typeResolvers;
     private final List<ProviderEntry<TypeInstantiator>> typeInstantiators;
     private final List<ProviderEntry<SetterMethodResolver>> setterMethodResolvers;
+    private final List<ProviderEntry<AnnotationProcessor>> annotationProcessors;
 
     public Providers(final ServiceProviderContext context) {
         this(ServiceLoaders.loadAll(InstancioServiceProvider.class), context);
@@ -45,6 +47,7 @@ public final class Providers {
         typeResolvers = ProviderEntry.from(spList, InstancioServiceProvider::getTypeResolver);
         typeInstantiators = ProviderEntry.from(spList, InstancioServiceProvider::getTypeInstantiator);
         setterMethodResolvers = ProviderEntry.from(spList, InstancioServiceProvider::getSetterMethodResolver);
+        annotationProcessors = ProviderEntry.from(spList, InstancioServiceProvider::getAnnotationProcessor);
     }
 
     public List<ProviderEntry<GeneratorProvider>> getGeneratorProviders() {
@@ -61,5 +64,9 @@ public final class Providers {
 
     public List<ProviderEntry<SetterMethodResolver>> getSetterMethodResolvers() {
         return setterMethodResolvers;
+    }
+
+    public List<ProviderEntry<AnnotationProcessor>> getAnnotationProcessors() {
+        return annotationProcessors;
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/util/Format.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Format.java
@@ -130,6 +130,14 @@ public final class Format {
                 withoutPackage(method.getParameterTypes()[0]));
     }
 
+    public static String methodNameWithParams(final Method method) {
+        final String params = Arrays.stream(method.getParameterTypes())
+                .map(Format::withoutPackage)
+                .collect(joining(", "));
+
+        return String.format("%s(%s)", method.getName(), params);
+    }
+
     public static String withoutPackage(final Type type) {
         return PACKAGE_PATTERN.matcher(type.getTypeName()).replaceAll("");
     }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/annotations/CollectionSizeOne.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/annotations/CollectionSizeOne.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.annotation;
+package org.annotations;
 
-import org.instancio.internal.generator.domain.internet.EmailGenerator;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
-final class JakartaBeanValidationAnnotationConsumer extends AbstractAnnotationConsumer {
-
-    JakartaBeanValidationAnnotationConsumer() {
-        putPrimary(() -> jakarta.validation.constraints.Email.class,
-                ((annotation, context) -> new EmailGenerator(context)));
-    }
-
-    @Override
-    protected AnnotationHandlerMap getAnnotationHandlerMap() {
-        return JakartaBeanValidationHandlerMap.getInstance();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CollectionSizeOne {
 }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/annotations/StringSuffix.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/annotations/StringSuffix.java
@@ -13,19 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.annotation;
+package org.annotations;
 
-import org.instancio.internal.generator.domain.internet.EmailGenerator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-final class JakartaBeanValidationAnnotationConsumer extends AbstractAnnotationConsumer {
+@Target({ElementType.FIELD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StringSuffix {
 
-    JakartaBeanValidationAnnotationConsumer() {
-        putPrimary(() -> jakarta.validation.constraints.Email.class,
-                ((annotation, context) -> new EmailGenerator(context)));
-    }
-
-    @Override
-    protected AnnotationHandlerMap getAnnotationHandlerMap() {
-        return JakartaBeanValidationHandlerMap.getInstance();
-    }
+    String value();
 }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorBVTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.beanvalidation.spi.annotationprocessor;
+
+import jakarta.validation.constraints.Size;
+import org.annotations.StringSuffix;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class AnnotationProcessorBVTest {
+
+    private static final int SIZE = 10;
+    private static final String FOO = "_foo";
+    private static final String BARBAZ = "_barbaz";
+
+    @WithSettings
+    private static final Settings SETTINGS = Settings.create()
+            .set(Keys.COLLECTION_NULLABLE, false)
+            .set(Keys.STRING_NULLABLE, false);
+
+    private static class Pojo {
+        @StringSuffix(FOO)
+        @Size(min = SIZE, max = SIZE)
+        String value;
+
+        List<@Size(min = SIZE, max = SIZE) @StringSuffix(BARBAZ) String> list;
+    }
+
+    @RepeatedTest(Constants.SAMPLE_SIZE_D)
+    void beanValidationWithCustomAnnotation() {
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.value)
+                .hasSize(SIZE + FOO.length())
+                .endsWith(FOO);
+
+        assertThat(result.list).allSatisfy(s -> assertThat(s)
+                .hasSize(SIZE + BARBAZ.length())
+                .endsWith(BARBAZ));
+    }
+}

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorPrecedenceBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorPrecedenceBVTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.beanvalidation.spi.annotationprocessor;
+
+import jakarta.validation.constraints.Size;
+import org.annotations.CollectionSizeOne;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class AnnotationProcessorPrecedenceBVTest {
+
+    private static final int SIZE = 10;
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.COLLECTION_NULLABLE, false);
+
+    @Test
+    void withCollectionSizeOneFirst() {
+        class Pojo {
+            @CollectionSizeOne // first
+            @Size(min = SIZE, max = SIZE)
+            List<String> list;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+        assertThat(result.list).hasSize(1);
+    }
+
+    @Test
+    void withCollectionSizeOneLast() {
+        class Pojo {
+            @Size(min = SIZE, max = SIZE)
+            @CollectionSizeOne // last
+            List<String> list;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+        assertThat(result.list).hasSize(1);
+    }
+}

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorWithBeanValidationDisabledBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/AnnotationProcessorWithBeanValidationDisabledBVTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.beanvalidation.spi.annotationprocessor;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.annotations.StringSuffix;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class AnnotationProcessorWithBeanValidationDisabledBVTest {
+
+    private static final int STRING_LENGTH_SETTING = 5;
+    private static final String SUFFIX = "foo";
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.STRING_ALLOW_EMPTY, false)
+            .set(Keys.STRING_NULLABLE, false)
+            .set(Keys.STRING_MIN_LENGTH, STRING_LENGTH_SETTING)
+            .set(Keys.STRING_MAX_LENGTH, STRING_LENGTH_SETTING)
+            .set(Keys.BEAN_VALIDATION_ENABLED, false); // BV disabled!
+
+    /**
+     * If Bean Validation is disabled, BV annotations should be ignored,
+     * but annotation processor should still handle custom annotations.
+     */
+    @RepeatedTest(Constants.SAMPLE_SIZE_D)
+    void beanValidationDisabled() {
+        class Pojo {
+            @StringSuffix(SUFFIX)
+            @NotNull
+            @Size(max = 1) // ignored since BV is disabled
+            String value;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.value)
+                .hasSize(STRING_LENGTH_SETTING + SUFFIX.length())
+                .endsWith(SUFFIX);
+    }
+}

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/package-info.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/annotationprocessor/package-info.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.annotation;
 
-import org.instancio.internal.generator.domain.internet.EmailGenerator;
-
-final class JakartaBeanValidationAnnotationConsumer extends AbstractAnnotationConsumer {
-
-    JakartaBeanValidationAnnotationConsumer() {
-        putPrimary(() -> jakarta.validation.constraints.Email.class,
-                ((annotation, context) -> new EmailGenerator(context)));
-    }
-
-    @Override
-    protected AnnotationHandlerMap getAnnotationHandlerMap() {
-        return JakartaBeanValidationHandlerMap.getInstance();
-    }
-}
+/**
+ * Tests for using custom annotation processor with Bean Validation.
+ *
+ * @see org.instancio.spi.InstancioServiceProvider.AnnotationProcessor
+ * @see org.spi.SampleSpiBV
+ */
+package org.instancio.test.beanvalidation.spi.annotationprocessor;

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/generatorprovider/FooFieldBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/generatorprovider/FooFieldBVTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.test.beanvalidation;
+package org.instancio.test.beanvalidation.spi.generatorprovider;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
@@ -25,10 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Tests for using custom generator provider implemented
- * in {@link org.spi.SampleSpi} with Bean Validation.
- */
 @FeatureTag(Feature.BEAN_VALIDATION)
 @ExtendWith(InstancioExtension.class)
 class FooFieldBVTest {

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/generatorprovider/package-info.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/spi/generatorprovider/package-info.java
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.annotation;
 
-import org.instancio.internal.generator.domain.internet.EmailGenerator;
-
-final class JakartaBeanValidationAnnotationConsumer extends AbstractAnnotationConsumer {
-
-    JakartaBeanValidationAnnotationConsumer() {
-        putPrimary(() -> jakarta.validation.constraints.Email.class,
-                ((annotation, context) -> new EmailGenerator(context)));
-    }
-
-    @Override
-    protected AnnotationHandlerMap getAnnotationHandlerMap() {
-        return JakartaBeanValidationHandlerMap.getInstance();
-    }
-}
+/**
+ * Tests for using custom generator provider with Bean Validation.
+ *
+ * @see org.instancio.spi.InstancioServiceProvider.GeneratorProvider
+ * @see org.spi.SampleSpiBV
+ */
+package org.instancio.test.beanvalidation.spi.generatorprovider;

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/spi/SampleSpiBV.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/spi/SampleSpiBV.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.spi;
+
+import org.annotations.CollectionSizeOne;
+import org.annotations.StringSuffix;
+import org.instancio.Node;
+import org.instancio.generator.Generator;
+import org.instancio.generator.specs.CollectionGeneratorSpec;
+import org.instancio.generator.specs.StringGeneratorSpec;
+import org.instancio.spi.InstancioServiceProvider;
+
+import java.lang.reflect.Field;
+
+public class SampleSpiBV implements InstancioServiceProvider {
+
+    @Override
+    public GeneratorProvider getGeneratorProvider() {
+        return (node, generators) -> {
+            Field field = node.getField();
+
+            if (field != null && field.getName().equals("foo")) {
+                return (Generator<?>) random -> "foo";
+            }
+            return null;
+        };
+    }
+
+    @Override
+    public AnnotationProcessor getAnnotationProcessor() {
+        return new AnnotationProcessor() {
+
+            @AnnotationHandler
+            void stringSuffix(StringSuffix annotation, StringGeneratorSpec spec, Node node) {
+                spec.suffix(annotation.value());
+            }
+
+            @AnnotationHandler
+            void collectionSizeOne(CollectionSizeOne annotation, CollectionGeneratorSpec<?> spec, Node node) {
+                spec.size(1);
+            }
+        };
+    }
+}

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
@@ -1,1 +1,1 @@
-org.spi.SampleSpi
+org.spi.SampleSpiBV

--- a/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomAnnotationProcessor.java
+++ b/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomAnnotationProcessor.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.example.spi;
+
+import org.instancio.Node;
+import org.instancio.generator.specs.InstantSpec;
+import org.instancio.generator.specs.LocalDateSpec;
+import org.instancio.generator.specs.LongSpec;
+import org.instancio.generator.specs.MapGeneratorSpec;
+import org.instancio.generator.specs.NumberGeneratorSpec;
+import org.instancio.generator.specs.StringGeneratorSpec;
+import org.instancio.spi.InstancioServiceProvider;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Warning: annotation processing is not invoked on any types
+ * that are handled by {@link CustomGeneratorProvider}.
+ */
+public class CustomAnnotationProcessor implements InstancioServiceProvider {
+
+    private static final AtomicInteger DUPLICATE_HANDLER_INVOCATION_COUNT = new AtomicInteger();
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface WithKeys {
+        String[] value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface CustomLongMin {
+        long value();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface CustomLongMax {
+        long value();
+    }
+
+    /**
+     * Since we have a custom string generator defined in {@link CustomGeneratorProvider},
+     * annotation processing on strings should not be invoked (this annotation should be ignored).
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface EmptyString {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface PastLocalDate {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnnotationForHandlerWithTooFewArgs {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnnotationForHandlerWithTooManyArgs {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface AnnotationWithTwoAnnotationHandlerMethods {
+    }
+
+    public static int getDuplicateHandlerInvocationCount() {
+        return DUPLICATE_HANDLER_INVOCATION_COUNT.get();
+    }
+
+    @Override
+    public AnnotationProcessor getAnnotationProcessor() {
+        return new AnnotationProcessorImpl();
+    }
+
+    public static class AnnotationProcessorImpl implements AnnotationProcessor {
+
+        @AnnotationHandler
+        void withKeys(final WithKeys annotation, final MapGeneratorSpec<String, ?> spec, final Node node) {
+            assertThat(node.getTargetClass()).isEqualTo(Map.class);
+
+            spec.withKeys(annotation.value());
+        }
+
+        @AnnotationHandler
+        void customLongMin(final CustomLongMin annotation, final LongSpec spec, final Node node) {
+            spec.min(annotation.value());
+        }
+
+        @AnnotationHandler
+        void customLongMax(final CustomLongMax annotation, final LongSpec spec, final Node node) {
+            spec.max(annotation.value());
+        }
+
+        @AnnotationHandler
+        void emptyString(final EmptyString annotation, final StringGeneratorSpec spec) {
+            failIfCalled();
+        }
+
+        @AnnotationHandler
+        void dupe1(final AnnotationWithTwoAnnotationHandlerMethods annotation, final NumberGeneratorSpec<Long> spec) {
+            incrementInvocationCount(spec);
+        }
+
+        @AnnotationHandler
+        void dupe2(final AnnotationWithTwoAnnotationHandlerMethods annotation, final NumberGeneratorSpec<Long> spec) {
+            incrementInvocationCount(spec);
+        }
+
+        private static void incrementInvocationCount(final NumberGeneratorSpec<Long> spec) {
+            long next = DUPLICATE_HANDLER_INVOCATION_COUNT.incrementAndGet();
+            spec.min(next).max(next);
+        }
+
+        /**
+         * This method should be ignored because the 1st argument is not an annotation.
+         */
+        @AnnotationHandler
+        void handlerWithInvalidAnnotationParameter(final Object invalidArg, final StringGeneratorSpec spec) {
+            failIfCalled();
+        }
+
+        /**
+         * This method should be ignored because the spec class is not valid for the given annotation.
+         */
+        @AnnotationHandler
+        void handlerWithInvalidGeneratorSpecParameter(final PastLocalDate annotation, final InstantSpec invalidSpec) {
+            failIfCalled();
+        }
+
+        /**
+         * This method should be ignored.
+         */
+        @AnnotationHandler
+        void handlerWithZeroArgs() {
+            failIfCalled();
+        }
+
+        @AnnotationHandler
+        void handlerWithTooFewArgs(final AnnotationForHandlerWithTooFewArgs annotation) {
+            failIfCalled();
+        }
+
+        @AnnotationHandler
+        void handlerWithTooManyArgs(
+                final AnnotationForHandlerWithTooManyArgs annotation,
+                final LocalDateSpec spec,
+                final Node node,
+                final Object extraArg) { // extra args not allowed
+
+            failIfCalled();
+        }
+    }
+
+    private static void failIfCalled() {
+        throw new AssertionError("Should not be called");
+    }
+}

--- a/instancio-tests/spi-tests/src/test/java/org/external/validation/AnnotationProcessorSpiValidationTest.java
+++ b/instancio-tests/spi-tests/src/test/java/org/external/validation/AnnotationProcessorSpiValidationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.validation;
+
+import org.example.spi.CustomAnnotationProcessor;
+import org.example.spi.CustomAnnotationProcessor.AnnotationForHandlerWithTooFewArgs;
+import org.example.spi.CustomAnnotationProcessor.AnnotationForHandlerWithTooManyArgs;
+import org.example.spi.CustomAnnotationProcessor.PastLocalDate;
+import org.instancio.Instancio;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * Tests for annotation processor SPI validation.
+ *
+ * @see CustomAnnotationProcessor
+ */
+@ExtendWith(InstancioExtension.class)
+class AnnotationProcessorSpiValidationTest {
+
+    /**
+     * The {@code @AnnotationHandler} method specifies invalid
+     * generator spec in the method signature.
+     */
+    @Test
+    void handlerWithInvalidSpec() {
+        class Pojo {
+            @PastLocalDate
+            LocalDate value;
+        }
+
+        Throwable ex = catchThrowable(() -> Instancio.create(Pojo.class));
+
+        assertThat(ex).isExactlyInstanceOf(InstancioApiException.class);
+
+        assertThat(normalised(ex.getMessage())).isEqualTo(normalised("""
+                Error creating an object
+                 -> at org.external.validation.AnnotationProcessorSpiValidationTest.lambda$handlerWithInvalidSpec$0(AnnotationProcessorSpiValidationTest.java:53)
+
+                Reason: invalid @AnnotationHandler method defined by org.example.spi.CustomAnnotationProcessor$AnnotationProcessorImpl
+
+                    @AnnotationHandler
+                    handlerWithInvalidGeneratorSpecParameter(CustomAnnotationProcessor$PastLocalDate, InstantSpec)
+
+                 -> Annotation ...............: CustomAnnotationProcessor$PastLocalDate
+                 -> Annotated type ...........: LocalDate
+                 -> Resolved generator spec ..: LocalDateGenerator
+                 -> Specified generator ......: InstantSpec (not valid)
+                 -> Matched node .............: field AnnotationProcessorSpiValidationTest$1Pojo.value (depth=1)
+
+                 │ Path to root:
+                 │   <1:AnnotationProcessorSpiValidationTest$1Pojo: LocalDate value>
+                 │    └──<0:AnnotationProcessorSpiValidationTest$1Pojo>   <-- Root
+                 │
+                 │ Format: <depth:class: field>
+
+                To resolve this issue:
+
+                 -> check if the annotated type is compatible with the annotation
+                 -> update the @AnnotationHandler method signature by specifying the correct generator spec class
+
+                The accepted signatures for @AnnotationHandler methods are:
+
+                 -> void example(Annotation annotation, GeneratorSpec<?> spec)
+                 -> void example(Annotation annotation, GeneratorSpec<?> spec, Node node)
+
+                where:
+
+                 - 'annotation' and 'spec' parameters can be subtypes of Annotation and GeneratorSpec, respectively.
+                 - 'node' parameter is optional.
+
+                Example:
+
+                  @Retention(RetentionPolicy.RUNTIME)
+                  public @interface HexString {
+                      int length();
+                  }
+
+                  @AnnotationHandler
+                  void handleZipCode(HexString annotation, StringGeneratorSpec spec) {
+                      spec.hex().length(annotation.length());
+                  }
+                """));
+    }
+
+    @Test
+    void handlerWithTooFewArgs() {
+        class Pojo {
+            @AnnotationForHandlerWithTooFewArgs
+            LocalDate value;
+        }
+
+        assertThatThrownBy(() -> Instancio.create(Pojo.class))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContainingAll(
+                        "handlerWithTooFewArgs",
+                        "Invalid number of method parameters: 1",
+                        "The accepted signatures for @AnnotationHandler methods are:");
+    }
+
+    @Test
+    void handlerWithTooManyArgs() {
+        class Pojo {
+            @AnnotationForHandlerWithTooManyArgs
+            LocalDate value;
+        }
+
+        assertThatThrownBy(() -> Instancio.create(Pojo.class))
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContainingAll(
+                        "handlerWithTooManyArgs",
+                        "Invalid number of method parameters: 4",
+                        "The accepted signatures for @AnnotationHandler methods are:");
+    }
+
+    private static String normalised(String s) {
+        return s.replace("\r", "").trim();
+    }
+}

--- a/instancio-tests/spi-tests/src/test/java/org/external/validation/package-info.java
+++ b/instancio-tests/spi-tests/src/test/java/org/external/validation/package-info.java
@@ -13,25 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.spi;
 
-import org.instancio.generator.Generator;
-import org.instancio.spi.InstancioServiceProvider;
-
-import java.lang.reflect.Field;
-
-public class SampleSpi implements InstancioServiceProvider {
-
-    @Override
-    public GeneratorProvider getGeneratorProvider() {
-        return (node, generators) -> {
-            Field field = node.getField();
-
-            if (field != null && field.getName().equals("foo")) {
-                return (Generator<?>) random -> "foo";
-            }
-            return null;
-        };
-    }
-
-}
+/**
+ * These tests are under {@code org.external} package because reported locations
+ * filter stacktrace elements containing {@code org.instancio}.
+ */
+package org.external.validation;

--- a/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/AnnotationProcessorSpiTest.java
+++ b/instancio-tests/spi-tests/src/test/java/org/instancio/spi/tests/AnnotationProcessorSpiTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.spi.tests;
+
+import org.example.spi.CustomAnnotationProcessor;
+import org.example.spi.CustomAnnotationProcessor.AnnotationWithTwoAnnotationHandlerMethods;
+import org.example.spi.CustomAnnotationProcessor.CustomLongMax;
+import org.example.spi.CustomAnnotationProcessor.CustomLongMin;
+import org.example.spi.CustomAnnotationProcessor.EmptyString;
+import org.example.spi.CustomAnnotationProcessor.WithKeys;
+import org.example.spi.CustomGeneratorProvider;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+/**
+ * Tests for annotation processor SPI.
+ *
+ * @see CustomAnnotationProcessor
+ */
+@ExtendWith(InstancioExtension.class)
+class AnnotationProcessorSpiTest {
+
+    @Test
+    void customAnnotation() {
+        class Pojo {
+            @WithKeys({"foo", "bar"})
+            Map<CharSequence, Long> map;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.map).containsKeys("foo", "bar");
+    }
+
+    @Test
+    void generatorProviderTakesPrecedenceOverAnnotationProcessor() {
+        class Pojo {
+            // since GeneratorProvider takes precedence, this annotation is ignored
+            @EmptyString
+            String value;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.value).isEqualTo(CustomGeneratorProvider.STRING_GENERATOR_VALUE);
+    }
+
+    @Test
+    void multipleAnnotations() {
+        class Pojo {
+            @CustomLongMin(-1)
+            @CustomLongMax(-1)
+            long value;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(result.value).isEqualTo(-1);
+    }
+
+    @Test
+    void annotationWithTwoAnnotationHandlerMethods() {
+        class Pojo {
+            @AnnotationWithTwoAnnotationHandlerMethods
+            long value;
+        }
+
+        final Pojo result = Instancio.create(Pojo.class);
+
+        assertThat(CustomAnnotationProcessor.getDuplicateHandlerInvocationCount()).isEqualTo(2);
+        assertThat(result.value).isEqualTo(2);
+    }
+
+    @Test
+    void shouldBeAbleToOverrideAnnotationsViaApi() {
+        class Pojo {
+            @CustomLongMin(-1)
+            @CustomLongMax(-1)
+            long value;
+        }
+
+        final Pojo result = Instancio.of(Pojo.class)
+                .set(field("value"), -2)
+                .create();
+
+        assertThat(result.value).isEqualTo(-2);
+    }
+}

--- a/instancio-tests/spi-tests/src/test/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
+++ b/instancio-tests/spi-tests/src/test/resources/META-INF/services/org.instancio.spi.InstancioServiceProvider
@@ -1,3 +1,4 @@
 org.example.spi.CustomTypeProvider
 org.example.spi.CustomGeneratorProvider
 org.example.spi.CustomSetterMethodResolver
+org.example.spi.CustomAnnotationProcessor

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2724,6 +2724,7 @@ It defines the following methods, which return `null` by default and can be over
 
 - `GeneratorProvider getGeneratorProvider()`
 - `TypeResolver getTypeResolver()`
+- `AnnotationProcessor getAnnotationProcessor()`
 - `TypeInstantiator getTypeInstantiator()`
 
 An implementation of `InstancioServiceProvider` can be registered by creating
@@ -2954,6 +2955,105 @@ assertThat(animal).isExactlyInstanceOf(Cat.class);
     Using `TypeResolver` it is also possible to resolve implementation classes
     via classpath scanning, for example, using a third-party library.
     For a sample implementation, see [`type-resolver-sample`](https://github.com/instancio/instancio-samples).
+
+
+## `AnnotationProcessor`
+
+!!! info "This is an experimental API available since version `4.5.0`"
+
+This interface allows processing custom annotations:
+
+```java
+interface AnnotationProcessor {
+    // no methods to implement
+}
+```
+
+It has no methods to implement. Instead, it relies on user-defined methods marked with
+the `@AnnotationHandler` annotation. The accepted signatures for `@AnnotationHandler` methods are:
+
+```java
+@AnnotationHandler
+void example(Annotation annotation, GeneratorSpec<?> spec, Node node)
+
+@AnnotationHandler
+void example(Annotation annotation, GeneratorSpec<?> spec)
+```
+
+The `annotation` and `spec` parameters can be subtypes `java.lang.annotation.Annotation`
+and `org.instancio.generator.GeneratorSpec`, respectively.
+The `node` parameter is optional, and can be omitted if it's not needed.
+
+### Use Case
+
+The main use case for implementing the `AnnotationProcessor` is to customise generated values
+based on custom annotations. Let's assume we have the following annotations and a POJO:
+
+```java linenums="1"  hl_lines="13 14"
+@Target({ElementType.FIELD, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Hex {
+    int length();
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MapWithKeys {
+    String[] value();
+}
+
+class Pojo {
+    @MapWithKeys({"foo", "bar"})
+    private Map<String, @Hex(length = 10) String> map;
+}
+```
+!!! attention ""
+    <lnum>13</lnum> The `@MapWithKeys` annotation specifies that a given `Map` must contain given keys.<br/>
+    <lnum>14</lnum> the `@Hex` annotation denotes that a string must be a hexadecimal value of the specified `length()`.<br/>
+
+
+Our `Pojo` declares a `Map` that should contain hexadecimal strings as values.
+The keys can be arbitrary strings, but the map should contain `foo` and `bar`.
+To achieve this, we can implement an `AnnotationProcessor` as shown below.
+
+```java linenums="1" hl_lines="3 4 8 9"
+public class AnnotationProcessorImpl implements AnnotationProcessor {
+
+    @AnnotationHandler
+    void withKeys(MapWithKeys annotation, MapGeneratorSpec<String, ?> mapSpec) {
+        mapSpec.withKeys(annotation.values());
+    }
+
+    @AnnotationHandler
+    void hexString(Hex annotation, StringGeneratorSpec stringSpec) {
+        stringSpec.hex().length(annotation.length());
+    }
+}
+```
+!!! attention ""
+    <lnum>3,8</lnum> methods must be annotated with `@AnnotationHandler`.<br/>
+    <lnum>4,9</lnum> the third parameter (`Node`) is omitted as it's not needed in this example.<br/>
+
+Instancio will use methods marked with `@AnnotationHandler` to process the annotations.
+The first argument must be the annotation, and the second is the `GeneratorSpec`
+applicable to the annotated type (to find the specific spec interface, see the
+`org.instancio.generator.specs` package [Javadoc](https://javadoc.io/doc/org.instancio/instancio-core/latest/org/instancio/generator/specs/package-summary.html)
+or the `org.instancio.generators.Generators` class).
+
+Once the above is in place, the following snippet:
+
+```java
+Pojo pojo = Instancio.create(Pojo.class);
+```
+
+should produce output similar to:
+
+```
+Pojo[map={bar=2F5E92847B, NGJKQBQ=25F845DB67, foo=824D732CAA, ODDVXUPESM=2EDB5EB46A}]
+```
+
+It should be noted that the `AnnotationProcessor` can only be used to customise
+existing generators. To define a custom `Generator` for a given annotation,
+use a custom [`GeneratorProvider`](#generatorprovider).
 
 
 ## `TypeInstantiator`


### PR DESCRIPTION
This PR introduces `AnnotationProcessor` interface for defining custom logic for processing annotations.

- See: #913


For example, given the following annotations and POJO:

```java
@Target({ElementType.FIELD, ElementType.TYPE_USE})
@Retention(RetentionPolicy.RUNTIME)
public @interface Hex { int length(); }

@Retention(RetentionPolicy.RUNTIME)
public @interface MapWithKeys { String[] value(); }

class Pojo {
    @MapWithKeys({"foo", "bar"})
    private Map<String, @Hex(length = 10) String> map = new HashMap<>();
}
```

A sample implementation might look like:

```java
public class SampleInstancioServiceProvider implements InstancioServiceProvider {
    @Override
    public AnnotationProcessor getAnnotationProcessor() {
        return new AnnotationProcessorImpl();
    }

    private static class AnnotationProcessorImpl implements AnnotationProcessor {
        @AnnotationHandler
        void withKeys(MapWithKeys annotation, MapGeneratorSpec<String, ?> mapSpec) {
            mapSpec.withKeys(annotation.value());
        }

        @AnnotationHandler
        void hexString(Hex annotation, StringGeneratorSpec stringSpec) {
            stringSpec.hex().length(annotation.length());
        }
    }
}
```

Sample usage:

```java
@Test
void shouldCreateMapBasedOnAnnotations() {
    Pojo result = Instancio.create(Pojo.class);

    // Sample output:
    // Pojo[map={bar=2F5E92847B, NGJKQBQ=25F845DB67, foo=824D732CAA, ODDVXUPESM=2EDB5EB46A}]

    assertThat(result.getMap())
            .hasSizeGreaterThan(2)
            .containsKeys("foo", "bar");

    assertThat(result.getMap().values()).allSatisfy(value ->
            assertThat(value).as("Hex value of length 10").matches("^[0-9A-F]{10}$"));
}
```


