### PR TITLE
New setting `StringType.NUMERIC_SEQUENCE` for generating sequential strings

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
@@ -41,6 +41,7 @@ public class StringGenerator extends AbstractGenerator<String>
 
     protected int minLength;
     protected int maxLength;
+    private long sequence;
     private boolean allowEmpty;
     private String prefix;
     private String suffix;
@@ -226,6 +227,9 @@ public class StringGenerator extends AbstractGenerator<String>
 
     @NotNull
     private String generateString(final Random random) {
+        if (stringType == StringType.NUMERIC_SEQUENCE) {
+            return String.valueOf(++sequence);
+        }
         final int length = random.intRange(minLength, maxLength);
 
         return stringType == StringType.UNICODE
@@ -311,10 +315,10 @@ public class StringGenerator extends AbstractGenerator<String>
                 Chars.LC_HEX,
                 Chars.UC_HEX,
                 Chars.MC_HEX),
-        UNICODE(
-                new char[0],
-                new char[0],
-                new char[0]);
+
+        NUMERIC_SEQUENCE(),
+
+        UNICODE();
 
         final char[] lowerCaseChars;
         final char[] upperCaseChars;
@@ -325,6 +329,10 @@ public class StringGenerator extends AbstractGenerator<String>
             this.lowerCaseChars = lowerCaseChars;
             this.upperCaseChars = upperCaseChars;
             this.mixedCaseChars = mixedCaseChars;
+        }
+
+        StringType() {
+            this(new char[0], new char[0], new char[0]);
         }
 
         private static final class Chars {

--- a/instancio-core/src/main/java/org/instancio/settings/StringType.java
+++ b/instancio-core/src/main/java/org/instancio/settings/StringType.java
@@ -20,6 +20,7 @@ import org.instancio.documentation.ExperimentalApi;
 /**
  * A setting that specifies the type of {@code String} to generate.
  *
+ * @see Keys#STRING_TYPE
  * @since 4.7.0
  */
 @ExperimentalApi
@@ -44,6 +45,7 @@ public enum StringType {
     /**
      * Represents a string that consists of digits {@code [0-9]}.
      *
+     * @see #NUMERIC_SEQUENCE
      * @since 4.7.0
      */
     DIGITS,
@@ -55,6 +57,15 @@ public enum StringType {
      * @since 4.7.0
      */
     HEX,
+
+    /**
+     * Represents a string sequence that starts from {@code "1"}
+     * and increments by one.
+     *
+     * @see #DIGITS
+     * @since 4.7.0
+     */
+    NUMERIC_SEQUENCE,
 
     /**
      * Represents a Unicode string that consists of random

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/string/StringGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/string/StringGeneratorTest.java
@@ -21,8 +21,10 @@ import org.instancio.generator.specs.StringGeneratorSpec;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
+import org.instancio.settings.StringType;
 import org.instancio.test.support.asserts.StringAssertExtras;
 import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.pojo.misc.StringFields;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.Character.UnicodeBlock;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -108,6 +111,23 @@ class StringGeneratorTest {
         @Test
         void digits() {
             assertThat(create(StringGeneratorSpec::digits)).containsOnlyDigits();
+        }
+
+        @Test
+        void numericSequence() {
+            final List<StringFields> result = Instancio.ofList(StringFields.class)
+                    .size(2)
+                    .withSetting(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE)
+                    .create();
+
+            assertThat(result.get(0).getOne()).isEqualTo("1");
+            assertThat(result.get(0).getTwo()).isEqualTo("2");
+            assertThat(result.get(0).getThree()).isEqualTo("3");
+            assertThat(result.get(0).getFour()).isEqualTo("4");
+            assertThat(result.get(1).getOne()).isEqualTo("5");
+            assertThat(result.get(1).getTwo()).isEqualTo("6");
+            assertThat(result.get(1).getThree()).isEqualTo("7");
+            assertThat(result.get(1).getFour()).isEqualTo("8");
         }
 
         @Nested

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
@@ -21,6 +21,7 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
+import org.instancio.settings.StringType;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.Character.UnicodeBlock;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -103,7 +105,7 @@ class StringSpecTest extends AbstractValueSpecTestTemplate<String> {
 
     @Nested
     @ExtendWith(InstancioExtension.class)
-    class DisallowEmpty {
+    class DisallowEmptyTest {
 
         @WithSettings
         private final Settings settings = Settings.create()
@@ -114,6 +116,24 @@ class StringSpecTest extends AbstractValueSpecTestTemplate<String> {
             final List<String> results = spec().allowEmpty(false).list(500);
 
             assertThat(results).hasSize(500).doesNotContain("");
+        }
+    }
+
+    @Nested
+    @ExtendWith(InstancioExtension.class)
+    class NumericSequenceTest {
+
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE);
+
+        @Test
+        void numericSequence() {
+            final List<String> results = spec().list(500);
+
+            assertThat(results).isEqualTo(IntStream.rangeClosed(1, 500)
+                    .mapToObj(String::valueOf)
+                    .collect(Collectors.toList()));
         }
     }
 }


### PR DESCRIPTION
The new type can be set using the `Keys.STRING_TYPE` setting or `instancio.properties`:

```
string.type=NUMERIC_SEQUENCE
```

Example:

```java
record Phone(String countryCode, String number) {}

List<Phone> phones = Instancio.ofList(Phone.class)
    .withSetting(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE)
    .create();

// Sample output:
// [Phone[countryCode=1,number=2],
//  Phone[countryCode=3,number=4],
//  Phone[countryCode=5,number=6]]
```

This setting can be combined with `Keys.STRING_FIELD_PREFIX_ENABLED` to produce sequential strings that are prefixed with field name:

```java
List<Phone> phones = Instancio.ofList(Phone.class)
    .withSetting(Keys.STRING_FIELD_PREFIX_ENABLED, true)
    .withSetting(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE)
    .create();

// Sample output:
// [Phone[countryCode=countryCode_1,number=number_2],
//  Phone[countryCode=countryCode_3,number=number_4],
//  Phone[countryCode=countryCode_5,number=number_6]]
```
