### PR TITLE
Add `numericSequence()` to string generator spec

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/StringGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/StringGeneratorSpec.java
@@ -16,6 +16,8 @@
 package org.instancio.generator.specs;
 
 import org.instancio.documentation.ExperimentalApi;
+import org.instancio.settings.Keys;
+import org.instancio.settings.StringType;
 
 import java.lang.Character.UnicodeBlock;
 
@@ -66,6 +68,8 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * by {@link String#length()}, or the number of code points when
      * generating a {@link #unicode(UnicodeBlock...)} string.
      *
+     * <p>This method has no effect if {@link #numericSequence()} is specified.
+     *
      * @param length exact length to generate
      * @return spec builder
      */
@@ -75,6 +79,8 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * Specifies the length of the string to generate as returned
      * by {@link String#length()}, or the number of code points when
      * generating a {@link #unicode(UnicodeBlock...)} string.
+     *
+     * <p>This method has no effect if {@link #numericSequence()} is specified.
      *
      * @param minLength minimum length (inclusive)
      * @param maxLength maximum length (inclusive)
@@ -87,6 +93,8 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * by {@link String#length()}, or the number of code points when
      * generating a {@link #unicode(UnicodeBlock...)} string.
      *
+     * <p>This method has no effect if {@link #numericSequence()} is specified.
+     *
      * @param length minimum length (inclusive)
      * @return spec builder
      * @since 1.0.1
@@ -97,6 +105,8 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * Specifies the maximum length of the string to generate as returned
      * by {@link String#length()}, or the number of code points when
      * generating a {@link #unicode(UnicodeBlock...)} string.
+     *
+     * <p>This method has no effect if {@link #numericSequence()} is specified.
      *
      * @param length maximum length (inclusive)
      * @return spec builder
@@ -113,6 +123,7 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      *
      * <ul>
      *   <li>{@link #digits()}</li>
+     *   <li>{@link #numericSequence()}</li>
      *   <li>{@link #unicode(UnicodeBlock...)}</li>
      * </ul>
      *
@@ -129,6 +140,7 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      *
      * <ul>
      *   <li>{@link #digits()}</li>
+     *   <li>{@link #numericSequence()}</li>
      *   <li>{@link #unicode(UnicodeBlock...)}</li>
      * </ul>
      *
@@ -145,6 +157,7 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      *
      * <ul>
      *   <li>{@link #digits()}</li>
+     *   <li>{@link #numericSequence()}</li>
      *   <li>{@link #unicode(UnicodeBlock...)}</li>
      * </ul>
      *
@@ -156,6 +169,9 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * Generates an alphanumeric string, uppercase by default,
      * that consists of characters {@code [0-9A-Z]}.
      *
+     * <p>The equivalent {@link Keys#STRING_TYPE} setting
+     * is {@link StringType#ALPHANUMERIC}.
+     *
      * @return spec builder
      * @see #upperCase()
      * @see #lowerCase()
@@ -166,6 +182,9 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
     /**
      * Generates a string that consists of digits {@code [0-9]}.
      *
+     * <p>The equivalent {@link Keys#STRING_TYPE} setting
+     * is {@link StringType#DIGITS}.
+     *
      * @return spec builder
      */
     StringGeneratorSpec digits();
@@ -174,6 +193,9 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * Generates a hexadecimal string, uppercase by default,
      * that consists of characters {@code [0-9A-F]}
      *
+     * <p>The equivalent {@link Keys#STRING_TYPE} setting
+     * is {@link StringType#HEX}.
+     *
      * @return spec builder
      * @see #upperCase()
      * @see #lowerCase()
@@ -181,6 +203,19 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * @since 2.11.0
      */
     StringGeneratorSpec hex();
+
+    /**
+     * Generates a string sequence that starts from {@code "1"}
+     * and increments by one.
+     *
+     * <p>The equivalent {@link Keys#STRING_TYPE} setting
+     * is {@link StringType#NUMERIC_SEQUENCE}.
+     *
+     * @return spec builder
+     * @since 4.7.0
+     */
+    @ExperimentalApi
+    StringGeneratorSpec numericSequence();
 
     /**
      * Generates a Unicode string that consists of random
@@ -218,6 +253,9 @@ public interface StringGeneratorSpec extends NullableGeneratorSpec<String> {
      * // Sample output:
      * // Comment[text="ф😬😅😟фҖӝ😲ЭӍ"]
      * }</pre>
+     *
+     * <p>The equivalent {@link Keys#STRING_TYPE} setting
+     * is {@link StringType#UNICODE}.
      *
      * @param blocks Unicode blocks to use when generating strings,
      *               or no argument to generate code points from random blocks

--- a/instancio-core/src/main/java/org/instancio/generator/specs/StringSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/StringSpec.java
@@ -81,6 +81,14 @@ public interface StringSpec extends ValueSpec<String>, StringGeneratorSpec {
      * @since 4.7.0
      */
     @Override
+    StringSpec numericSequence();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 4.7.0
+     */
+    @Override
     @ExperimentalApi
     StringSpec unicode(Character.UnicodeBlock... blocks);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/StringGenerator.java
@@ -197,6 +197,12 @@ public class StringGenerator extends AbstractGenerator<String>
     }
 
     @Override
+    public StringGenerator numericSequence() {
+        stringType = StringType.NUMERIC_SEQUENCE;
+        return this;
+    }
+
+    @Override
     public StringGenerator unicode(Character.UnicodeBlock... blocks) {
         stringType = StringType.UNICODE;
         unicodeBlocks = Arrays.asList(blocks);

--- a/instancio-core/src/main/java/org/instancio/settings/StringType.java
+++ b/instancio-core/src/main/java/org/instancio/settings/StringType.java
@@ -16,9 +16,17 @@
 package org.instancio.settings;
 
 import org.instancio.documentation.ExperimentalApi;
+import org.instancio.generator.specs.StringGeneratorSpec;
 
 /**
  * A setting that specifies the type of {@code String} to generate.
+ * String type can be set using the {@link Keys#STRING_TYPE}:
+ *
+ * <pre>{@code
+ * Person person = Instancio.of(Person.class)
+ *     .withSetting(Keys.STRING_TYPE, StringType.ALPHANUMERIC) // all strings alphanumeric
+ *     .create();
+ * }</pre>
  *
  * @see Keys#STRING_TYPE
  * @since 4.7.0
@@ -38,6 +46,9 @@ public enum StringType {
      * Represents an alphanumeric string, uppercase by default,
      * that consists of characters {@code [0-9A-Z]}.
      *
+     * <p>The equivalent string generator spec method is
+     * {@link StringGeneratorSpec#alphaNumeric()}.
+     *
      * @since 4.7.0
      */
     ALPHANUMERIC,
@@ -45,7 +56,9 @@ public enum StringType {
     /**
      * Represents a string that consists of digits {@code [0-9]}.
      *
-     * @see #NUMERIC_SEQUENCE
+     * <p>The equivalent string generator spec method is
+     * {@link StringGeneratorSpec#digits()}.
+     *
      * @since 4.7.0
      */
     DIGITS,
@@ -53,6 +66,9 @@ public enum StringType {
     /**
      * Represents a hexadecimal string, uppercase by default,
      * that consists of characters {@code [0-9A-F]}
+     *
+     * <p>The equivalent string generator spec method is
+     * {@link StringGeneratorSpec#hex()}.
      *
      * @since 4.7.0
      */
@@ -62,7 +78,9 @@ public enum StringType {
      * Represents a string sequence that starts from {@code "1"}
      * and increments by one.
      *
-     * @see #DIGITS
+     * <p>The equivalent string generator spec method is
+     * {@link StringGeneratorSpec#numericSequence()}.
+     *
      * @since 4.7.0
      */
     NUMERIC_SEQUENCE,
@@ -76,6 +94,9 @@ public enum StringType {
      *   <li>{@link Character#SURROGATE}</li>
      *   <li>{@link Character#UNASSIGNED}</li>
      * </ul>
+     *
+     * <p>The equivalent string generator spec method is
+     * {@link StringGeneratorSpec#unicode(Character.UnicodeBlock...)}.
      *
      * @since 4.7.0
      */

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/string/StringGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/string/StringGeneratorTest.java
@@ -21,7 +21,6 @@ import org.instancio.generator.specs.StringGeneratorSpec;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.settings.StringType;
 import org.instancio.test.support.asserts.StringAssertExtras;
 import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.pojo.misc.StringFields;
@@ -117,7 +116,7 @@ class StringGeneratorTest {
         void numericSequence() {
             final List<StringFields> result = Instancio.ofList(StringFields.class)
                     .size(2)
-                    .withSetting(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE)
+                    .generate(allStrings(), gen -> gen.string().numericSequence())
                     .create();
 
             assertThat(result.get(0).getOne()).isEqualTo("1");

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/StringSpecTest.java
@@ -21,7 +21,6 @@ import org.instancio.junit.InstancioExtension;
 import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
-import org.instancio.settings.StringType;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.Nested;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.Character.UnicodeBlock;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -70,6 +68,11 @@ class StringSpecTest extends AbstractValueSpecTestTemplate<String> {
         assertThat(spec().mixedCase().length(20).get()).isMixedCase();
         assertThat(spec().alphaNumeric().length(20).get()).isAlphanumeric();
         assertThat(spec().digits().get()).containsOnlyDigits();
+    }
+
+    @Test
+    void numericSequence() {
+        assertThat(spec().numericSequence().list(3)).containsExactly("1", "2", "3");
     }
 
     @Test
@@ -116,24 +119,6 @@ class StringSpecTest extends AbstractValueSpecTestTemplate<String> {
             final List<String> results = spec().allowEmpty(false).list(500);
 
             assertThat(results).hasSize(500).doesNotContain("");
-        }
-    }
-
-    @Nested
-    @ExtendWith(InstancioExtension.class)
-    class NumericSequenceTest {
-
-        @WithSettings
-        private final Settings settings = Settings.create()
-                .set(Keys.STRING_TYPE, StringType.NUMERIC_SEQUENCE);
-
-        @Test
-        void numericSequence() {
-            final List<String> results = spec().list(500);
-
-            assertThat(results).isEqualTo(IntStream.rangeClosed(1, 500)
-                    .mapToObj(String::valueOf)
-                    .collect(Collectors.toList()));
         }
     }
 }


### PR DESCRIPTION
Add the string generator spec method equivalent to the recently added `StringType.NUMERIC_SEQUENCE` setting.

- #1019