### PR TITLE
New top-level APIs for creating blank objects

### DIFF
--- a/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
+++ b/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
@@ -196,6 +196,15 @@ public interface CartesianProductApi<T> extends
     /**
      * {@inheritDoc}
      *
+     * @since 4.7.0
+     */
+    @Override
+    @ExperimentalApi
+    CartesianProductApi<T> withBlank(TargetSelector selector);
+
+    /**
+     * {@inheritDoc}
+     *
      * @since 4.0.0
      */
     @Override

--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -156,6 +156,54 @@ public final class Instancio {
     }
 
     /**
+     * Creates a blank object of the specified class.
+     *
+     * <p>The created object will have the following properties:
+     *
+     * <ul>
+     *   <li>value fields (strings, numbers, dates, etc) are {@code null}</li>
+     *   <li>arrays, collections, and maps are empty</li>
+     *   <li>nested POJOs are blank</li>
+     * </ul>
+     *
+     * <p>For example, assuming the following POJO:
+     *
+     * <pre>{@code
+     * class Person {
+     *     String name;
+     *     LocalDate dateOfBirth;
+     *     List<Phone> phoneNumbers;
+     *     Address address;
+     * }
+     * }</pre>
+     *
+     * <p>Creating a blank {@code Person} object will produce:
+     *
+     * <pre>{@code
+     * Person person = Instancio.createBlank(Person.class);
+     *
+     * // Output:
+     * // Person[
+     * //   name=null,
+     * //   dateOfBirth=null,
+     * //   phoneNumbers=[] // empty List
+     * //   address=Address[street=null, city=null, country=null] // blank nested POJO
+     * // ]
+     * }</pre>
+     *
+     * @param type the type of blank object to create
+     * @param <T>  the type of object
+     * @return a blank object of the specified type
+     * @see InstancioOperations#withBlank(TargetSelector)
+     * @see #ofBlank(Class)
+     * @since 4.7.0
+     */
+    @ExperimentalApi
+    public static <T> T createBlank(final Class<T> type) {
+        return ofBlank(type).create();
+    }
+
+    /**
      * Creates a {@link List} of random size.
      *
      * <p>Unless configured otherwise, the generated size will be between
@@ -328,6 +376,52 @@ public final class Instancio {
      */
     public static <T> InstancioOfClassApi<T> of(final Class<T> type) {
         return new OfClassApiImpl<>(type);
+    }
+
+    /**
+     * Builder version of the {@link #createBlank(Class)} method
+     * that allows customisation of generated values.
+     *
+     * <p>For example, assuming the following POJO:
+     *
+     * <pre>{@code
+     * class Person {
+     *     String name;
+     *     LocalDate dateOfBirth;
+     *     List<Phone> phoneNumbers;
+     *     Address address;
+     * }
+     * }</pre>
+     *
+     * <p>The snippet below will create a blank {@code Person} object
+     * with two initialised fields:
+     *
+     * <pre>{@code
+     * Person person = Instancio.ofBlank(Person.class)
+     *     .set(field(Address::getCountry), "Canada")
+     *     .generate(field(Person::getDateOfBirth), gen -> gen.temporal().localDate().past())
+     *     .create()
+     *
+     * // Sample output:
+     * // Person[
+     * //   name=null,
+     * //   dateOfBirth=1990-12-29,
+     * //   phoneNumbers=[]
+     * //   address=Address[street=null, city=null, country=Canada]
+     * //]
+     * }</pre>
+     *
+     * @param type the type of blank object to create
+     * @param <T>  the type of object
+     * @return API builder reference
+     * @see InstancioOperations#withBlank(TargetSelector)
+     * @since 4.7.0
+     */
+    @ExperimentalApi
+    public static <T> InstancioOfClassApi<T> ofBlank(final Class<T> type) {
+        final InstancioOfClassApi<T> api = new OfClassApiImpl<>(type);
+        api.withBlank(Select.root());
+        return api;
     }
 
     /**

--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -208,6 +208,15 @@ public interface InstancioApi<T> extends
     /**
      * {@inheritDoc}
      *
+     * @since 4.7.0
+     */
+    @Override
+    @ExperimentalApi
+    InstancioApi<T> withBlank(TargetSelector selector);
+
+    /**
+     * {@inheritDoc}
+     *
      * @since 1.4.0
      */
     @Override

--- a/instancio-core/src/main/java/org/instancio/InstancioOperations.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioOperations.java
@@ -585,4 +585,38 @@ interface InstancioOperations<T> {
      * @since 4.0.0
      */
     InstancioOperations<T> withSeed(long seed);
+
+    /**
+     * Specifies that a blank object should be generated for the selected target.
+     *
+     * <p>A blank object has the following properties:
+     *
+     * <ul>
+     *   <li>value fields (strings, numbers, dates, etc) are {@code null}</li>
+     *   <li>arrays, collections, and maps are empty</li>
+     *   <li>nested POJOs are blank</li>
+     * </ul>
+     *
+     * <p>Example:
+     * <pre>{@code
+     * Person person = Instancio.of(Person.class)
+     *     .withBlank(field(Person::getAddress))
+     *     .create();
+     *
+     * // Output:
+     * // Person[
+     * //   name="GNQTXA",
+     * //   dateOfBirth=1988-04-09,
+     * //   address=Address[street=null, city=null, country=null] // blank Address
+     * //]
+     * }</pre>
+     *
+     * @param selector for fields and/or classes this method should be applied to
+     * @return API builder reference
+     * @see Instancio#createBlank(Class)
+     * @see Instancio#ofBlank(Class)
+     * @since 4.7.0
+     */
+    @ExperimentalApi
+    InstancioOperations<T> withBlank(TargetSelector selector);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -146,6 +146,12 @@ public class ApiImpl<T> implements InstancioApi<T> {
     }
 
     @Override
+    public InstancioApi<T> withBlank(final TargetSelector selector) {
+        modelContextBuilder.withBlank(selector);
+        return this;
+    }
+
+    @Override
     public InstancioApi<T> withSeed(final long seed) {
         modelContextBuilder.withSeed(seed);
         return this;

--- a/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
@@ -156,6 +156,12 @@ public class CartesianProductApiImpl<T> implements CartesianProductApi<T> {
     }
 
     @Override
+    public CartesianProductApi<T> withBlank(final TargetSelector selector) {
+        modelContextBuilder.withBlank(selector);
+        return this;
+    }
+
+    @Override
     public CartesianProductApi<T> withSeed(final long seed) {
         modelContextBuilder.withSeed(seed);
         return this;

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/BaseSelector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/BaseSelector.java
@@ -28,11 +28,18 @@ abstract class BaseSelector implements UnusedSelectorDescription, InternalSelect
     private final List<Scope> scopes;
     private final Throwable stackTraceHolder;
     private final boolean isLenient;
+    private final boolean isHiddenFromVerboseOutput;
 
-    BaseSelector(final List<Scope> scopes, final Throwable stackTraceHolder, final boolean isLenient) {
+    BaseSelector(
+            final List<Scope> scopes,
+            final Throwable stackTraceHolder,
+            final boolean isLenient,
+            final boolean isHiddenFromVerboseOutput) {
+
         this.scopes = Collections.unmodifiableList(scopes);
         this.stackTraceHolder = stackTraceHolder;
         this.isLenient = isLenient;
+        this.isHiddenFromVerboseOutput = isHiddenFromVerboseOutput;
     }
 
     @NotNull
@@ -49,6 +56,11 @@ abstract class BaseSelector implements UnusedSelectorDescription, InternalSelect
     @Override
     public final boolean isLenient() {
         return isLenient;
+    }
+
+    @Override
+    public final boolean isHiddenFromVerboseOutput() {
+        return isHiddenFromVerboseOutput;
     }
 
     @Override

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/BlankSelectors.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/BlankSelectors.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.selectors;
+
+import org.instancio.documentation.InternalApi;
+import org.instancio.internal.nodes.InternalNode;
+import org.instancio.internal.nodes.NodeKind;
+
+import java.util.Collections;
+import java.util.function.Predicate;
+
+@InternalApi
+public final class BlankSelectors {
+    private static final int PRIORITY = Integer.MAX_VALUE; // lowest priority
+
+    private static final InternalSelector ARRAY_SELECTOR = new BlankSelector(
+            node -> node.is(NodeKind.ARRAY), "arraySelector()");
+
+    private static final InternalSelector COLLECTION_SELECTOR = new BlankSelector(
+            node -> node.is(NodeKind.COLLECTION), "collectionSelector()");
+
+    private static final InternalSelector MAP_SELECTOR = new BlankSelector(
+            node -> node.is(NodeKind.MAP), "mapSelector()");
+
+    private static final InternalSelector LEAF_SELECTOR = new BlankSelector(
+            node -> node.getChildren().isEmpty() && node.getParent() != null
+                    && !node.getParent().is(NodeKind.ARRAY)
+                    && !node.getParent().is(NodeKind.COLLECTION)
+                    && !node.getParent().is(NodeKind.MAP),
+            "leafSelector()");
+
+    public static InternalSelector arraySelector() {
+        return ARRAY_SELECTOR;
+    }
+
+    public static InternalSelector collectionSelector() {
+        return COLLECTION_SELECTOR;
+    }
+
+    public static InternalSelector mapSelector() {
+        return MAP_SELECTOR;
+    }
+
+    public static InternalSelector leafSelector() {
+        return LEAF_SELECTOR;
+    }
+
+    private static final class BlankSelector extends PredicateSelectorImpl {
+        private BlankSelector(final Predicate<InternalNode> predicate, final String description) {
+            super(PRIORITY,
+                    predicate,
+                    Collections.emptyList(),
+                    /* depth = */ null,
+                    /* isLenient = */ true,
+                    /* isHiddenFromVerboseOutput = */ true,
+                    description,
+                    new Throwable());
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s.%s.lenient() [internal]",
+                    BlankSelectors.class.getSimpleName(),
+                    getApiInvocationDescription());
+        }
+    }
+
+    private BlankSelectors() {
+        // non-instantiable
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/InternalSelector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/InternalSelector.java
@@ -16,6 +16,7 @@
 
 package org.instancio.internal.selectors;
 
+import org.instancio.InstancioApi;
 import org.instancio.Scope;
 import org.instancio.ScopeableSelector;
 import org.instancio.TargetSelector;
@@ -36,4 +37,10 @@ public interface InternalSelector extends ScopeableSelector, Flattener<TargetSel
     List<Scope> getScopes();
 
     boolean isLenient();
+
+    /**
+     * Specifies whether this selector should be reported in
+     * the output produced by {@link InstancioApi#verbose()}.
+     */
+    boolean isHiddenFromVerboseOutput();
 }

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/PredicateSelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/PredicateSelectorImpl.java
@@ -51,10 +51,11 @@ public class PredicateSelectorImpl extends BaseSelector implements PredicateSele
             final List<Scope> scopes,
             final SelectorDepth selectorDepth,
             final boolean isLenient,
+            final boolean isHiddenFromVerboseOutput,
             final String apiInvocationDescription,
             final Throwable stackTraceHolder) {
 
-        super(scopes, stackTraceHolder, isLenient);
+        super(scopes, stackTraceHolder, isLenient, isHiddenFromVerboseOutput);
         this.priority = priority;
         this.nodePredicate = nodePredicate;
         this.selectorDepth = selectorDepth;
@@ -68,6 +69,7 @@ public class PredicateSelectorImpl extends BaseSelector implements PredicateSele
                 builder.scopes,
                 builder.selectorDepth,
                 builder.isLenient,
+                builder.isHiddenFromVerboseOutput,
                 defaultIfNull(builder.apiInvocationDescription, DEFAULT_SELECTOR_DESCRIPTION),
                 defaultIfNull(builder.stackTraceHolder, Throwable::new));
     }
@@ -80,6 +82,10 @@ public class PredicateSelectorImpl extends BaseSelector implements PredicateSele
      */
     public int getPriority() {
         return priority;
+    }
+
+    protected final String getApiInvocationDescription() {
+        return apiInvocationDescription;
     }
 
     public Predicate<InternalNode> getNodePredicate() {
@@ -140,6 +146,7 @@ public class PredicateSelectorImpl extends BaseSelector implements PredicateSele
         builder.stackTraceHolder = getStackTraceHolder();
         builder.selectorDepth = selectorDepth;
         builder.isLenient = isLenient();
+        builder.isHiddenFromVerboseOutput = isHiddenFromVerboseOutput();
         return builder;
     }
 
@@ -153,6 +160,7 @@ public class PredicateSelectorImpl extends BaseSelector implements PredicateSele
         private List<Scope> scopes = new ArrayList<>(0);
         private SelectorDepth selectorDepth;
         private boolean isLenient;
+        private boolean isHiddenFromVerboseOutput;
         private String apiInvocationDescription;
         private Throwable stackTraceHolder;
 

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/SelectorImpl.java
@@ -58,7 +58,7 @@ public final class SelectorImpl extends BaseSelector implements Selector, Groupa
                          @Nullable final Integer depth,
                          final boolean isLenient) {
 
-        super(scopes, stackTraceHolder, isLenient);
+        super(scopes, stackTraceHolder, isLenient, /*isHiddenFromVerboseOutput*/ false);
         this.target = target;
         this.parent = parent;
         this.depth = depth;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankAssignTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankAssignTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.generators.Generators;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringsGhi;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Assign.valueOf;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.BLANK, Feature.ASSIGN})
+@ExtendWith(InstancioExtension.class)
+class BlankAssignTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void copyValueOfNullField() {
+        final StringsGhi result = Instancio.ofBlank(StringsGhi.class)
+                .assign(valueOf(StringsGhi::getG).to(StringsGhi::getH))
+                .create();
+
+        assertThat(result.g).isEqualTo(result.h).isNull();
+    }
+
+    @Test
+    void copyValueOfNonNullField() {
+        final StringsGhi result = Instancio.ofBlank(StringsGhi.class)
+                .generate(field(StringsGhi::getG), Generators::string)
+                .assign(valueOf(StringsGhi::getG).to(StringsGhi::getH))
+                .create();
+
+        assertThat(result.g).isEqualTo(result.h).isNotBlank();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankCartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankCartesianProductTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.BLANK, Feature.CARTESIAN_PRODUCT})
+@ExtendWith(InstancioExtension.class)
+class BlankCartesianProductTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void cartesianProduct_withBlankRoot() {
+        final List<StringsAbc> results = Instancio.ofCartesianProduct(StringsAbc.class)
+                .with(field(StringsAbc::getA), "A")
+                .with(field(StringsAbc::getB), "B1", "B2")
+                .withBlank(root())
+                .list();
+
+        assertThat(results).allSatisfy(result -> {
+            assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+            assertThatObject(result.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+        });
+
+        assertThat(results).extracting(StringsAbc::getA).containsExactly("A", "A");
+        assertThat(results).extracting(StringsAbc::getB).containsExactly("B1", "B2");
+    }
+
+    @Test
+    void cartesianProduct_withBlankNestedPojo() {
+        final List<StringsAbc> results = Instancio.ofCartesianProduct(StringsAbc.class)
+                .with(field(StringsAbc::getA), "A")
+                .with(field(StringsAbc::getB), "B1", "B2")
+                .withBlank(field(StringsAbc::getDef))
+                .list();
+
+        assertThat(results).allSatisfy(result -> {
+            assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+            assertThatObject(result.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+        });
+
+        assertThat(results).extracting(StringsAbc::getA).containsExactly("A", "A");
+        assertThat(results).extracting(StringsAbc::getB).containsExactly("B1", "B2");
+    }
+
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankClassWithoutFieldsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankClassWithoutFieldsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.ClassWithoutFields;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.BLANK)
+@ExtendWith(InstancioExtension.class)
+class BlankClassWithoutFieldsTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    /**
+     * Ensure that unused selector error is not thrown when calling
+     * {@code createBlank()} on a class without fields
+     * (that is, the leaf selector used internally should be lenient).
+     */
+    @Test
+    void emptyClass() {
+        final ClassWithoutFields result = Instancio.createBlank(ClassWithoutFields.class);
+
+        assertThat(result).isNotNull();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankModelTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+import static org.instancio.Select.root;
+
+@FeatureTag({Feature.BLANK, Feature.MODEL})
+@ExtendWith(InstancioExtension.class)
+class BlankModelTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void createFromBlankModel() {
+        final Model<StringHolder> model = Instancio.ofBlank(StringHolder.class).toModel();
+
+        final StringHolder result = Instancio.create(model);
+
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void createFromBlankModelWithSelector() {
+        final Model<StringHolder> model = Instancio.ofBlank(StringHolder.class)
+                .set(field(StringHolder::getValue), "foo")
+                .toModel();
+
+        final StringHolder result = Instancio.create(model);
+
+        assertThat(result.getValue()).isEqualTo("foo");
+    }
+
+    @Test
+    void createFromModel_withBlankObject() {
+        final Model<StringHolder> model = Instancio.of(StringHolder.class).toModel();
+
+        final StringHolder result = Instancio.of(model)
+                .withBlank(root())
+                .create();
+
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void createFromModelWithSelector_withBlankObject() {
+        final Model<StringHolder> model = Instancio.of(StringHolder.class)
+                .set(fields().named("value"), "foo")
+                .toModel();
+
+        final StringHolder result = Instancio.of(model)
+                .withBlank(root())
+                .create();
+
+        assertThat(result.getValue()).isEqualTo("foo");
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankOfCollectionApiTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankOfCollectionApiTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.exception.InstancioException;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({
+        Feature.BLANK,
+        Feature.OF_LIST,
+        Feature.OF_MAP,
+        Feature.OF_SET,
+})
+@ExtendWith(InstancioExtension.class)
+class BlankOfCollectionApiTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void ofList() {
+        final List<StringHolder> results = Instancio.ofList(StringHolder.class)
+                .withBlank(all(StringHolder.class))
+                .create();
+
+        assertThat(results).isNotEmpty()
+                .allSatisfy(obj -> assertThatObject(obj).hasAllFieldsOfTypeSetToNull(String.class));
+    }
+
+    @Test
+    void ofListWithSelector() {
+        final List<StringHolder> results = Instancio.ofList(StringHolder.class)
+                .withBlank(all(StringHolder.class))
+                .set(field(StringHolder::getValue), "foo")
+                .create();
+
+        assertThat(results).isNotEmpty()
+                .extracting(StringHolder::getValue)
+                .containsOnly("foo");
+    }
+
+    @Test
+    void ofMap() {
+        final Map<StringHolder, Long> results = Instancio.ofMap(StringHolder.class, Long.class)
+                // disable FAIL_ON_ERROR because we can't populate a set with more than
+                // one element (by default, min size is 2, which would result an an error)
+                .withSetting(Keys.FAIL_ON_ERROR, false)
+                .withBlank(all(StringHolder.class))
+                .create();
+
+        assertThat(results.keySet()).hasSize(1)
+                .allSatisfy(obj -> assertThatObject(obj).hasAllFieldsOfTypeSetToNull(String.class));
+    }
+
+    @Test
+    void ofSet_withFailOnErrorDisabled() {
+        final Set<StringHolder> results = Instancio.ofSet(StringHolder.class)
+                // disable FAIL_ON_ERROR because we can't populate a set with more than
+                // one element (by default, min size is 2, which would result an an error)
+                .withSetting(Keys.FAIL_ON_ERROR, false)
+                .withBlank(all(StringHolder.class))
+                .create();
+
+        assertThat(results).hasSize(1)
+                .allSatisfy(obj -> assertThatObject(obj).hasAllFieldsOfTypeSetToNull(String.class));
+    }
+
+    @Test
+    void ofSet_withFailOnErrorEnabled() {
+        final InstancioApi<Set<StringHolder>> api = Instancio.ofSet(StringHolder.class)
+                .withBlank(all(StringHolder.class));
+
+        assertThatThrownBy(api::create)
+                .isExactlyInstanceOf(InstancioException.class)
+                .hasMessageContaining("unable to populate Collection of size");
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankOnCompleteTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankOnCompleteTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.person.Address;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.pojo.person.Pet;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.types;
+
+@FeatureTag({Feature.BLANK, Feature.ON_COMPLETE})
+@ExtendWith(InstancioExtension.class)
+class BlankOnCompleteTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void onComplete() {
+        final List<Class<?>> callbackTypes = new ArrayList<>();
+
+        Instancio.ofBlank(Person.class)
+                .onComplete(types(), o -> callbackTypes.add(o.getClass()))
+                .create();
+
+        // Callbacks only called on these types because everything else is null
+        assertThat(callbackTypes).containsExactlyInAnyOrder(
+                Address.class, Person.class, Pet[].class, ArrayList.class);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankRootObjectTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankRootObjectTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.exception.InstancioException;
+import org.instancio.generators.Generators;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.pojo.nested.OuterClass;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.allStrings;
+import static org.instancio.Select.field;
+import static org.instancio.Select.scope;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+/**
+ * Tests for creating a blank root object using:
+ *
+ * <ul>
+ *   <li>{@link Instancio#createBlank(Class)}</li>
+ *   <li>{@link Instancio#ofBlank(Class)}</li>
+ * </ul>
+ */
+@FeatureTag(Feature.BLANK)
+@ExtendWith(InstancioExtension.class)
+class BlankRootObjectTest {
+
+    /**
+     * Tests for {@link Instancio#createBlank(Class)}.
+     */
+    @Nested
+    class CreateBlankTest {
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.FAIL_ON_ERROR, true);
+
+        @Test
+        void rootObjectIsASimpleValueType() {
+            assertThat(Instancio.createBlank(String.class)).isNotBlank();
+            assertThat(Instancio.createBlank(Integer.class)).isNotNull();
+        }
+
+        @Test
+        void rootObjectIsAPojo() {
+            final Pojo result = Instancio.createBlank(Pojo.class);
+
+            assertThat(result.string).isNull();
+            assertThat(result.primitive).isZero();
+            assertThat(result.optionalStringHolder).isNotEmpty();
+            assertThat(result.optionalStringHolder.get().getValue()).isNull();
+            assertThat(result.optionalString).isEmpty();
+            assertThat(result.listString).isEmpty();
+            assertThat(result.listStringHolder).isEmpty();
+            assertThat(result.mapStringHolderLong).isEmpty();
+            assertThat(result.mapLongStringHolder).isEmpty();
+            assertThat(result.arrayString).isEmpty();
+            assertThat(result.arrayStringHolder).isEmpty();
+            assertThatObject(result.stringsAbc).hasAllFieldsOfTypeSetToNull(String.class);
+            assertThatObject(result.stringsAbc.def).hasAllFieldsOfTypeSetToNull(String.class);
+            assertThatObject(result.stringsAbc.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+        }
+    }
+
+    /**
+     * Tests for {@link Instancio#ofBlank(Class)}.
+     */
+    @Nested
+    class OfBlankTest {
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.FAIL_ON_ERROR, true);
+
+        @Test
+        void overrideArrayLength() {
+            final int length = 5;
+            final Pojo result = Instancio.ofBlank(Pojo.class)
+                    .generate(field(Pojo::getArrayString), gen -> gen.array().length(length))
+                    .generate(field(Pojo::getArrayStringHolder), gen -> gen.array().length(length))
+                    .create();
+
+            assertThat(result.getArrayString()).hasSize(length).doesNotContainNull();
+            assertThat(result.getArrayStringHolder()).hasSize(length)
+                    .allSatisfy(e -> assertThat(e.getValue()).isNull());
+        }
+
+        @Test
+        void overrideCollectionSize() {
+            final int size = 5;
+            final Pojo result = Instancio.ofBlank(Pojo.class)
+                    .generate(field(Pojo::getListString), gen -> gen.collection().size(size))
+                    .generate(field(Pojo::getListStringHolder), gen -> gen.collection().size(size))
+                    .create();
+
+            assertThat(result.getListString()).hasSize(size).doesNotContainNull();
+            assertThat(result.getListStringHolder()).hasSize(size)
+                    .allSatisfy(e -> assertThat(e.getValue()).isNull());
+        }
+
+        @Test
+        void overrideMapSize() {
+            final int size = 1;
+            final Pojo result = Instancio.ofBlank(Pojo.class)
+                    .generate(field(Pojo::getMapStringHolderLong), gen -> gen.map().size(size))
+                    .generate(field(Pojo::getMapLongStringHolder), gen -> gen.map().size(size))
+                    .create();
+
+            assertThat(result.getMapStringHolderLong()).hasSize(size);
+            assertThat(result.getMapStringHolderLong().keySet()).doesNotContainNull()
+                    .allSatisfy(stringHolder -> assertThat(stringHolder.getValue()).isNull());
+            assertThat(result.getMapStringHolderLong().values()).doesNotContainNull();
+
+            assertThat(result.getMapLongStringHolder()).hasSize(size);
+            assertThat(result.getMapLongStringHolder().keySet()).doesNotContainNull();
+            assertThat(result.getMapLongStringHolder().values()).doesNotContainNull()
+                    .allSatisfy(stringHolder -> assertThat(stringHolder.getValue()).isNull());
+        }
+
+        @Test
+        void mapWithSizeGreaterThanOne() {
+            final int size = 2;
+            final InstancioApi<Pojo> api = Instancio.ofBlank(Pojo.class)
+                    .generate(field(Pojo::getMapStringHolderLong), gen -> gen.map().size(size));
+
+            // Since the key is always a blank POJO, we can't generate distinct keys
+            assertThatThrownBy(api::create)
+                    .isExactlyInstanceOf(InstancioException.class)
+                    .hasMessageContaining("unable to populate Map of size %d", size);
+        }
+
+        @Test
+        void overrideOptionalString() {
+            final Pojo result = Instancio.ofBlank(Pojo.class)
+                    .generate(allStrings().within(scope(Pojo::getOptionalString)), Generators::string)
+                    .create();
+
+            assertThat(result.getOptionalString()).isNotEmpty();
+            assertThat(result.getOptionalString().get()).isNotBlank();
+        }
+
+
+        @Test
+        void rootObjectIsAPojo() {
+            class Container {
+                List<OuterClass> list;
+            }
+
+            final Container result = Instancio.ofBlank(Container.class)
+                    .generate(field("list"), gen -> gen.collection().size(1))
+                    .create();
+
+            assertThat(result.list).hasSize(1).allSatisfy((OuterClass outer) -> {
+                assertThat(outer.getInnerClass().getValue()).isNull();
+                assertThat(outer.getInnerStaticClass().getValue()).isNull();
+                assertThat(outer.getInnermostStaticClass().getValue()).isNull();
+            });
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static final class Pojo {
+        private String string;
+        private int primitive;
+        private Optional<StringHolder> optionalStringHolder;
+        private Optional<String> optionalString;
+        private List<String> listString;
+        private List<StringHolder> listStringHolder;
+        private Map<Long, StringHolder> mapLongStringHolder; // key is a leaf
+        private Map<StringHolder, Long> mapStringHolderLong; // key is a POJO
+        private String[] arrayString;
+        private StringHolder[] arrayStringHolder;
+        private StringsAbc stringsAbc;
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSelectorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.SelectorGroup;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.pojo.collections.lists.TwoListsOfItemString;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojo;
+import org.instancio.test.support.pojo.cyclic.onetomany.MainPojoContainer;
+import org.instancio.test.support.pojo.generics.basic.Item;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.pojo.misc.StringsDef;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.pojo.person.Phone;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.allInts;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+import static org.instancio.Select.scope;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.BLANK, Feature.SELECTOR})
+@ExtendWith(InstancioExtension.class)
+class BlankSelectorTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void rootSelector() {
+        final StringHolder result = Instancio.of(StringHolder.class)
+                .withBlank(root())
+                .create();
+
+        assertThat(result.getValue()).isNull();
+    }
+
+    @Test
+    void classSelector_nestedPojo() {
+        final StringsAbc result = Instancio.of(StringsAbc.class)
+                .withBlank(all(StringsDef.class))
+                .create();
+
+        assertThat(result.a).isNotBlank();
+        assertThat(result.b).isNotBlank();
+        assertThat(result.c).isNotBlank();
+        assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+    }
+
+    @Test
+    void classSelector_collectionElementPojo() {
+        final Person result = Instancio.of(Person.class)
+                .withBlank(all(Phone.class))
+                .create();
+
+        // blank elements
+        assertThat(result.getAddress().getPhoneNumbers()).isNotEmpty()
+                .allSatisfy(phone -> assertThatObject(phone).hasAllFieldsOfTypeSetToNull(String.class));
+
+        // other fields should be populated
+        assertThat(result.getName()).isNotBlank();
+        assertThat(result.getAddress().getCity()).isNotBlank();
+        assertThat(result.getPets()).isNotEmpty().allSatisfy(pet -> assertThat(pet.getName()).isNotBlank());
+    }
+
+    @Test
+    void classSelector_withScope() {
+        final TwoListsOfItemString result = Instancio.of(TwoListsOfItemString.class)
+                .withBlank(all(Item.class).within(scope(TwoListsOfItemString::getList2)))
+                .create();
+
+        assertThat(result.getList1()).isNotEmpty().allSatisfy(item -> assertThat(item.getValue()).isNotBlank());
+        assertThat(result.getList2()).isNotEmpty().allSatisfy(item -> assertThat(item.getValue()).isNull());
+    }
+
+    @Test
+    void classSelector_withDepth() {
+        final StringsAbc result = Instancio.of(StringsAbc.class)
+                .withBlank(types().atDepth(d -> d > 1))
+                .create();
+
+        assertThat(result.a).isNotBlank();
+        assertThat(result.b).isNotBlank();
+        assertThat(result.c).isNotBlank();
+        assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+    }
+
+    @Test
+    void selectorGroup() {
+        final SelectorGroup group = all(
+                field(MainPojoContainer::getMainPojo1),
+                field(MainPojo::getDetailPojos).within(scope(MainPojoContainer::getMainPojo2)));
+
+        final MainPojoContainer result = Instancio.of(MainPojoContainer.class)
+                .withBlank(group)
+                .create();
+
+        assertThat(result.getMainPojo1().getId()).isNull();
+        assertThat(result.getMainPojo2().getId()).isNotNull();
+
+        assertThat(result.getMainPojo1().getDetailPojos()).isEmpty();
+        assertThat(result.getMainPojo2().getDetailPojos()).isEmpty();
+    }
+
+    /**
+     * Blank selectors are lenient and should not trigger the unused selector error.
+     */
+    @Test
+    void unmatchedBlankSelector_shouldBeSilentlyIgnored() {
+        final StringHolder result = Instancio.of(StringHolder.class)
+                .withBlank(allInts())
+                .create();
+
+        assertThat(result.getValue()).isNotBlank();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSetModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSetModelTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.pojo.misc.StringsDef;
+import org.instancio.test.support.pojo.misc.StringsGhi;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.BLANK, Feature.SET_MODEL})
+@ExtendWith(InstancioExtension.class)
+class BlankSetModelTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void setBlankModel_toNonBlankObject() {
+        final Model<StringsDef> blanknModel = Instancio.ofBlank(StringsDef.class)
+                .set(field(StringsGhi::getH), "H")
+                .toModel();
+
+        final StringsAbc result = Instancio.of(StringsAbc.class)
+                .setModel(all(StringsDef.class), blanknModel)
+                .create();
+
+        assertThat(result.a).isNotBlank();
+        assertThat(result.b).isNotBlank();
+        assertThat(result.c).isNotBlank();
+        assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThat(result.def.ghi.g).isNull();
+        assertThat(result.def.ghi.h).isEqualTo("H");
+        assertThat(result.def.ghi.i).isNull();
+    }
+
+    @Test
+    void setBlankModel_toBlankObject() {
+        final Model<StringsDef> blankModel = Instancio.ofBlank(StringsDef.class)
+                .set(fields().named("h"), "H")
+                .toModel();
+
+        // set blank model on blank object
+        final StringsAbc result = Instancio.ofBlank(StringsAbc.class)
+                .setModel(all(StringsDef.class), blankModel)
+                .create();
+
+        assertThatObject(result).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThat(result.def.ghi.g).isNull();
+        assertThat(result.def.ghi.h).isEqualTo("H");
+        assertThat(result.def.ghi.i).isNull();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSubtypeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankSubtypeTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.person.Address;
+import org.instancio.test.support.pojo.person.Phone;
+import org.instancio.test.support.pojo.person.PhoneWithType;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.BLANK, Feature.SUBTYPE})
+@ExtendWith(InstancioExtension.class)
+class BlankSubtypeTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void subtype() {
+        final Address result = Instancio.ofBlank(Address.class)
+                .subtype(all(Phone.class), PhoneWithType.class)
+                .generate(field(Address::getPhoneNumbers), gen -> gen.collection().size(3))
+                .create();
+
+        assertThat(result.getPhoneNumbers()).hasSize(3).allSatisfy(phone -> {
+            assertThat(phone).isExactlyInstanceOf(PhoneWithType.class);
+            assertThat(phone.getCountryCode()).isNull();
+            assertThat(phone.getNumber()).isNull();
+            assertThat(((PhoneWithType) phone).getPhoneType()).isNull();
+        });
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankVerboseTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankVerboseTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.person.Address;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.tags.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+
+@FeatureTag(Feature.CARTESIAN_PRODUCT)
+@ExtendWith(InstancioExtension.class)
+class BlankVerboseTest {
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @BeforeEach
+    void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(standardOut);
+    }
+
+    /**
+     * Disable Method Assignment since that affects the {@code verbose()}
+     * output (by including setter methods).
+     */
+    @Test
+    @RunWith.FieldAssignmentOnly
+    void verbose() {
+        Instancio.ofBlank(Person.class)
+                .withBlank(all(Address.class))
+                .withBlank(field(Address::getCity))
+                .withBlank(fields().named("country"))
+                .verbose()
+                .create();
+
+        final String actual = outputStreamCaptor.toString()
+                .replaceAll("\r", "")
+                .replaceAll("\n", "");
+
+        // The selector specified by the user should be reported in verbose output,
+        // but blank selectors should not be included.
+        assertThat(actual).contains("### Selectors" +
+                "Selectors and matching nodes, if any:" +
+                "________________________________________________________________________________________"
+        );
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithCustomGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithCustomGeneratorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.Random;
+import org.instancio.generator.AfterGenerate;
+import org.instancio.generator.Generator;
+import org.instancio.generator.Hints;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.pojo.misc.StringsDef;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.instancio.Select.all;
+import static org.instancio.Select.types;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+@FeatureTag({Feature.BLANK, Feature.GENERATOR, Feature.SUPPLY})
+@ExtendWith(InstancioExtension.class)
+class BlankWithCustomGeneratorTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    private final Generator<StringsDef> pojoGenerator = new Generator<StringsDef>() {
+        @Override
+        public StringsDef generate(final Random random) {
+            return StringsDef.builder()
+                    .d("D")
+                    .e("E")
+                    .build();
+        }
+
+        @Override
+        public Hints hints() {
+            return Hints.afterGenerate(AfterGenerate.POPULATE_ALL);
+        }
+    };
+
+    @Test
+    void withPojoGenerator() {
+        final StringsAbc result = Instancio.ofBlank(StringsAbc.class)
+                .supply(all(StringsDef.class), pojoGenerator)
+                .create();
+
+        // The values assigned to the POJO's fields by the custom generator are overwritten.
+        // This is because to create a blank, a predicate selector is used internally
+        // to set all leaf nodes to null, which overwrites custom generator values.
+        assertThatObject(result).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+    }
+
+    @Test
+    void withStringGenerator() {
+        final Generator<String> generator = random -> "foo";
+        final StringsAbc result = Instancio.ofBlank(StringsAbc.class)
+                .supply(types().of(String.class), generator)
+                .create();
+
+        assertThatObject(result).hasAllFieldsOfTypeEqualTo(String.class, "foo");
+        assertThatObject(result.def).hasAllFieldsOfTypeEqualTo(String.class, "foo");
+        assertThatObject(result.def.ghi).hasAllFieldsOfTypeEqualTo(String.class, "foo");
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithInitialisedFieldsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithInitialisedFieldsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.LongHolderWithDefaults;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.BLANK)
+@ExtendWith(InstancioExtension.class)
+class BlankWithInitialisedFieldsTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void createBlank() {
+        final LongHolderWithDefaults result = Instancio.createBlank(LongHolderWithDefaults.class);
+
+        // The initialised wrapper is overwritten to null, but the primitive is not.
+        // This should probably be fixed for consistency.
+        assertThat(result.getPrimitive()).isEqualTo(LongHolderWithDefaults.PRIMITIVE);
+        assertThat(result.getWrapper()).isNull();
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithTypeParametersTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankWithTypeParametersTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.types;
+
+@FeatureTag({Feature.BLANK, Feature.WITH_TYPE_PARAMETERS})
+@ExtendWith(InstancioExtension.class)
+class BlankWithTypeParametersTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void emptyList() {
+        final List<StringHolder> results = Instancio.ofBlank(List.class)
+                .withTypeParameters(StringHolder.class)
+                .create();
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void nonEmptyList() {
+        final List<StringHolder> results = Instancio.ofBlank(List.class)
+                .withTypeParameters(StringHolder.class)
+                .generate(types().of(Collection.class), gen -> gen.collection().size(5))
+                .create();
+
+        assertThat(results).hasSize(5)
+                .allSatisfy(result -> assertThat(result.getValue()).isNull());
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/WithBlankTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/WithBlankTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.blank;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.TargetSelector;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.instancio.test.support.pojo.basic.StringHolder;
+import org.instancio.test.support.pojo.collections.lists.TwoListsOfItemString;
+import org.instancio.test.support.pojo.collections.lists.TwoListsOfLong;
+import org.instancio.test.support.pojo.misc.StringFields;
+import org.instancio.test.support.pojo.misc.StringsAbc;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+import static org.instancio.test.support.asserts.ReflectionAssert.assertThatObject;
+
+/**
+ * Tests for {@link InstancioApi#withBlank(TargetSelector)}.
+ */
+@FeatureTag(Feature.BLANK)
+@ExtendWith(InstancioExtension.class)
+class WithBlankTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.FAIL_ON_ERROR, true);
+
+    @Test
+    void withBlankField_valueType() {
+        final StringFields result = Instancio.of(StringFields.class)
+                .withBlank(field(StringFields::getOne))
+                .withBlank(field(StringFields::getThree))
+                .create();
+
+        assertThat(result).hasNoNullFieldsOrPropertiesExcept("one", "three");
+    }
+
+    @Test
+    void withBlankField_collectionOfValueType() {
+        final TwoListsOfLong result = Instancio.of(TwoListsOfLong.class)
+                .withBlank(field(TwoListsOfLong::getList1))
+                .create();
+
+        assertThat(result.getList1()).isEmpty();
+        assertThat(result.getList2()).isNotEmpty().doesNotContainNull();
+    }
+
+    @Test
+    void withBlankFieldCollectionOfPojo() {
+        final TwoListsOfItemString result = Instancio.of(TwoListsOfItemString.class)
+                .withBlank(field(TwoListsOfItemString::getList1))
+                .create();
+
+        assertThat(result.getList1()).isEmpty();
+        assertThat(result.getList2()).isNotEmpty()
+                .allSatisfy(item -> assertThat(item.getValue()).isNotBlank());
+    }
+
+    @Test
+    void withBlankFieldCollectionOfPojoAndCollectionOfSizeOverride() {
+        final TwoListsOfItemString result = Instancio.of(TwoListsOfItemString.class)
+                .withBlank(field(TwoListsOfItemString::getList1))
+                .generate(field(TwoListsOfItemString::getList1), gen -> gen.collection().size(2))
+                .create();
+
+        assertThat(result.getList1()).hasSize(2)
+                .allSatisfy(item -> assertThat(item.getValue()).isNull());
+
+        assertThat(result.getList2()).isNotEmpty()
+                .allSatisfy(item -> assertThat(item.getValue()).isNotBlank());
+    }
+
+    @Test
+    void withBlankNestedPojo() {
+        @Getter
+        class Container {
+            // This should be blank
+            Pojo nestedPojo;
+            // These should be populated
+            List<StringHolder> listStringHolder;
+            Map<StringHolder, Long> mapStringHolderLong;
+            StringHolder[] arrayStringHolder;
+        }
+
+        final Container result = Instancio.of(Container.class)
+                .withBlank(field(Container::getNestedPojo))
+                .create();
+
+        assertBlankPojo(result.nestedPojo);
+        assertThatObject(result.listStringHolder).isFullyPopulated();
+        assertThatObject(result.mapStringHolderLong).isFullyPopulated();
+        assertThatObject(result.arrayStringHolder).isFullyPopulated();
+    }
+
+    private static void assertBlankPojo(final Pojo result) {
+        assertThat(result.string).isNull();
+        assertThat(result.primitive).isZero();
+        assertThat(result.optionalStringHolder).isNotEmpty();
+        assertThat(result.optionalStringHolder.get().getValue()).isNull();
+        assertThat(result.optionalString).isEmpty();
+        assertThat(result.listString).isEmpty();
+        assertThat(result.listStringHolder).isEmpty();
+        assertThat(result.mapStringHolderLong).isEmpty();
+        assertThat(result.mapLongStringHolder).isEmpty();
+        assertThat(result.arrayString).isEmpty();
+        assertThat(result.arrayStringHolder).isEmpty();
+        assertThatObject(result.stringsAbc).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.stringsAbc.def).hasAllFieldsOfTypeSetToNull(String.class);
+        assertThatObject(result.stringsAbc.def.ghi).hasAllFieldsOfTypeSetToNull(String.class);
+    }
+
+    @Getter
+    @Setter
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static final class Pojo {
+        private String string;
+        private int primitive;
+        private Optional<StringHolder> optionalStringHolder;
+        private Optional<String> optionalString;
+        private List<String> listString;
+        private List<StringHolder> listStringHolder;
+        private Map<Long, StringHolder> mapLongStringHolder; // key is a leaf
+        private Map<StringHolder, Long> mapStringHolderLong; // key is a POJO
+        private String[] arrayString;
+        private StringHolder[] arrayStringHolder;
+        private StringsAbc stringsAbc;
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this, ToStringStyle.MULTI_LINE_STYLE);
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/CustomPredicateNodeSelectorTest.java
@@ -69,6 +69,7 @@ class CustomPredicateNodeSelectorTest {
                     Collections.emptyList(),
                     /* depth = */ null,
                     /* isLenient = */ false,
+                    /* isHiddenFromVerboseOutput = */ false,
                     apiInvocationDescription,
                     new Throwable());
         }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/BlankSelectorsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/BlankSelectorsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.selectors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BlankSelectorsTest {
+
+    @Test
+    void verifyToString() {
+        assertThat(BlankSelectors.arraySelector())
+                .hasToString("BlankSelectors.arraySelector().lenient() [internal]");
+
+        assertThat(BlankSelectors.collectionSelector())
+                .hasToString("BlankSelectors.collectionSelector().lenient() [internal]");
+
+        assertThat(BlankSelectors.mapSelector())
+                .hasToString("BlankSelectors.mapSelector().lenient() [internal]");
+
+        assertThat(BlankSelectors.leafSelector())
+                .hasToString("BlankSelectors.leafSelector().lenient() [internal]");
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/selectors/SelectorImplTest.java
@@ -47,7 +47,7 @@ class SelectorImplTest {
     void root() {
         final SelectorImpl root = SelectorImpl.getRootSelector();
         assertThat(root).hasAllNullFieldsOrPropertiesExcept(
-                "target", "scopes", "stackTraceHolder", "depth", "hash", "isLenient");
+                "target", "scopes", "stackTraceHolder", "depth", "hash", "isLenient", "isHiddenFromVerboseOutput");
 
         assertThat(root.getScopes()).isEmpty();
     }

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
@@ -101,6 +101,7 @@ public enum Feature {
     SET,
     SET_BACK_REFERENCES,
     SETTINGS,
+    BLANK, // createBlank(), ofBlank(), withBlank() APIs
     STREAM,
     STRING_FIELD_PREFIX,
     STRING_GENERATOR,

--- a/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/BlankRecordTest.java
+++ b/instancio-tests/java16-tests/src/test/java/org/instancio/test/java16/BlankRecordTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java16;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.java16.record.PersonRecord;
+import org.instancio.test.support.java16.record.PhoneRecord;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+
+@FeatureTag(Feature.BLANK)
+@ExtendWith(InstancioExtension.class)
+class BlankRecordTest {
+
+    @Test
+    void blankRecord() {
+        final PersonRecord result = Instancio.createBlank(PersonRecord.class);
+
+        assertThat(result.name()).isNull();
+        assertThat(result.age()).isZero();
+        assertThat(result.address().street()).isNull();
+        assertThat(result.address().city()).isNull();
+        assertThat(result.address().phoneNumbers()).isEmpty();
+    }
+
+    @Test
+    void blankRecordWithSelector() {
+        final PersonRecord result = Instancio.of(PersonRecord.class)
+                .withBlank(all(PhoneRecord.class))
+                .create();
+
+        assertThat(result.name()).isNotBlank();
+        assertThat(result.age()).isPositive();
+        assertThat(result.address().street()).isNotBlank();
+        assertThat(result.address().city()).isNotBlank();
+        assertThat(result.address().phoneNumbers()).isNotEmpty().allSatisfy(phone -> {
+            assertThat(phone.countryCode()).isNull();
+            assertThat(phone.number()).isNull();
+        });
+    }
+}


### PR DESCRIPTION
This PR introduces three new methods for creating blank objects:

- `Instancio.createBlank(Class<T>)`
- `Instancio.ofBlank(Class<T>)`
- `withBlank(TargetSelector)`

A blank object has the following properties

- `null` value fields (strings, numbers, dates)
- blank nested POJOs
- empty arrays and collections

### Examples:

```java
Person person = Instancio.createBlank(Person.class);

// Output:
// Person[
//    name=<null>,
//    dateOfBirth=<null>,
//    phoneNumbers=[] // empty List
//    address=Address[street=<null>, city=<null>, country=<null>] // blank nested POJO
//]
```

Customising the object using the builder API:

```java
Person person = Instancio.ofBlankPerson.class)
    .generate(field(Person::getPhoneNumbers), gen -> gen.collection().size(2))
    .create();

// Output:
// Person[
//    name=<null>,
//    dateOfBirth=<null>,
//    phoneNumbers=[Phone[countryCode=<null>,number=<null>], Phone[countryCode=<null>,number=<null>],
//    address=Address[street=<null>, city=<null>, country=<null>]
//]
```
