### PR TITLE
Renamed the Cartesian product API method `list()` to `create()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
+++ b/instancio-core/src/main/java/org/instancio/CartesianProductApi.java
@@ -33,7 +33,7 @@ import java.util.function.Supplier;
  * <ul>
  *   <li>{@link #with(TargetSelector, Object[])} for specifying product values
  *       (see the method's Javadoc for an example)</li>
- *   <li>{@link #list()} for obtaining the results as a list</li>
+ *   <li>{@link #create()} for obtaining the results as a list</li>
  * </ul>
  *
  * @param <T> type to create
@@ -48,7 +48,7 @@ public interface CartesianProductApi<T> extends
     /**
      * Sets a range of values for generating the Cartesian product.
      * The results are returned as a list in lexicographical order
-     * using the {@link #list()} method.
+     * using the {@link #create()} method.
      *
      * <p>Example:
      * <pre>{@code
@@ -57,7 +57,7 @@ public interface CartesianProductApi<T> extends
      * List<Widget> results = Instancio.ofCartesianProduct(Widget.class)
      *     .with(field(Widget::type), "FOO", "BAR", "BAZ")
      *     .with(field(Widget::num), 1, 2, 3)
-     *     .list();
+     *     .create();
      * }</pre>
      *
      * <p>This will produce the following list of {@code Widget} objects:
@@ -84,7 +84,7 @@ public interface CartesianProductApi<T> extends
      * List<Container> results = Instancio.ofCartesianProduct(Container.class)
      *     .with(field(Widget::type), "FOO", "BAR", "BAZ")
      *     .with(field(Widget::num), 1, 2, 3)
-     *     .list();
+     *     .create();
      * }</pre>
      *
      * <p>The above will produce an error with a message:
@@ -108,7 +108,7 @@ public interface CartesianProductApi<T> extends
      * @since 4.0.0
      */
     @ExperimentalApi
-    List<T> list();
+    List<T> create();
 
     /**
      * {@inheritDoc}

--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -484,7 +484,7 @@ public final class Instancio {
      * List<Widget> results = Instancio.ofCartesianProduct(Widget.class)
      *     .with(field(Widget::type), "FOO", "BAR", "BAZ")
      *     .with(field(Widget::num), 1, 2, 3)
-     *     .list();
+     *     .create();
      * }</pre>
      *
      * <p>This will produce the following list of {@code Widget} objects:

--- a/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
@@ -204,7 +204,7 @@ public class CartesianProductApiImpl<T> implements CartesianProductApi<T> {
     }
 
     @Override
-    public List<T> list() {
+    public List<T> create() {
         final List<List<Object>> cartesianInputs = new ArrayList<>();
         for (CartesianValues rangeValue : cartesianValues) {
             cartesianInputs.add(rangeValue.values);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankCartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankCartesianProductTest.java
@@ -47,7 +47,7 @@ class BlankCartesianProductTest {
                 .setBlank(root())
                 .with(field(StringsAbc::getA), "A")
                 .with(field(StringsAbc::getB), "B1", "B2")
-                .list();
+                .create();
 
         assertThat(results).allSatisfy(result -> {
             assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);
@@ -64,7 +64,7 @@ class BlankCartesianProductTest {
                 .setBlank(field(StringsAbc::getDef))
                 .with(field(StringsAbc::getA), "A")
                 .with(field(StringsAbc::getB), "B1", "B2")
-                .list();
+                .create();
 
         assertThat(results).allSatisfy(result -> {
             assertThatObject(result.def).hasAllFieldsOfTypeSetToNull(String.class);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductAssignTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductAssignTest.java
@@ -44,7 +44,7 @@ class CartesianProductAssignTest {
                 .with(field(IntegerHolder::getWrapper), 3, 4)
                 .assign(valueOf(IntegerHolder::getPrimitive).set(8))
                 .assign(valueOf(IntegerHolder::getWrapper).set(9))
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(8, 8, 8, 8);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(9, 9, 9, 9);
@@ -57,7 +57,7 @@ class CartesianProductAssignTest {
                 .with(field(IntegerHolder::getWrapper), null, null) // placeholders to be overwritten by assign()
                 .assign(given(IntegerHolder::getPrimitive).is(1).set(field(IntegerHolder::getWrapper), 10))
                 .assign(given(IntegerHolder::getPrimitive).is(2).set(field(IntegerHolder::getWrapper), 20))
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 1, 2, 2);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(10, 10, 20, 20);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductIgnoreTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductIgnoreTest.java
@@ -37,7 +37,7 @@ class CartesianProductIgnoreTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .ignore(field(IntegerHolder::getWrapper))
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductModelTest.java
@@ -47,7 +47,7 @@ class CartesianProductModelTest {
         final List<Person> results = Instancio.ofCartesianProduct(model)
                 .with(field(Person::getGender), Gender.MALE, Gender.FEMALE)
                 .with(field(Person::getAge), 30, 40)
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(4)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductNullableTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductNullableTest.java
@@ -46,7 +46,7 @@ class CartesianProductNullableTest {
                 .with(field(IntegerHolder::getPrimitive), range)
                 .with(field(IntegerHolder::getWrapper), range)
                 .withNullable(allInts())
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(range.length * range.length)
@@ -64,7 +64,7 @@ class CartesianProductNullableTest {
                 .with(field(IntegerHolder::getWrapper), range)
                 .withNullable(allInts())
                 .withSettings(Settings.create().set(Keys.COLLECTION_ELEMENTS_NULLABLE, true))
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(range.length * range.length)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductOnCompleteTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductOnCompleteTest.java
@@ -44,7 +44,7 @@ class CartesianProductOnCompleteTest {
                 .with(field(Person::getGender), Gender.FEMALE, Gender.MALE)
                 .with(field(Person::getAge), 30, 40)
                 .onComplete(field(Person::getGender), (Gender g) -> genders.add(g))
-                .list();
+                .create();
 
         assertThat(genders).containsExactly(Gender.FEMALE, Gender.FEMALE, Gender.MALE, Gender.MALE);
     }
@@ -57,7 +57,7 @@ class CartesianProductOnCompleteTest {
                 .with(field(Person::getGender), Gender.FEMALE, Gender.MALE)
                 .with(field(Person::getAge), 30, 40)
                 .onComplete(all(Person.class), val -> callbackCount.incrementAndGet())
-                .list();
+                .create();
 
         assertThat(callbackCount).hasValue(4);
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSeedTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSeedTest.java
@@ -57,7 +57,7 @@ class CartesianProductSeedTest {
         first = Instancio.ofCartesianProduct(new TypeToken<Triplet<Boolean, Boolean, UUID>>() {})
                 .with(field(Triplet.class, "left"), true, false)
                 .with(field(Triplet.class, "mid"), true, false)
-                .list();
+                .create();
 
         final Set<UUID> uuids = first.stream().map(Triplet::getRight).collect(Collectors.toSet());
         assertThat(uuids)
@@ -81,7 +81,7 @@ class CartesianProductSeedTest {
         final List<Triplet<Boolean, Boolean, UUID>> result = Instancio.ofCartesianProduct(new TypeToken<Triplet<Boolean, Boolean, UUID>>() {})
                 .with(field(Triplet.class, "left"), true, false)
                 .with(field(Triplet.class, "mid"), true, false)
-                .list();
+                .create();
 
         assertThat(result).isEqualTo(first);
     }
@@ -94,7 +94,7 @@ class CartesianProductSeedTest {
                 .withSeed(SEED)
                 .with(field(Triplet.class, "left"), true, false)
                 .with(field(Triplet.class, "mid"), true, false)
-                .list();
+                .create();
 
         assertThat(result).isEqualTo(first);
     }
@@ -107,7 +107,7 @@ class CartesianProductSeedTest {
                 .withSettings(Settings.create().set(Keys.SEED, SEED))
                 .with(field(Triplet.class, "left"), true, false)
                 .with(field(Triplet.class, "mid"), true, false)
-                .list();
+                .create();
 
         assertThat(result).isEqualTo(first);
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSelectorTest.java
@@ -57,7 +57,7 @@ class CartesianProductSelectorTest {
     void withAllInts() {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(allInts(), 1, 2)
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 2);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(1, 2);
@@ -69,7 +69,7 @@ class CartesianProductSelectorTest {
                 .with(all(
                         field(IntegerHolder::getPrimitive),
                         field(IntegerHolder::getWrapper)), 1, 2)
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 2);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(1, 2);
@@ -80,7 +80,7 @@ class CartesianProductSelectorTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(types().of(int.class), 1, 2)
                 .with(types().of(Integer.class), 3, 4)
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 1, 2, 2);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(3, 4, 3, 4);
@@ -94,7 +94,7 @@ class CartesianProductSelectorTest {
                 .with(types().of(Integer.class), 3, 4)
                 .set(field(IntegerHolder::getWrapper), 9)
                 .lenient()
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 1, 2, 2);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(9, 9, 9, 9);
@@ -110,7 +110,7 @@ class CartesianProductSelectorTest {
                         .set(Keys.ON_SET_METHOD_NOT_FOUND, OnSetMethodNotFound.IGNORE))
                 .with(setter(DynPerson::setName), "foo", "bar")
                 .with(setter(DynPerson::setAge), 30, 40)
-                .list();
+                .create();
 
         assertThat(results).extracting(DynPerson::getName).containsExactly("foo", "foo", "bar", "bar");
         assertThat(results).extracting(DynPerson::getAge).containsExactly(30, 40, 30, 40);
@@ -120,7 +120,7 @@ class CartesianProductSelectorTest {
     void withRootSelector() {
         final List<DynPerson> results = Instancio.ofCartesianProduct(DynPerson.class)
                 .set(root(), null)
-                .list();
+                .create();
 
         assertThat(results).isNull();
     }
@@ -132,7 +132,7 @@ class CartesianProductSelectorTest {
                 .with(field(IntegerHolder::getWrapper), 3, 4);
 
 
-        assertThatThrownBy(api::list)
+        assertThatThrownBy(api::create)
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("no item is available to emit()");
     }
@@ -143,7 +143,7 @@ class CartesianProductSelectorTest {
         final List<TwoIntegerHolders> results = Instancio.ofCartesianProduct(TwoIntegerHolders.class)
                 .with(field(IntegerHolder::getPrimitive).within(scope(TwoIntegerHolders::getTwo)), -1, -2)
                 .with(field(IntegerHolder::getWrapper).within(scope(TwoIntegerHolders::getTwo)), -3, -4)
-                .list();
+                .create();
 
         assertThat(results)
                 .extracting(r -> r.getTwo().getPrimitive())

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSettingsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSettingsTest.java
@@ -43,7 +43,7 @@ class CartesianProductSettingsTest {
                 .with(field(StringAndPrimitiveFields::getIntOne), INT_ONE)
                 .with(field(StringAndPrimitiveFields::getIntTwo), INT_TWO)
                 .withSetting(Keys.STRING_MAX_LENGTH, 1)
-                .list();
+                .create();
 
         assertResults(results);
     }
@@ -54,7 +54,7 @@ class CartesianProductSettingsTest {
                 .with(field(StringAndPrimitiveFields::getIntOne), INT_ONE)
                 .with(field(StringAndPrimitiveFields::getIntTwo), INT_TWO)
                 .withSettings(Settings.create().set(Keys.STRING_MAX_LENGTH, 1))
-                .list();
+                .create();
 
         assertResults(results);
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSubtypeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSubtypeTest.java
@@ -42,7 +42,7 @@ class CartesianProductSubtypeTest {
         final List<NumberHolder> results = Instancio.ofCartesianProduct(NumberHolder.class)
                 .with(field(NumberHolder::getX), 1, 2, 3)
                 .subtype(field(NumberHolder::getY), Long.class)
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(3)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSupplyGenerateTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductSupplyGenerateTest.java
@@ -38,7 +38,7 @@ class CartesianProductSupplyGenerateTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .generate(field(IntegerHolder::getWrapper), gen -> gen.ints().max(-1))
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2)
@@ -52,7 +52,7 @@ class CartesianProductSupplyGenerateTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .generate(field(IntegerHolder::getWrapper), Gen.ints().range(-1, -1))
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2)
@@ -66,7 +66,7 @@ class CartesianProductSupplyGenerateTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .supply(field(IntegerHolder::getWrapper), () -> -1)
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2)
@@ -80,7 +80,7 @@ class CartesianProductSupplyGenerateTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .supply(field(IntegerHolder::getWrapper), random -> -1)
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductTest.java
@@ -58,7 +58,7 @@ class CartesianProductTest {
     @DisplayName("When no values are specified, should return a single object")
     void withNoValues() {
         final List<StringHolder> results = Instancio.ofCartesianProduct(StringHolder.class)
-                .list();
+                .create();
 
         assertThat(results).singleElement().hasNoNullFieldsOrProperties();
     }
@@ -70,7 +70,7 @@ class CartesianProductTest {
         final List<Triplet<PhoneType, Integer, Boolean>> results = Instancio.ofCartesianProduct(
                         new TypeToken<Triplet<PhoneType, Integer, Boolean>>() {})
                 .with(allInts(), expectedInts)
-                .list();
+                .create();
 
         assertThat(results)
                 .allSatisfy(e -> assertThat(e).hasNoNullFieldsOrProperties())
@@ -85,7 +85,7 @@ class CartesianProductTest {
         final List<Triplet<PhoneType, Integer, Boolean>> results = Instancio.ofCartesianProduct(
                         new TypeToken<Triplet<PhoneType, Integer, Boolean>>() {})
                 .with(all(Integer.class), expectedInts)
-                .list();
+                .create();
 
         assertThat(results)
                 .allSatisfy(e -> assertThat(e).hasNoNullFieldsOrProperties())
@@ -100,7 +100,7 @@ class CartesianProductTest {
                 .with(all(PhoneType.class), PhoneType.CELL, PhoneType.HOME, PhoneType.WORK)
                 .with(allInts(), 1, 2)
                 .with(allBooleans(), true, false)
-                .list();
+                .create();
 
         assertThat(results)
                 .extracting(Triplet::getLeft)
@@ -124,7 +124,7 @@ class CartesianProductTest {
                 .with(field(StringsAbc::getA), "a1", "a2")
                 .with(field(StringsDef::getE), "d1", "d2", "d3")
                 .with(field(StringsGhi::getI), "i1", "i2")
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(2 * 3 * 2)
@@ -155,7 +155,7 @@ class CartesianProductTest {
                 // custom values
                 .set(field(Person::getName), expectedName)
                 .generate(field(Person::getDate), gen -> gen.temporal().date().past())
-                .list();
+                .create();
 
         assertThat(results)
                 .hasSize(6) // 3 genders x 2 age values
@@ -182,7 +182,7 @@ class CartesianProductTest {
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .with(field(IntegerHolder::getWrapper), 3, 4)
                 .set(field(IntegerHolder::getPrimitive), 8)
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive)
                 .as("Should overwrites [1, 1, 2, 2]")
@@ -217,7 +217,7 @@ class CartesianProductTest {
                 // duplicate selectors
                 .with(field(IntegerHolder::getPrimitive), 5, 6)
                 .with(field(IntegerHolder::getWrapper), 7, 8)
-                .list();
+                .create();
 
         assertThat(results).hasSize(16);
 
@@ -236,7 +236,7 @@ class CartesianProductTest {
                 .with(field(IntegerHolder::getPrimitive), range)
                 .with(field(IntegerHolder::getWrapper), range);
 
-        assertThatThrownBy(api::list)
+        assertThatThrownBy(api::create)
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("Cartesian product too large; must have size at most Integer.MAX_VALUE");
     }
@@ -246,7 +246,7 @@ class CartesianProductTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2, 3)
                 .generate(field(IntegerHolder::getWrapper), gen -> gen.emit().items(5, 6, 7))
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 2, 3);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(5, 6, 7);
@@ -257,7 +257,7 @@ class CartesianProductTest {
         final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2, 3)
                 .generate(field(IntegerHolder::getWrapper), gen -> gen.intSeq().start(5))
-                .list();
+                .create();
 
         assertThat(results).extracting(IntegerHolder::getPrimitive).containsExactly(1, 2, 3);
         assertThat(results).extracting(IntegerHolder::getWrapper).containsExactly(5, 6, 7);
@@ -281,7 +281,7 @@ class CartesianProductTest {
                 .with(field(SingleValueHolder::getValue), 1, 2)
                 .with(field(Person::getName), "foo", "bar") // invalid selector
                 .lenient()
-                .list();
+                .create();
 
         // Ideally, it would return [1, 2]
         assertThat(results)
@@ -307,7 +307,7 @@ class CartesianProductTest {
             final List<IntegerHolder> results = Instancio.ofCartesianProduct(IntegerHolder.class)
                     .withMaxDepth(2)
                     .with(field(IntegerHolder::getPrimitive), 1, 2)
-                    .list();
+                    .create();
 
             assertThat(results)
                     .extracting(IntegerHolder::getPrimitive)
@@ -320,7 +320,7 @@ class CartesianProductTest {
                     .withMaxDepth(1)
                     .with(field(IntegerHolder::getPrimitive), 1, 2);
 
-            assertThatThrownBy(api::list)
+            assertThatThrownBy(api::create)
                     .isExactlyInstanceOf(UnusedSelectorException.class)
                     .hasMessageContaining("field(IntegerHolder, \"primitive\")");
         }
@@ -359,7 +359,7 @@ class CartesianProductTest {
         void withSingleNullObject() {
             final List<Pair<Integer, Boolean>> results = Instancio.ofCartesianProduct(new TypeToken<Pair<Integer, Boolean>>() {})
                     .with(allInts(), (Object) null)
-                    .list();
+                    .create();
 
             assertThat(results)
                     .hasSize(1)
@@ -374,7 +374,7 @@ class CartesianProductTest {
             final List<Pair<Integer, Boolean>> results = Instancio.ofCartesianProduct(new TypeToken<Pair<Integer, Boolean>>() {})
                     .with(allInts(), null, null)
                     .with(allBooleans(), null, null)
-                    .list();
+                    .create();
 
             assertThat(results)
                     .hasSize(4)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductVerboseTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/cartesianproduct/CartesianProductVerboseTest.java
@@ -53,7 +53,7 @@ class CartesianProductVerboseTest {
         Instancio.ofCartesianProduct(IntegerHolder.class)
                 .with(field(IntegerHolder::getPrimitive), 1, 2)
                 .verbose()
-                .list();
+                .create();
 
         assertThat(outputStreamCaptor)
                 .asString()

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/filter/FilterWithCartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/filter/FilterWithCartesianProductTest.java
@@ -39,7 +39,7 @@ class FilterWithCartesianProductTest {
                 .with(field(StringFields::getOne), "one")
                 .with(field(StringFields::getTwo), "two")
                 .filter(all(field(StringFields::getThree), field(StringFields::getFour)), (String s) -> s.length() == 5)
-                .list();
+                .create();
 
         assertThat(results)
                 .singleElement()

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/setmodel/SetModelCartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/setmodel/SetModelCartesianProductTest.java
@@ -46,7 +46,7 @@ class SetModelCartesianProductTest {
         final List<StringsAbc> results = Instancio.ofCartesianProduct(StringsAbc.class)
                 .setModel(all(StringsDef.class), model)
                 .with(field(StringsAbc::getA), "a")
-                .list();
+                .create();
 
         assertThat(results).hasSize(1).allSatisfy(result -> {
             assertThat(result.getA()).isEqualTo("a");

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/setmodel/SetModelSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/setmodel/SetModelSelectorTest.java
@@ -137,7 +137,7 @@ class SetModelSelectorTest {
                             fields().declaredIn(Inner.class).matching("^item\\d$").atDepth(d -> d == 2),
                             fields(f -> f.getType() == Item.class).atDepth(2)
                     )
-                    .list();
+                    .create();
 
             return pairs.stream().map(pair -> Arguments.of(pair.getStringSelector(), pair.getModelSelector()));
         }
@@ -200,7 +200,7 @@ class SetModelSelectorTest {
                             fields().declaredIn(Inner.class).matching("item2").atDepth(d -> d == 2),
                             fields(f -> f.getDeclaringClass() == Inner.class && f.getName().equals("item2"))
                     )
-                    .list();
+                    .create();
 
             return pairs.stream().map(pair -> Arguments.of(pair.getStringSelector(), pair.getModelSelector()));
         }
@@ -256,7 +256,7 @@ class SetModelSelectorTest {
                             fields().declaredIn(Inner.class).named("item2"),
                             fields(f -> f.getDeclaringClass() == Inner.class && f.getName().equals("item2"))
                     )
-                    .list();
+                    .create();
 
             return pairs.stream().map(pair -> Arguments.of(pair.getStringSelector(), pair.getModelSelector()));
         }
@@ -313,7 +313,7 @@ class SetModelSelectorTest {
                             fields().declaredIn(Outer.class).named("item"),
                             fields(f -> f.getDeclaringClass() == Outer.class && f.getName().equals("item"))
                     )
-                    .list();
+                    .create();
 
             return pairs.stream().map(pair -> Arguments.of(pair.getStringSelector(), pair.getModelSelector()));
         }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/ApiContractTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/ApiContractTest.java
@@ -242,7 +242,7 @@ class ApiContractTest {
     @Test
     void methodsNotSupportedByCartesianProductApi() {
         assertThatClass(CartesianProductApi.class)
-                .hasNoMethodsNamed("create", "asResult", "toModel");
+                .hasNoMethodsNamed("asResult", "toModel");
     }
 
     /**

--- a/instancio-tests/java17-tests/src/test/java/org/instancio/test/java17/generator/CustomerGeneratorRecordWithNullFieldTest.java
+++ b/instancio-tests/java17-tests/src/test/java/org/instancio/test/java17/generator/CustomerGeneratorRecordWithNullFieldTest.java
@@ -83,7 +83,7 @@ class CustomerGeneratorRecordWithNullFieldTest {
         return Instancio.ofCartesianProduct(new TypeToken<Pair<Boolean, AfterGenerate>>() {})
                 .with(allBooleans(), true, false)
                 .with(all(AfterGenerate.class), AfterGenerate.values())
-                .list()
+                .create()
                 .stream()
                 .map(pair -> Arguments.of(pair.getLeft(), pair.getRight()));
     }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -134,10 +134,10 @@ Map<UUID, Address> map = Instancio.ofMap(UUID.class, Address.class).size(3)
 
 // Create from a model
 Model<Person> personModel = Instancio.of(Person.class)
-    .ignore(field(Person:getAge))
+    .ignore(field(Person::getAge))
     .toModel();
 
-Set<Person> set = Instancio.ofSet(personModel).size(5).create()
+Set<Person> set = Instancio.ofSet(personModel).size(5).create();
 ```
 
 Specifying the collection size is optional.
@@ -2466,9 +2466,9 @@ where **all** elements of `List<OrderItem>` are the **same instance** of the `Or
 
 # Cartesian Product
 
-!!! warning "Experimental feature"
+!!! info "This is an experimental API available since version `4.0.0`"
 
-Since `4.0.0` Instancio supports generating the Cartesian product using the following methods:
+The following methods are the entry points for generating the Cartesian product:
 
 ``` java linenums="1" title="Cartesian Product API"
 Instancio.ofCartesianProduct(Class<T> type)
@@ -2476,12 +2476,13 @@ Instancio.ofCartesianProduct(TypeTokenSupplier<T> supplier)
 Instancio.ofCartesianProduct(Model<T> model)
 ```
 
-In addition, there are two new methods specific to the Cartesian product API:
+Inputs can be specified using the following method:
 
-- `with(TargetSelector, Object...)` for specifying the inputs
-- `list()` for getting the results
+```java
+with(TargetSelector, Object...)
+```
 
-Consider the following example:
+As an example, consider the snippet below.
 
 ```java linenums="1"
 record Widget(String type, int num) {}
@@ -2489,7 +2490,7 @@ record Widget(String type, int num) {}
 List<Widget> results = Instancio.ofCartesianProduct(Widget.class)
     .with(field(Widget::type), "FOO", "BAR", "BAZ")
     .with(field(Widget::num), 1, 2, 3)
-    .list();
+    .create();
 ```
 
 This will produce a list containing 9 results in lexicographical order:
@@ -2518,7 +2519,7 @@ record Container(List<Widget> widgets) {}
 List<Container> results = Instancio.ofCartesianProduct(Container.class)
     .with(field(Widget::type), "FOO", "BAR", "BAZ")
     .with(field(Widget::num), 1, 2, 3)
-    .list();
+    .create();
 }
 ```
 


### PR DESCRIPTION
This is a breaking change of an experimental API. The motivation is to make it more consistent with `InstancioApi`, which should make the API more intuitive.

