### PR TITLE
Improvements to handling sealed abstract types

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeContext.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.nodes;
 
 import org.instancio.InstancioApi;
+import org.instancio.Random;
 import org.instancio.TargetSelector;
 import org.instancio.internal.context.BooleanSelectorMap;
 import org.instancio.internal.context.ModelContext;
@@ -35,6 +36,7 @@ import java.util.Set;
 public final class NodeContext {
     private final int maxDepth;
     private final Settings settings;
+    private final Random random;
     private final Map<TypeVariable<?>, Type> rootTypeMap;
     private final BooleanSelectorMap ignoredSelectorMap;
     private final SubtypeSelectorMap subtypeSelectorMap;
@@ -46,6 +48,7 @@ public final class NodeContext {
     public NodeContext(final ModelContext<?> modelContext) {
         maxDepth = modelContext.getMaxDepth();
         settings = modelContext.getSettings();
+        random = modelContext.getRandom();
         rootTypeMap = modelContext.getRootTypeMap();
         ignoredSelectorMap = modelContext.getIgnoreSelectorMap();
         subtypeSelectorMap = modelContext.getSubtypeSelectorMap();
@@ -61,6 +64,10 @@ public final class NodeContext {
 
     public Settings getSettings() {
         return settings;
+    }
+
+    public Random getRandom() {
+        return random;
     }
 
     public Map<TypeVariable<?>, Type> getRootTypeMap() {

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/NodeCreator.java
@@ -19,6 +19,7 @@ import org.instancio.exception.InstancioException;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.nodes.resolvers.NodeKindResolverFacade;
 import org.instancio.internal.util.Format;
+import org.instancio.internal.util.SealedClassUtils;
 import org.instancio.internal.util.TypeUtils;
 import org.instancio.internal.util.Verify;
 import org.instancio.settings.AssignmentType;
@@ -35,6 +36,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -183,6 +185,10 @@ class NodeCreator {
                 LOG.trace("Resolved subtype: {} -> {}", node.getRawType().getName(), subtype.get().getName());
             }
             return subtype;
+        }
+        if (SealedClassUtils.isSealedAbstractType(node.getTargetClass()) && !node.isContainer()) {
+            final List<Class<?>> impls = SealedClassUtils.getSealedClassImplementations(node.getTargetClass());
+            return Optional.of(nodeContext.getRandom().oneOf(impls));
         }
         return Optional.ofNullable(resolveSubtypeFromAncestors(node));
     }

--- a/instancio-core/src/main/java/org/instancio/internal/util/ReflectionUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/ReflectionUtils.java
@@ -162,7 +162,12 @@ public final class ReflectionUtils {
     }
 
     public static boolean isArrayOrConcrete(final Class<?> klass) {
-        return klass.isArray() || (!klass.isInterface() && !Modifier.isAbstract(klass.getModifiers()));
+        return klass.isArray() || !isInterfaceOrAbstract(klass);
+    }
+
+    public static boolean isInterfaceOrAbstract(final Class<?> klass) {
+        final int modifiers = klass.getModifiers();
+        return Modifier.isInterface(modifiers) || Modifier.isAbstract(modifiers);
     }
 
     public static boolean neitherNullNorPrimitiveWithDefaultValue(final Class<?> type, @Nullable final Object value) {

--- a/instancio-core/src/main/java/org/instancio/internal/util/SealedClassUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/SealedClassUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.util;
+
+import java.util.List;
+
+/**
+ * Helper class for working with {@code sealed} classes.
+ * This class has different implementations depending on Java version.
+ */
+public final class SealedClassUtils {
+
+    @SuppressWarnings("unused")
+    public static List<Class<?>> getSealedClassImplementations(final Class<?> sealedClass) {
+        throw new IllegalStateException("Should not be invoked");
+    }
+
+    @SuppressWarnings("all")
+    public static boolean isSealedAbstractType(final Class<?> klass) {
+        return false; // always false for java versions < 17
+    }
+
+    private SealedClassUtils() {
+        // non-instantiable
+    }
+}

--- a/instancio-core/src/main/java17/org/instancio/internal/util/SealedClassUtils.java
+++ b/instancio-core/src/main/java17/org/instancio/internal/util/SealedClassUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.util;
+
+import org.instancio.internal.util.IgnoreJRERequirement;
+import org.instancio.internal.util.ReflectionUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@IgnoreJRERequirement
+public final class SealedClassUtils {
+
+    public static List<Class<?>> getSealedClassImplementations(final Class<?> sealedClass) {
+        final List<Class<?>> results = new ArrayList<>();
+
+        for (Class<?> subclass : sealedClass.getPermittedSubclasses()) {
+            if (subclass.isSealed()) {
+                results.addAll(getSealedClassImplementations(subclass));
+            } else {
+                results.add(subclass);
+            }
+        }
+        return results;
+    }
+
+    public static boolean isSealedAbstractType(final Class<?> klass) {
+        return klass.isSealed() && ReflectionUtils.isInterfaceOrAbstract(klass);
+    }
+
+    private SealedClassUtils() {
+        // non-instantiable
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/SealedClassUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/SealedClassUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SealedClassUtilsTest {
+
+    //@formatter:off
+    private sealed interface SealedInterfaceA permits SealedInterfaceB, SealedInterfaceImpl1 {}
+    private sealed interface SealedInterfaceB extends SealedInterfaceA permits SealedAbstractClassB {}
+    private static sealed abstract class SealedAbstractClassB implements SealedInterfaceB permits SealedInterfaceImpl2 {}
+    private static final class SealedInterfaceImpl1 implements SealedInterfaceA {}
+    private static final class SealedInterfaceImpl2 extends SealedAbstractClassB {}
+    private static sealed class SealedConcreteClass permits SealedConcreteSubClass {}
+    private static final class SealedConcreteSubClass extends SealedConcreteClass {}
+    //@formatter:on
+
+    @Test
+    void getSealedClassImplementations() {
+        assertThat(SealedClassUtils.getSealedClassImplementations(SealedInterfaceA.class))
+                .containsExactlyInAnyOrder(SealedInterfaceImpl1.class, SealedInterfaceImpl2.class);
+
+        assertThat(SealedClassUtils.getSealedClassImplementations(SealedInterfaceB.class))
+                .containsOnly(SealedInterfaceImpl2.class);
+
+        assertThat(SealedClassUtils.getSealedClassImplementations(SealedAbstractClassB.class))
+                .containsOnly(SealedInterfaceImpl2.class);
+    }
+
+    @ValueSource(classes = {SealedInterfaceA.class, SealedInterfaceB.class, SealedAbstractClassB.class})
+    @ParameterizedTest
+    void isSealedAbstractTypeTrue(final Class<?> klass) {
+        assertThat(SealedClassUtils.isSealedAbstractType(klass)).isTrue();
+    }
+
+    @ValueSource(classes = {SealedInterfaceImpl1.class, SealedConcreteClass.class, SealedConcreteSubClass.class})
+    @ParameterizedTest
+    void isSealedAbstractTypeFalse(final Class<?> klass) {
+        assertThat(SealedClassUtils.isSealedAbstractType(klass)).isFalse();
+    }
+}

--- a/instancio-tests/java17-tests/src/test/java/org/instancio/test/java17/SealedAbstractTypeTest.java
+++ b/instancio-tests/java17-tests/src/test/java/org/instancio/test/java17/SealedAbstractTypeTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.java17;
+
+import org.instancio.Gen;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+
+/**
+ * NOTE: this test fails in IntelliJ, run it using Maven
+ */
+@ExtendWith(InstancioExtension.class)
+class SealedAbstractTypeTest {
+
+    //@formatter:off
+    private sealed interface SealedInterfaceA permits SealedInterfaceB, SealedInterfaceImpl1 {}
+    private sealed interface SealedInterfaceB extends SealedInterfaceA permits SealedAbstractClassB {}
+    private static sealed abstract class SealedAbstractClassB implements SealedInterfaceB permits SealedInterfaceImpl2 {}
+    private static final class SealedInterfaceImpl1 implements SealedInterfaceA { UUID uuid; }
+    private static final class SealedInterfaceImpl2 extends SealedAbstractClassB { String string; Long num; }
+    //@formatter:on
+
+    /**
+     * If no explicit subtype is specified, should use a random implementation class.
+     */
+    @Test
+    void abstractTypeWithoutSubtype_shouldUseRandomImplementationClass() {
+        final List<SealedInterfaceA> results = Instancio.stream(SealedInterfaceA.class)
+                .limit(Constants.SAMPLE_SIZE_DD)
+                .toList();
+
+        assertThat(results)
+                .filteredOn(r -> r.getClass() == SealedInterfaceImpl1.class)
+                .isNotEmpty()
+                .allSatisfy(SealedAbstractTypeTest::assertImpl1);
+
+        assertThat(results)
+                .filteredOn(r -> r.getClass() == SealedInterfaceImpl2.class)
+                .isNotEmpty()
+                .allSatisfy(SealedAbstractTypeTest::assertImpl2);
+    }
+
+    @Test
+    void abstractTypeWithSubtype_shouldUseTheSpecifiedSubtype() {
+        final Class<?> expectedSubtype = Gen.oneOf(SealedInterfaceImpl1.class, SealedInterfaceImpl2.class).get();
+
+        final List<SealedInterfaceA> results = Instancio.of(SealedInterfaceA.class)
+                .subtype(all(SealedInterfaceA.class), expectedSubtype)
+                .stream()
+                .limit(Constants.SAMPLE_SIZE_DD)
+                .toList();
+
+        assertThat(results).as("Should contain only instances of %s", expectedSubtype)
+                .hasSize(Constants.SAMPLE_SIZE_DD)
+                .hasOnlyElementsOfType(expectedSubtype);
+
+        if (expectedSubtype == SealedInterfaceImpl1.class) {
+            assertThat(results).allSatisfy(SealedAbstractTypeTest::assertImpl1);
+        } else {
+            assertThat(results).allSatisfy(SealedAbstractTypeTest::assertImpl2);
+        }
+    }
+
+    @ValueSource(classes = {SealedInterfaceB.class, SealedAbstractClassB.class})
+    @ParameterizedTest
+    void abstractTypeWithSingleImplementation(final Class<?> sealedAbstractType) {
+        final Object result = Instancio.create(sealedAbstractType);
+
+        assertImpl2(result);
+    }
+
+    @Test
+    void collectionOfSealedAbstractType_shouldUseRandomImplementationClass() {
+        final List<SealedInterfaceA> results = Instancio.ofList(SealedInterfaceA.class)
+                .size(Constants.SAMPLE_SIZE_DD)
+                .create();
+
+        final Set<Class<?>> elementTypes = results.stream()
+                .map(SealedInterfaceA::getClass)
+                .collect(Collectors.toSet());
+
+        // A random type is picked, but once picked, all elements should be of the same type
+        assertThat(elementTypes).hasSize(1);
+
+        assertThat(results).hasSize(Constants.SAMPLE_SIZE_DD).allSatisfy(elem -> {
+            if (elem instanceof SealedInterfaceImpl1) {
+                assertImpl1(elem);
+            } else {
+                assertImpl2(elem);
+            }
+        });
+    }
+
+    private static void assertImpl1(final Object actual) {
+        assertThat(actual).isExactlyInstanceOf(SealedInterfaceImpl1.class);
+        assertThat(((SealedInterfaceImpl1) actual).uuid).isNotNull();
+    }
+
+    private static void assertImpl2(final Object actual) {
+        assertThat(actual).isExactlyInstanceOf(SealedInterfaceImpl2.class);
+
+        SealedInterfaceImpl2 impl = (SealedInterfaceImpl2) actual;
+        assertThat(impl.string).isNotBlank();
+        assertThat(impl.num).isPositive();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,21 @@
                                     </configuration>
                                 </execution>
                                 <execution>
+                                    <id>java-17</id>
+                                    <phase>compile</phase>
+                                    <goals>
+                                        <goal>compile</goal>
+                                    </goals>
+                                    <configuration>
+                                        <release>17</release>
+                                        <compileSourceRoots>
+                                            <compileSourceRoot>${project.basedir}/src/main/java17
+                                            </compileSourceRoot>
+                                        </compileSourceRoots>
+                                        <multiReleaseOutput>true</multiReleaseOutput>
+                                    </configuration>
+                                </execution>
+                                <execution>
                                     <id>java-21</id>
                                     <phase>compile</phase>
                                     <goals>

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -1622,16 +1622,19 @@ Subtype mapping allows mapping a type to its subtype. This can be used for:
 - specifying an implementation class for an abstract class or interface
 - testing behaviour using different implementations
 
-By default, Instancio does not resolve the implementation class of an abstract type.
-The only exceptions to this are JDK classes, such `List`, `Map`, `CharSequence`, etc,
-which default to `ArrayList`, `HashMap`, and `String`, respectively.
+By default, Instancio does not resolve implementation classes of an abstract type.
+The only exceptions to this are:
+
+- JDK classes, such `List`, `Map`, `CharSequence`, etc.
+  (which default to `ArrayList`, `HashMap`, and `String`, respectively).
+- `sealed` interfaces and abstract classes (which default to a random implementation).
 
 For user-defined abstract types, the implementation class must be specified via the API.
 If not specified:
 
 - a `null` value will be generated where the abstract type is a field
-- an empty collection will be generated where the abstract type is collection element
-- an exception will be thrown if root type is abstract and no subtype is specified
+- an empty collection will be generated if the abstract type is a collection element
+- an exception will be thrown if the root type is abstract and no subtype is specified
 
 ### Specifying Subtypes
 


### PR DESCRIPTION
Given a sealed abstract type, pick a random concrete class as the subtype, unless an explicit subtype was specified by the user.