### PR TITLE
New top-level `as(Function)` API (#1048)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -21,6 +21,7 @@ import org.instancio.generator.GeneratorSpec;
 import org.instancio.settings.SettingKey;
 import org.instancio.settings.Settings;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -70,6 +71,38 @@ public interface InstancioApi<T> extends
      * @since 1.5.1
      */
     Result<T> asResult();
+
+    /**
+     * A convenience method for mapping the result (as returned by the
+     * {@link #create()} method) to another object using a {@code function}.
+     *
+     * <p>For example, this method can be used to return the result
+     * as JSON or other formats:
+     *
+     * <pre>{@code
+     * String json = Instancio.of(Person.class).as(json());
+     * }</pre>
+     *
+     * where {@code json()} is a user-defined method implemented
+     * using the preferred library, e.g. using Jackson:
+     *
+     * <pre>{@code
+     * public static <T> Function<T, String> json() {
+     *     return result -> new ObjectMapper()
+     *             .writerWithDefaultPrettyPrinter()
+     *             .writeValueAsString(result);
+     * }
+     * }</pre>
+     *
+     * @param function the function for mapping the result
+     * @param <R> the type of object the result is mapped to
+     * @return the object returned by applying the mapping function to the result
+     * @since 4.8.0
+     */
+    @ExperimentalApi
+    default <R> R as(Function<T, R> function) {
+        return function.apply(create());
+    }
 
     /**
      * Creates an infinite stream of distinct, fully populated object instances.

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/as/CreateAsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/as/CreateAsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.as;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.AS)
+@ExtendWith(InstancioExtension.class)
+class CreateAsTest {
+
+    @Test
+    void stringAsInteger() {
+        final Integer result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.string().digits().prefix("1").length(2))
+                .as(Integer::parseInt);
+
+        assertThat(result).isBetween(100, 999);
+    }
+
+    @Test
+    void ofSetAsList() {
+        final List<String> result = Instancio.ofSet(String.class)
+                .size(10)
+                .as(ArrayList::new);
+
+        assertThat(result).hasSize(10).doesNotContainNull();
+    }
+
+    @Test
+    void withNullableResult() {
+        final Set<String> results = Stream.generate(() ->
+                        Instancio.of(Integer.class)
+                                .withNullable(root())
+                                .as(r -> r == null ? null : r.toString()))
+                .limit(Constants.SAMPLE_SIZE_DD)
+                .collect(Collectors.toSet());
+
+        assertThat(results)
+                .hasSizeGreaterThan(1)
+                .containsNull();
+    }
+}

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
@@ -29,7 +29,11 @@ public enum Feature {
     ARRAY_GENERATOR_SUBTYPE,
     ARRAY_GENERATOR_WITH,
     /**
-     * Tests for {@code assign()} API.
+     * Tests for {@code as(Function)}.
+     */
+    AS,
+    /**
+     * Tests for {@code assign()}.
      */
     ASSIGN,
     /**


### PR DESCRIPTION
This PR adds a method for applying a `Function` to the result, e.g.

```java
static <T> Function<T, String> json() {
    return result -> new ObjectMapper()
            .writerWithDefaultPrettyPrinter()
            .writeValueAsString(result);
}

String json = Instancio.of(Person.class).as(json());
```


