### PR TITLE
Rename `ValueSpec.map()` to `as()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/ValueSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/ValueSpec.java
@@ -100,15 +100,30 @@ public interface ValueSpec<T> extends GeneratorSpec<T> {
     }
 
     /**
+     * Maps the generated value using the specified {@code function}.
+     *
+     * @param function mapping function
+     * @param <R> result type
+     * @return the result of the mapping function
+     * @since 4.8.0
+     */
+    default <R> R as(final Function<T, R> function) {
+        return function.apply(get());
+    }
+
+    /**
      * Maps the generated value using the specified function.
      *
-     * @param fn  mapping function
+     * @param function mapping function
      * @param <R> result type
      * @return the result of the mapping function
      * @since 2.6.0
+     * @deprecated this method is deprecated and will be removed in version 5;
+     *             use the {@link #as(Function)} method instead.
      */
-    default <R> R map(final Function<T, R> fn) {
-        return fn.apply(get());
+    @Deprecated
+    default <R> R map(final Function<T, R> function) {
+        return as(function);
     }
 
     /**

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractValueSpecTestTemplate.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/AbstractValueSpecTestTemplate.java
@@ -59,6 +59,12 @@ public abstract class AbstractValueSpecTestTemplate<T> {
     }
 
     @Test
+    protected final void as() {
+        final String result = spec().as(Object::toString);
+        assertThat(result).isNotBlank();
+    }
+
+    @Test
     protected final void map() {
         final String result = spec().map(Object::toString);
         assertThat(result).isNotBlank();


### PR DESCRIPTION
The `map()` method was deprecated for removal in version 5.