### PR TITLE
Support for assigning value with randomisation

### DIFF
--- a/instancio-core/src/main/java/org/instancio/RandomFunction.java
+++ b/instancio-core/src/main/java/org/instancio/RandomFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+import org.instancio.documentation.ExperimentalApi;
+
+/**
+ * A function that accepts an argument and produces a randomised result.
+ *
+ * @param <T> the input type
+ * @param <R> the result type
+ * @since 5.0.0
+ */
+@ExperimentalApi
+@FunctionalInterface
+public interface RandomFunction<T, R> {
+
+    /**
+     * Applies this function to the given {@code input}.
+     *
+     * @param input the function input
+     * @param random instance for randomising the result
+     * @return the function result
+     * @since 5.0.0
+     */
+    @ExperimentalApi
+    R apply(T input, Random random);
+}

--- a/instancio-core/src/main/java/org/instancio/ValueOfOriginDestination.java
+++ b/instancio-core/src/main/java/org/instancio/ValueOfOriginDestination.java
@@ -30,15 +30,29 @@ public interface ValueOfOriginDestination extends Assignment {
 
     /**
      * Specifies a function for mapping the value of the
-     * origin selector to another type.
+     * origin selector to another value.
      *
      * @param valueMapper a function for mapping the origin value
      * @param <T>         the origin value type
      * @param <R>         the destination value type
      * @return continuation of the builder for optionally specifying a predicate
      * @since 3.0.0
+     * @see #as(RandomFunction)
      */
     <T, R> ValueOfOriginDestinationPredicate as(Function<T, R> valueMapper);
+
+    /**
+     * Specifies a function for mapping the value of the
+     * origin selector to another (randomised) value.
+     *
+     * @param valueMapper a function for mapping the origin value
+     * @param <T>         the origin value type
+     * @param <R>         the destination value type
+     * @return continuation of the builder for optionally specifying a predicate
+     * @since 5.0.0
+     * @see #as(Function)
+     */
+    <T, R> ValueOfOriginDestinationPredicate as(RandomFunction<T, R> valueMapper);
 
     /**
      * A predicate that must be satisfied by the value matched

--- a/instancio-core/src/main/java/org/instancio/internal/assignment/InternalAssignment.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assignment/InternalAssignment.java
@@ -17,6 +17,7 @@ package org.instancio.internal.assignment;
 
 import org.instancio.Assignment;
 import org.instancio.TargetSelector;
+import org.instancio.RandomFunction;
 import org.instancio.documentation.InternalApi;
 import org.instancio.generator.Generator;
 import org.instancio.internal.ApiValidator;
@@ -24,7 +25,6 @@ import org.instancio.internal.Flattener;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 @InternalApi
@@ -34,7 +34,7 @@ public final class InternalAssignment implements Assignment, Flattener<InternalA
     private final TargetSelector destination;
     private final GeneratorHolder generatorHolder;
     private final Generator<?> generator;
-    private final Function<?, ?> valueMapper;
+    private final RandomFunction<?, ?> valueMapper;
 
     private InternalAssignment(final Builder builder) {
         origin = builder.origin;
@@ -68,8 +68,8 @@ public final class InternalAssignment implements Assignment, Flattener<InternalA
     }
 
     @SuppressWarnings("unchecked")
-    public <S, T> Function<S, T> getValueMapper() {
-        return (Function<S, T>) valueMapper;
+    public <S, T> RandomFunction<S, T> getValueMapper() {
+        return (RandomFunction<S, T>) valueMapper;
     }
 
     @Override
@@ -98,7 +98,7 @@ public final class InternalAssignment implements Assignment, Flattener<InternalA
         private TargetSelector destination;
         private GeneratorHolder generatorHolder;
         private Generator<?> generator;
-        private Function<?, ?> valueMapper;
+        private RandomFunction<?, ?> valueMapper;
 
         private Builder() {
         }
@@ -128,7 +128,7 @@ public final class InternalAssignment implements Assignment, Flattener<InternalA
             return this;
         }
 
-        public Builder valueMapper(final Function<?, ?> valueMapper) {
+        public Builder valueMapper(final RandomFunction<?, ?> valueMapper) {
             this.valueMapper = valueMapper;
             return this;
         }

--- a/instancio-core/src/main/java/org/instancio/internal/assignment/InternalValueOfOriginDestination.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assignment/InternalValueOfOriginDestination.java
@@ -16,6 +16,8 @@
 package org.instancio.internal.assignment;
 
 import org.instancio.Assignment;
+import org.instancio.Random;
+import org.instancio.RandomFunction;
 import org.instancio.TargetSelector;
 import org.instancio.ValueOfOriginDestination;
 import org.instancio.ValueOfOriginDestinationPredicate;
@@ -32,7 +34,7 @@ public class InternalValueOfOriginDestination
     private final TargetSelector origin;
     private final TargetSelector destination;
     private Predicate<?> predicate;
-    private Function<?, ?> valueMapper;
+    private RandomFunction<?, ?> valueMapper;
 
     public InternalValueOfOriginDestination(final TargetSelector origin, final TargetSelector destination) {
         this.origin = origin;
@@ -40,7 +42,13 @@ public class InternalValueOfOriginDestination
     }
 
     @Override
-    public <T, R> ValueOfOriginDestinationPredicate as(final Function<T, R> valueMapper) {
+    public <T, R> ValueOfOriginDestinationPredicate as(final Function<T, R> f) {
+        this.valueMapper = (T arg, Random random) -> f.apply(arg);
+        return new InternalValueOfOriginDestinationPredicate(origin, destination, predicate, valueMapper);
+    }
+
+    @Override
+    public <T, R> ValueOfOriginDestinationPredicate as(final RandomFunction<T, R> valueMapper) {
         this.valueMapper = valueMapper;
         return new InternalValueOfOriginDestinationPredicate(origin, destination, predicate, valueMapper);
     }

--- a/instancio-core/src/main/java/org/instancio/internal/assignment/InternalValueOfOriginDestinationPredicate.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assignment/InternalValueOfOriginDestinationPredicate.java
@@ -16,13 +16,13 @@
 package org.instancio.internal.assignment;
 
 import org.instancio.Assignment;
+import org.instancio.RandomFunction;
 import org.instancio.TargetSelector;
 import org.instancio.ValueOfOriginDestinationPredicate;
 import org.instancio.internal.Flattener;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 public class InternalValueOfOriginDestinationPredicate
@@ -30,14 +30,14 @@ public class InternalValueOfOriginDestinationPredicate
 
     private final TargetSelector origin;
     private final TargetSelector destination;
-    private final Function<?, ?> valueMapper;
+    private final RandomFunction<?, ?> valueMapper;
     private Predicate<?> predicate;
 
     public InternalValueOfOriginDestinationPredicate(
             final TargetSelector origin,
             final TargetSelector destination,
             final Predicate<?> predicate,
-            final Function<?, ?> valueMapper) {
+            final RandomFunction<?, ?> valueMapper) {
 
         this.origin = origin;
         this.destination = destination;

--- a/instancio-core/src/main/java/org/instancio/internal/generation/AssignmentNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generation/AssignmentNodeHandler.java
@@ -97,7 +97,7 @@ class AssignmentNodeHandler implements NodeHandler {
                     Object destinationResult = candidateResult.getValue();
 
                     if (assignment.getValueMapper() != null) {
-                        destinationResult = assignment.getValueMapper().apply(destinationResult);
+                        destinationResult = assignment.getValueMapper().apply(destinationResult, context.getRandom());
                     }
 
                     // Since the same object instance is assigned to different fields,

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignValueOfTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignValueOfTest.java
@@ -17,9 +17,11 @@ package org.instancio.test.features.assign;
 
 import org.instancio.Assignment;
 import org.instancio.Instancio;
+import org.instancio.Random;
 import org.instancio.When;
 import org.instancio.generator.Generator;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.basic.IntegerHolder;
 import org.instancio.test.support.pojo.collections.lists.ListString;
 import org.instancio.test.support.pojo.misc.StringsAbc;
 import org.instancio.test.support.pojo.misc.StringsDef;
@@ -91,6 +93,17 @@ class AssignValueOfTest {
                 .create();
 
         assertThat(result.def.e).isEqualTo("prefix-" + result.def.ghi.h);
+    }
+
+    @Test
+    void valueOfAsRandom() {
+        final IntegerHolder result = Instancio.of(IntegerHolder.class)
+                .assign(valueOf(IntegerHolder::getPrimitive)
+                        .to(IntegerHolder::getWrapper)
+                        .as((Integer source, Random random) -> source + random.oneOf(1, -1)))
+                .create();
+
+        assertThat(result.getWrapper()).isIn(result.getPrimitive() + 1, result.getPrimitive() - 1);
     }
 
     @Test


### PR DESCRIPTION
This PR introduces an interface for randomising results when mapping objects using assignments:

```java
public interface RandomFunction<T, R> {
    R apply(T input, Random random);
```

Example: create a time period between 1 and 30 days, inclusive.

```java
record TimePeriod(LocalDate start, LocalDate end) {}

TimePeriod period = Instancio.of(TimePeriod.class)
    .assign(Assign.valueOf(TimePeriod::start)
            .to(TimePeriod::end)
            .as((LocalDate start, Random random) -> start.plusDays(random.intRange(1, 30))))
    .create();

// Sample output: TimePeriod[start=2012-01-22, end=2012-01-30]
```
