### PR TITLE
Experimental API breaking change: renamed CSV spec `separator()` to `delimiter()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/CsvGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/CsvGeneratorSpec.java
@@ -144,14 +144,14 @@ public interface CsvGeneratorSpec extends GeneratorSpec<String> {
     CsvGeneratorSpec wrapIf(Predicate<Object> condition);
 
     /**
-     * Specifies the value separator.
-     * The default is comma: {@code ','}.
+     * Specifies the delimiter used to separate values.
+     * The default delimiter is a comma ({@code ','}).
      *
-     * @param separator for separating values
+     * @param delimiter the character used to separate values
      * @return spec builder
-     * @since 2.12.0
+     * @since 5.0.0
      */
-    CsvGeneratorSpec separator(String separator);
+    CsvGeneratorSpec delimiter(String delimiter);
 
     /**
      * Specifies the line separator.

--- a/instancio-core/src/main/java/org/instancio/generator/specs/CsvSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/CsvSpec.java
@@ -30,30 +30,59 @@ import java.util.function.Predicate;
 @ExperimentalApi
 public interface CsvSpec extends CsvGeneratorSpec, ValueSpec<String> {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec column(String name, Generator<?> generator);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec column(String name, GeneratorSpec<?> generatorSpec);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec rows(int rows);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec rows(int minRows, int maxRows);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec noHeader();
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec wrapWith(String wrapWith);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec wrapIf(Predicate<Object> condition);
 
+    /**
+     * {@inheritDoc}
+     *
+     * @since 5.0.0
+     */
     @Override
-    CsvSpec separator(String separator);
+    CsvSpec delimiter(String delimiter);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     CsvSpec lineSeparator(String lineSeparator);
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/CsvGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/CsvGenerator.java
@@ -34,7 +34,7 @@ public class CsvGenerator extends AbstractGenerator<String> implements CsvSpec {
     private boolean includeHeader = true;
     private String wrapWith;
     private Predicate<Object> wrapIf = o -> true;
-    private String separator = ",";
+    private String delimiter = ",";
     private String lineSeparator = System.lineSeparator();
     private final List<Column> columns = new ArrayList<>();
 
@@ -103,8 +103,8 @@ public class CsvGenerator extends AbstractGenerator<String> implements CsvSpec {
     }
 
     @Override
-    public CsvGenerator separator(final String separator) {
-        this.separator = separator;
+    public CsvGenerator delimiter(final String delimiter) {
+        this.delimiter = delimiter;
         return this;
     }
 
@@ -154,7 +154,7 @@ public class CsvGenerator extends AbstractGenerator<String> implements CsvSpec {
                 sb.append(wrapWith);
             }
             if (c < cols - 1) {
-                sb.append(separator);
+                sb.append(delimiter);
             }
         }
     }
@@ -163,7 +163,7 @@ public class CsvGenerator extends AbstractGenerator<String> implements CsvSpec {
         for (int c = 0; c < cols; c++) {
             sb.append(columns.get(c).name);
             if (c < cols - 1) {
-                sb.append(separator);
+                sb.append(delimiter);
             }
         }
         sb.append(lineSeparator);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/text/CsvGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/text/CsvGeneratorTest.java
@@ -96,7 +96,7 @@ class CsvGeneratorTest {
         final String result = Instancio.of(String.class)
                 .generate(allStrings(), gen -> gen.text().csv()
                         .rows(1)
-                        .separator(" || ")
+                        .delimiter(" || ")
                         .column("col1", random -> "val1")
                         .column("col2", random -> "val2"))
                 .create();

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/CsvSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/text/CsvSpecTest.java
@@ -42,7 +42,7 @@ class CsvSpecTest extends AbstractValueSpecTestTemplate<String> {
                 .column("col3", random -> 123)
                 .column("col4", random -> true)
                 .rows(3)
-                .separator("|")
+                .delimiter("|")
                 .wrapWith("'")
                 .wrapIf(obj -> obj.toString().contains(","))
                 .get();


### PR DESCRIPTION
Motivation: to make naming consistent with the recently added `CsvFormatOptions` class for feeds