### PR TITLE
Support for generating intervals

### DIFF
--- a/instancio-core/src/main/java/org/instancio/IntervalSupplier.java
+++ b/instancio-core/src/main/java/org/instancio/IntervalSupplier.java
@@ -17,26 +17,33 @@ package org.instancio;
 
 import org.instancio.documentation.ExperimentalApi;
 
+import java.util.function.Supplier;
+
 /**
- * A function that accepts an argument and produces a randomised result.
+ * A supplier of {@code start} and {@code end} interval values.
  *
- * @param <T> the input type
- * @param <R> the result type
- * @see RandomUnaryOperator
+ * @param <T> the type of value underlying the interval
+ * @see InstancioGenApi#intervalStarting(Object)
  * @since 5.0.0
  */
 @ExperimentalApi
-@FunctionalInterface
-public interface RandomFunction<T, R> {
+public interface IntervalSupplier<T> {
 
     /**
-     * Applies this function to the given {@code input}.
+     * Returns a supplier that produces interval start value.
      *
-     * @param input  the function input
-     * @param random instance for randomising the result
-     * @return the function result
+     * @return a supplier for interval start values
      * @since 5.0.0
      */
     @ExperimentalApi
-    R apply(T input, Random random);
+    Supplier<T> start();
+
+    /**
+     * Returns a supplier that produces interval end value.
+     *
+     * @return a supplier for interval end values
+     * @since 5.0.0
+     */
+    @ExperimentalApi
+    Supplier<T> end();
 }

--- a/instancio-core/src/main/java/org/instancio/RandomUnaryOperator.java
+++ b/instancio-core/src/main/java/org/instancio/RandomUnaryOperator.java
@@ -18,25 +18,28 @@ package org.instancio;
 import org.instancio.documentation.ExperimentalApi;
 
 /**
- * A function that accepts an argument and produces a randomised result.
+ * Represents a unary operator that produces a result of the same type
+ * as its operand. This operator can use an additional {@link Random}
+ * parameter for randomising the output, if necessary.
  *
- * @param <T> the input type
- * @param <R> the result type
- * @see RandomUnaryOperator
+ * @param <T> the type of the input and output of the function
+ * @see RandomFunction
  * @since 5.0.0
  */
 @ExperimentalApi
 @FunctionalInterface
-public interface RandomFunction<T, R> {
+public interface RandomUnaryOperator<T> extends RandomFunction<T, T> {
 
     /**
-     * Applies this function to the given {@code input}.
+     * Applies this operator to the given operand,
+     * using the provided {@link Random} instance.
      *
      * @param input  the function input
      * @param random instance for randomising the result
      * @return the function result
      * @since 5.0.0
      */
+    @Override
     @ExperimentalApi
-    R apply(T input, Random random);
+    T apply(T input, Random random);
 }

--- a/instancio-core/src/main/java/org/instancio/generator/specs/IntervalSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/IntervalSpec.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.IntervalSupplier;
+import org.instancio.RandomUnaryOperator;
+import org.instancio.documentation.ExperimentalApi;
+import org.instancio.generator.ValueSpec;
+
+/**
+ * Spec for generating intervals of various types,
+ * such as numeric and temporal values.
+ *
+ * @param <T> the type of value that defines the interval
+ * @since 5.0.0
+ */
+@ExperimentalApi
+public interface IntervalSpec<T> extends ValueSpec<IntervalSupplier<T>> {
+
+    /**
+     * Specifies the function for calculating the {@code start}
+     * value of the next interval based on the {@code end}
+     * value of the current interval.
+     *
+     * @param nextStartFn function for calculating the starting
+     *                    value of the next interval
+     * @return API builder reference
+     * @since 5.0.0
+     */
+    @ExperimentalApi
+    IntervalSpec<T> nextStart(RandomUnaryOperator<T> nextStartFn);
+
+    /**
+     * Specifies the function for calculating the {@code end}
+     * value of the interval based on the {@code start}
+     * value of the current interval.
+     *
+     * @param nextEndFn function for calculating the {@code end}
+     *                  value of the interval
+     * @return API builder reference
+     * @since 5.0.0
+     */
+    @ExperimentalApi
+    IntervalSpec<T> nextEnd(RandomUnaryOperator<T> nextEndFn);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 5.0.0
+     */
+    @Override
+    IntervalSpec<T> nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/internal/GenApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/GenApiImpl.java
@@ -26,6 +26,7 @@ import org.instancio.generator.specs.EnumSpec;
 import org.instancio.generator.specs.FloatSpec;
 import org.instancio.generator.specs.HashSpec;
 import org.instancio.generator.specs.IntegerSpec;
+import org.instancio.generator.specs.IntervalSpec;
 import org.instancio.generator.specs.LongSpec;
 import org.instancio.generator.specs.NumericSequenceSpec;
 import org.instancio.generator.specs.OneOfArraySpec;
@@ -146,6 +147,11 @@ public final class GenApiImpl implements InstancioGenApi {
     @Override
     public <T> OneOfCollectionSpec<T> oneOf(final Collection<T> choices) {
         return generators().oneOf(choices);
+    }
+
+    @Override
+    public <T> IntervalSpec<T> intervalStarting(final T startingValue) {
+        return generators().intervalStarting(startingValue);
     }
 
     @SuppressWarnings("unchecked")

--- a/instancio-core/src/main/java/org/instancio/internal/feed/AbstractFeed.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/AbstractFeed.java
@@ -30,6 +30,7 @@ import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.misc.SupplierBackedGenerator;
 import org.instancio.internal.util.ErrorMessageUtils;
 import org.instancio.internal.util.Fail;
+import org.instancio.internal.util.PropertyBitSet;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.internal.util.StringUtils;
 import org.instancio.settings.FeedDataAccess;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/misc/IntervalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/misc/IntervalGenerator.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.misc;
+
+import org.instancio.IntervalSupplier;
+import org.instancio.Random;
+import org.instancio.RandomUnaryOperator;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.IntervalSpec;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.util.PropertyBitSet;
+
+import java.util.function.Supplier;
+
+public class IntervalGenerator<T> extends AbstractGenerator<IntervalSupplier<T>> implements IntervalSpec<T> {
+
+    private final T startingValue;
+    private RandomUnaryOperator<T> nextStartFunction;
+    private RandomUnaryOperator<T> nextEndFunction;
+
+    public IntervalGenerator(final GeneratorContext context, final T startingValue) {
+        super(context);
+        this.startingValue = ApiValidator.notNull(startingValue, "starting value must not be null");
+    }
+
+    @Override
+    public String apiMethod() {
+        // no validation needed for this method since
+        // it's only available via Instancio.gen()
+        return null;
+    }
+
+    @Override
+    public IntervalGenerator<T> nextStart(final RandomUnaryOperator<T> fn) {
+        this.nextStartFunction = fn;
+        return this;
+    }
+
+    @Override
+    public IntervalGenerator<T> nextEnd(final RandomUnaryOperator<T> fn) {
+        this.nextEndFunction = fn;
+        return this;
+    }
+
+    @Override
+    public IntervalGenerator<T> nullable() {
+        super.nullable();
+        return this;
+    }
+
+    @Override
+    protected IntervalSupplier<T> tryGenerateNonNull(final Random random) {
+        ApiValidator.notNull(nextStartFunction, "'nextStart' function must not be null");
+        ApiValidator.notNull(nextEndFunction, "'nextEnd' function must not be null");
+
+        return new IntervalSupplierImpl<>(random, startingValue, nextStartFunction, nextEndFunction);
+    }
+
+    private static final class IntervalSupplierImpl<T> implements IntervalSupplier<T> {
+        private static final String START = "start";
+        private static final String END = "end";
+
+        private final PropertyBitSet propertyBitSet = new PropertyBitSet();
+        private final Random random;
+        private final RandomUnaryOperator<T> nextStartFunction;
+        private final RandomUnaryOperator<T> nextEndFunction;
+        private T intervalStart;
+        private T intervalEnd;
+
+        private IntervalSupplierImpl(
+                final Random random,
+                final T startingValue,
+                final RandomUnaryOperator<T> nextStartFunction,
+                final RandomUnaryOperator<T> nextEndFunction) {
+
+            this.random = random;
+            this.nextStartFunction = nextStartFunction;
+            this.nextEndFunction = nextEndFunction;
+            this.intervalStart = startingValue;
+            this.intervalEnd = nextEndFunction.apply(startingValue, random);
+        }
+
+        @Override
+        public Supplier<T> start() {
+            return () -> {
+                updateState(START);
+                return intervalStart;
+            };
+        }
+
+        @Override
+        public Supplier<T> end() {
+            return () -> {
+                updateState(END);
+                return intervalEnd;
+            };
+        }
+
+        private void updateState(final String property) {
+            if (propertyBitSet.get(property)) {
+                propertyBitSet.clear();
+                intervalStart = nextStartFunction.apply(intervalEnd, random);
+                intervalEnd = nextEndFunction.apply(intervalStart, random);
+            }
+            propertyBitSet.set(property);
+        }
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/generators/BuiltInGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generators/BuiltInGenerators.java
@@ -28,6 +28,7 @@ import org.instancio.generator.specs.EnumSpec;
 import org.instancio.generator.specs.FloatSpec;
 import org.instancio.generator.specs.HashSpec;
 import org.instancio.generator.specs.IntegerSpec;
+import org.instancio.generator.specs.IntervalSpec;
 import org.instancio.generator.specs.LongSpec;
 import org.instancio.generator.specs.MapGeneratorSpec;
 import org.instancio.generator.specs.NumericSequenceSpec;
@@ -65,6 +66,7 @@ import org.instancio.internal.generator.lang.LongGenerator;
 import org.instancio.internal.generator.lang.ShortGenerator;
 import org.instancio.internal.generator.lang.StringGenerator;
 import org.instancio.internal.generator.misc.EmitGenerator;
+import org.instancio.internal.generator.misc.IntervalGenerator;
 import org.instancio.internal.generator.sequence.IntegerSequenceGenerator;
 import org.instancio.internal.generator.sequence.LongSequenceGenerator;
 import org.instancio.internal.generator.shuffle.ShuffleGenerator;
@@ -208,6 +210,11 @@ public final class BuiltInGenerators implements Generators, ValueSpecs {
     @Override
     public <T> EmitGeneratorSpec<T> emit() {
         return new EmitGenerator<>(context);
+    }
+
+    @Override
+    public <T> IntervalSpec<T> intervalStarting(final T startingValue) {
+        return new IntervalGenerator<>(context, startingValue);
     }
 
     // AtomicSpecs not available (yet)

--- a/instancio-core/src/main/java/org/instancio/internal/util/PropertyBitSet.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/PropertyBitSet.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.instancio.internal.feed;
-
-import org.instancio.internal.util.Sonar;
+package org.instancio.internal.util;
 
 import java.util.BitSet;
 import java.util.HashMap;

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/IntervalGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/IntervalGeneratorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.misc;
+
+import org.instancio.Instancio;
+import org.instancio.IntervalSupplier;
+import org.instancio.junit.Given;
+import org.instancio.junit.InstanceProvider;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.InstancioSource;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class IntervalGeneratorTest {
+
+    private static class BetweenZeroAnd10 implements InstanceProvider {
+        @Override
+        public Object provide(final ElementContext context) {
+            return context.random().intRange(0, 10);
+        }
+    }
+
+    @InstancioSource
+    @ParameterizedTest
+    void dateIntervals_callingStartFirst(
+            @Given(BetweenZeroAnd10.class) final int startingValue,
+            @Given(BetweenZeroAnd10.class) final int intervalLength,
+            @Given(BetweenZeroAnd10.class) final int betweenIntervals) {
+
+        final IntervalSupplier<Integer> results = getIntervals(
+                startingValue, intervalLength, betweenIntervals);
+
+        int start = startingValue;
+        int end = startingValue + intervalLength;
+
+        for (int i = 0; i < Constants.SAMPLE_SIZE_DD; i++) {
+            // start() first
+            assertThat(results.start().get()).isEqualTo(start);
+            assertThat(results.end().get()).isEqualTo(end);
+
+            start = end + betweenIntervals;
+            end = start + intervalLength;
+        }
+    }
+
+    @InstancioSource
+    @ParameterizedTest
+    void dateIntervals_callingEndFirst(
+            @Given(BetweenZeroAnd10.class) final int startingValue,
+            @Given(BetweenZeroAnd10.class) final int intervalLength,
+            @Given(BetweenZeroAnd10.class) final int betweenIntervals) {
+
+        final IntervalSupplier<Integer> results = getIntervals(
+                startingValue, intervalLength, betweenIntervals);
+
+        int start = startingValue;
+        int end = startingValue + intervalLength;
+
+        for (int i = 0; i < Constants.SAMPLE_SIZE_DD; i++) {
+            // end() first
+            assertThat(results.end().get()).isEqualTo(end);
+            assertThat(results.start().get()).isEqualTo(start);
+
+            start = end + betweenIntervals;
+            end = start + intervalLength;
+        }
+    }
+
+    @Test
+    void consecutiveStartInvocations(
+            @Given(BetweenZeroAnd10.class) final int startingValue,
+            @Given(BetweenZeroAnd10.class) final int intervalLength,
+            @Given(BetweenZeroAnd10.class) final int betweenIntervals) {
+
+        final IntervalSupplier<Integer> results = getIntervals(
+                startingValue, intervalLength, betweenIntervals);
+
+        int prev = results.start().get();
+        for (int i = 0; i < Constants.SAMPLE_SIZE_DD; i++) {
+            final Integer cur = results.start().get();
+
+            assertThat(cur - prev).isEqualTo(betweenIntervals + intervalLength);
+            prev = cur;
+        }
+    }
+
+    @Test
+    void consecutiveEndInvocations(
+            @Given(BetweenZeroAnd10.class) final int startingValue,
+            @Given(BetweenZeroAnd10.class) final int intervalLength,
+            @Given(BetweenZeroAnd10.class) final int betweenIntervals) {
+
+        final IntervalSupplier<Integer> results = getIntervals(
+                startingValue, intervalLength, betweenIntervals);
+
+        int prev = results.end().get();
+        for (int i = 0; i < Constants.SAMPLE_SIZE_DD; i++) {
+            final Integer cur = results.end().get();
+
+            assertThat(cur - prev).isEqualTo(betweenIntervals + intervalLength);
+            prev = cur;
+        }
+    }
+
+    private static IntervalSupplier<Integer> getIntervals(
+            @Given(BetweenZeroAnd10.class) final int startingValue,
+            @Given(BetweenZeroAnd10.class) final int intervalLength,
+            @Given(BetweenZeroAnd10.class) final int betweenIntervals) {
+
+        return Instancio.gen()
+                .intervalStarting(startingValue)
+                .nextEnd((start, random) -> start + intervalLength)
+                .nextStart((end, random) -> end + betweenIntervals)
+                .get();
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/misc/IntervalGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/misc/IntervalGeneratorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.misc;
+
+import org.instancio.IntervalSupplier;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.generator.AbstractGeneratorTestTemplate;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IntervalGeneratorTest extends AbstractGeneratorTestTemplate<IntervalSupplier<Integer>, IntervalGenerator<Integer>> {
+
+    private static final int STARTING_VALUE = 1;
+
+    private final IntervalGenerator<Integer> generator = new IntervalGenerator<>(getGeneratorContext(), STARTING_VALUE)
+            .nextStart((i, random) -> i)
+            .nextEnd((i, random) -> i);
+
+    @Override
+    protected String getApiMethod() {
+        return null;
+    }
+
+    @Override
+    protected IntervalGenerator<Integer> generator() {
+        return generator;
+    }
+
+    @Test
+    void generate() {
+        assertThat(generator.generate(random)).isInstanceOf(IntervalSupplier.class);
+    }
+
+    @Nested
+    class ValidationTest {
+
+        @Test
+        void nullStartingValue() {
+            final GeneratorContext generatorContext = getGeneratorContext();
+
+            assertThatThrownBy(() -> new IntervalGenerator<>(generatorContext, null))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("starting value must not be null");
+        }
+
+        @Test
+        void nullNextStartFunction() {
+            final GeneratorContext generatorContext = getGeneratorContext();
+            final IntervalGenerator<Integer> invalidGenerator = new IntervalGenerator<>(generatorContext, STARTING_VALUE)
+                    .nextEnd((i, random) -> i);
+
+            assertThatThrownBy(() -> invalidGenerator.generate(random))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("'nextStart' function must not be null");
+        }
+
+        @Test
+        void nullNextEndFunction() {
+            final GeneratorContext generatorContext = getGeneratorContext();
+            final IntervalGenerator<Integer> invalidGenerator = new IntervalGenerator<>(generatorContext, STARTING_VALUE)
+                    .nextStart((i, random) -> i);
+
+            assertThatThrownBy(() -> invalidGenerator.generate(random))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("'nextEnd' function must not be null");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for generating intervals of various types, such as numeric and temporal values.

Example: generate a list of vacations with start/end dates.

```java
 record Vacation(LocalDate start, LocalDate end) {}
```

- The first vacation should start on `2000-01-01`.
- Each vacation should last between 1-3 weeks.
- There should be  12-15 months between vacations.

```java
 IntervalSupplier<LocalDate> vacationDates = Instancio.gen()
     .intervalStarting(LocalDate.of(2000, 1, 1))
     .nextStart((end, random) -> end.plusMonths(random.intRange(12, 15)))
     .nextEnd((start, random) -> start.plusWeeks(random.intRange(1, 3)))
     .get();

 List<Vacation> vacations = Instancio.ofList(Vacation.class)
     .size(4)
     .supply(field(Vacation::start), vacationDates.start())
     .supply(field(Vacation::end), vacationDates.end())
     .create();

 // Sample output:
 // [Vacation[start=2000-01-01, end=2000-01-15],
 //  Vacation[start=2001-02-15, end=2001-03-08],
 //  Vacation[start=2002-03-08, end=2002-03-15],
 //  Vacation[start=2003-06-15, end=2003-07-06]]
```
