### PR TITLE
Support for quoted CSV values in feeds

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/feed/csv/InternalCsvFormatOptions.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/csv/InternalCsvFormatOptions.java
@@ -21,6 +21,8 @@ import org.instancio.settings.FeedDataTrim;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 
+import static java.lang.String.format;
+
 public final class InternalCsvFormatOptions implements FormatOptionsProvider.FormatOptions {
 
     private final String commentPrefix;
@@ -33,10 +35,17 @@ public final class InternalCsvFormatOptions implements FormatOptionsProvider.For
 
     private InternalCsvFormatOptions(final Builder builder, final Settings settings) {
         this.commentPrefix = builder.commentPrefix;
-        this.delimiter = builder.delimiter;
+        this.delimiter = validateDelimiter(builder.delimiter);
         this.feedDataTrim = builder.feedDataTrim != null
                 ? builder.feedDataTrim
                 : settings.get(Keys.FEED_DATA_TRIM);
+    }
+
+    private char validateDelimiter(char delimiter) {
+        if (delimiter == '"') {
+            throw new IllegalArgumentException(format("Invalid delimiter: %s", delimiter));
+        }
+        return delimiter;
     }
 
     String getCommentPrefix() {

--- a/instancio-tests/jackson-tests/src/test/java/org/instancio/test/jackson/feed/FeedFormatQuotedCsvParserTest.java
+++ b/instancio-tests/jackson-tests/src/test/java/org/instancio/test/jackson/feed/FeedFormatQuotedCsvParserTest.java
@@ -1,0 +1,81 @@
+package org.instancio.test.jackson.feed;
+
+import org.instancio.junit.InstancioExtension;
+import org.instancio.feed.Feed;
+import org.instancio.feed.FeedSpec;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Instancio.createFeed;
+import static org.instancio.Instancio.ofFeed;
+import static org.instancio.settings.FeedDataTrim.NONE;
+import static org.instancio.settings.FeedDataTrim.UNQUOTED;
+import static org.instancio.settings.Keys.FEED_DATA_TRIM;
+
+@FeatureTag(Feature.FEED)
+@ExtendWith(InstancioExtension.class)
+class FeedFormatQuotedCsvParserTest {
+
+    @Test
+    void sampleQuotedFeed() {
+        @Feed.Source(string = """
+        col1, col2, col3
+        "a,b", c, "d, e,  f"
+        """)
+        interface SampleFeed extends Feed {
+            FeedSpec<String> col1();
+            FeedSpec<String> col2();
+            FeedSpec<String> col3();
+        }
+
+        var feed = createFeed(SampleFeed.class);
+        assertThat(feed.col1().get()).isEqualTo("a,b");
+        assertThat(feed.col2().get()).isEqualTo("c");
+        assertThat(feed.col3().get()).isEqualTo("d, e,  f");
+    }
+
+    @Test
+    void shouldTrimOnlyUnquotedValues() {
+        @Feed.Source(string = """
+            col1, col2, col3
+            " a,b "  ,   c  ,   " d, e,  f "
+            """)
+        interface SampleFeed extends Feed {
+            FeedSpec<String> col1();
+            FeedSpec<String> col2();
+            FeedSpec<String> col3();
+        }
+
+        var feed = ofFeed(SampleFeed.class)
+                .withSetting(FEED_DATA_TRIM, UNQUOTED)
+                .create();
+
+        assertThat(feed.col1().get()).isEqualTo(" a,b "); // not trimmed
+        assertThat(feed.col2().get()).isEqualTo("c"); // trimmed
+        assertThat(feed.col3().get()).isEqualTo(" d, e,  f "); // not trimmed
+    }
+
+    @Test
+    void shouldNotTrimAnyValues() {
+        @Feed.Source(string = """
+        col1,col2,col3
+        " a "    , b ,   " c "
+        """)
+        interface SampleFeed extends Feed {
+            FeedSpec<String> col1();
+            FeedSpec<String> col2();
+            FeedSpec<String> col3();
+        }
+
+        var feed = ofFeed(SampleFeed.class)
+                .withSetting(FEED_DATA_TRIM, NONE)
+                .create();
+
+        assertThat(feed.col1().get()).isEqualTo(" a ");
+        assertThat(feed.col2().get()).isEqualTo(" b ");
+        assertThat(feed.col3().get()).isEqualTo(" c ");
+    }
+}


### PR DESCRIPTION
Hi @armandino , I've successfully parsed CSV files with quoted values, but it led to an exception when the delimiter is a quote. I'm wondering if this is a valid edge case that we should spend time addressing, or if it's safe to move on without handling it.