### PR TITLE
Add `as(Function)` method to the `oneOf()` generator spec

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/OneOfArrayGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OneOfArrayGeneratorSpec.java
@@ -23,7 +23,9 @@ import org.instancio.generator.GeneratorSpec;
  * @param <T> type of value
  * @since 1.0.1
  */
-public interface OneOfArrayGeneratorSpec<T> extends NullableGeneratorSpec<T> {
+public interface OneOfArrayGeneratorSpec<T> extends
+        AsGeneratorSpec<T>,
+        NullableGeneratorSpec<T> {
 
     /**
      * Selects a random value from the given choices.

--- a/instancio-core/src/main/java/org/instancio/generator/specs/OneOfCollectionGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/OneOfCollectionGeneratorSpec.java
@@ -25,7 +25,9 @@ import java.util.Collection;
  * @param <T> type of value
  * @since 1.0.1
  */
-public interface OneOfCollectionGeneratorSpec<T> extends NullableGeneratorSpec<T> {
+public interface OneOfCollectionGeneratorSpec<T> extends
+        AsGeneratorSpec<T>,
+        NullableGeneratorSpec<T> {
 
     /**
      * Selects a random value from the given choices.

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/oneof/OneOfArrayGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/oneof/OneOfArrayGeneratorTest.java
@@ -17,6 +17,7 @@ package org.instancio.test.features.generator.oneof;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.misc.OptionalString;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
@@ -24,11 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.allStrings;
+import static org.instancio.Select.field;
 
 @FeatureTag({Feature.GENERATE, Feature.ONE_OF_ARRAY_GENERATOR})
 @ExtendWith(InstancioExtension.class)
@@ -73,5 +76,14 @@ class OneOfArrayGeneratorTest {
                 .limit(Constants.SAMPLE_SIZE_DD);
 
         assertThat(results).containsOnly("one", null);
+    }
+
+    @Test
+    void oneOfAs() {
+        final OptionalString result = Instancio.of(OptionalString.class)
+                .generate(field(OptionalString::getOptional), gen -> gen.oneOf("one").as(Optional::of))
+                .create();
+
+        assertThat(result.getOptional()).contains("one");
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/oneof/OneOfCollectionGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/oneof/OneOfCollectionGeneratorTest.java
@@ -18,6 +18,7 @@ package org.instancio.test.features.generator.oneof;
 import org.instancio.Instancio;
 import org.instancio.internal.util.CollectionUtils;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.misc.OptionalString;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
@@ -28,11 +29,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.allStrings;
+import static org.instancio.Select.field;
 
 @FeatureTag({Feature.GENERATE, Feature.ONE_OF_COLLECTION_GENERATOR})
 @ExtendWith(InstancioExtension.class)
@@ -79,5 +82,16 @@ class OneOfCollectionGeneratorTest {
                 .limit(Constants.SAMPLE_SIZE_DD);
 
         assertThat(results).containsOnly("one", null);
+    }
+
+    @Test
+    void oneOfAs() {
+        final Set<String> choices = Collections.singleton("one");
+
+        final OptionalString result = Instancio.of(OptionalString.class)
+                .generate(field(OptionalString::getOptional), gen -> gen.oneOf(choices).as(Optional::of))
+                .create();
+
+        assertThat(result.getOptional()).contains("one");
     }
 }


### PR DESCRIPTION
Sample usage:

```java
class Pojo {
  JsonNullable<String> jsonNullableString;
}

Pojo pojo = Instancio.of(Pojo.class)
        .generate(field("jsonNullableString"), gen -> gen.oneOf("foo", "bar").as(JsonNullable::of))
        .create();
```

Related to:

- #1209