### PR TITLE
Bug fix: only report the initial seed for `@InstancioSource` tests

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/internal/Constants.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/Constants.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit.internal;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
+
+public final class Constants {
+
+    public static final ExtensionContext.Namespace INSTANCIO_NAMESPACE = create("org.instancio");
+    public static final String INSTANCIO_SOURCE_STATE = "instancio.source.state";
+
+    private Constants() {
+        // non-instantiable
+    }
+}

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceArgumentsProvider.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceArgumentsProvider.java
@@ -34,6 +34,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.instancio.junit.internal.Constants.INSTANCIO_NAMESPACE;
+import static org.instancio.junit.internal.Constants.INSTANCIO_SOURCE_STATE;
+
 /**
  * A provider that generates arguments for {@link InstancioSource}.
  */
@@ -59,8 +62,14 @@ public class InstancioSourceArgumentsProvider
         final Parameter[] parameters = context.getRequiredTestMethod().getParameters();
         final int samples = getNumberOfSamples(settings);
 
+        final InstancioSourceState state = new InstancioSourceState(threadLocalRandom.get().getSeed(), samples);
+        context.getStore(INSTANCIO_NAMESPACE).put(INSTANCIO_SOURCE_STATE, state);
+
         return Stream
-                .generate(() -> Arguments.of(createObjects(parameters, random, settings)))
+                .generate(() -> {
+                    state.decrementSamplesRemaining();
+                    return Arguments.of(createObjects(parameters, random, settings));
+                })
                 .limit(samples);
     }
 

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceState.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit.internal;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InstancioSourceState {
+
+    private final long initialSeed;
+    private final AtomicInteger samplesRemaining;
+
+    public InstancioSourceState(final long initialSeed, final int samplesRemaining) {
+        this.initialSeed = initialSeed;
+        this.samplesRemaining = new AtomicInteger(samplesRemaining);
+    }
+
+    public long getInitialSeed() {
+        return initialSeed;
+    }
+
+    public void decrementSamplesRemaining() {
+        samplesRemaining.decrementAndGet();
+    }
+
+    public boolean allSamplesGenerated() {
+        return samplesRemaining.get() == 0;
+    }
+}


### PR DESCRIPTION
Given a test annotated with:

```java
@InstancioSource(samples = 5)
@ParameterizedTest
```

Each failed sample will report the same seed value. Using the reported seed, all the samples can be reproduced.