### PR TITLE
Float and double generator improvements

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
@@ -18,16 +18,15 @@ package org.instancio.internal.annotation;
 import org.instancio.Random;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.specs.ArrayGeneratorSpec;
-import org.instancio.generator.specs.BigDecimalGeneratorSpec;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.generator.specs.MapGeneratorSpec;
 import org.instancio.generator.specs.NumberGeneratorSpec;
 import org.instancio.generator.specs.StringGeneratorSpec;
 import org.instancio.generator.specs.TemporalGeneratorSpec;
 import org.instancio.internal.generator.array.ArrayGenerator;
-import org.instancio.internal.generator.lang.AbstractRandomNumberGeneratorSpec;
 import org.instancio.internal.generator.lang.BooleanGenerator;
 import org.instancio.internal.generator.lang.StringGenerator;
+import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.internal.generator.specs.InternalLengthGeneratorSpec;
 import org.instancio.internal.generator.util.CollectionGenerator;
 import org.instancio.internal.generator.util.MapGenerator;
@@ -90,9 +89,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
                 numSpec.max(converter.apply(max));
                 AnnotationUtils.setSpecNullableToFalse(spec);
 
-                // Currently fractions are supported for BigDecimal, but not float/double
-                if (spec instanceof BigDecimalGeneratorSpec) {
-                    ((BigDecimalGeneratorSpec) spec).scale(fraction);
+                if (spec instanceof InternalFractionalNumberGeneratorSpec) {
+                    ((InternalFractionalNumberGeneratorSpec<?>) spec).scale(fraction);
                 }
             }
         }
@@ -145,7 +143,7 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
                 final String value = getValue(annotation);
                 final Function<BigDecimal, Number> converter = NumberUtils.bigDecimalConverter(targetClass);
                 final BigDecimal min = new BigDecimal(value);
-                final AbstractRandomNumberGeneratorSpec<Number> numSpec = (AbstractRandomNumberGeneratorSpec<Number>) spec;
+                final NumberGeneratorSpec<Number> numSpec = (NumberGeneratorSpec<Number>) spec;
                 numSpec.min(converter.apply(min));
                 AnnotationUtils.setSpecNullableToFalse(spec);
             }

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/CommonPersistenceAnnotationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/CommonPersistenceAnnotationHandlerMap.java
@@ -16,8 +16,8 @@
 package org.instancio.internal.annotation;
 
 import org.instancio.generator.GeneratorSpec;
-import org.instancio.generator.specs.BigDecimalGeneratorSpec;
 import org.instancio.generator.specs.StringGeneratorSpec;
+import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.internal.util.Range;
 import org.instancio.settings.Keys;
 
@@ -52,15 +52,16 @@ class CommonPersistenceAnnotationHandlerMap extends AnnotationHandlerMap {
 
                 final StringGeneratorSpec stringSpec = (StringGeneratorSpec) spec;
                 stringSpec.length(range.min(), range.max());
-            } else if (spec instanceof BigDecimalGeneratorSpec) {
+            } else if (spec instanceof InternalFractionalNumberGeneratorSpec) {
                 final int precision = getPrecision(annotation);
                 final int scale = getScale(annotation);
-                final BigDecimalGeneratorSpec bdSpec = (BigDecimalGeneratorSpec) spec;
+                final InternalFractionalNumberGeneratorSpec<?> fractionalSpec =
+                        (InternalFractionalNumberGeneratorSpec<?>) spec;
 
                 if (precision > 0) {
-                    bdSpec.precision(precision).scale(scale);
+                    fractionalSpec.precision(precision).scale(scale);
                 } else if (scale != 0) {
-                    bdSpec.scale(scale);
+                    fractionalSpec.scale(scale);
                 }
             }
         }

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationHandlerMap.java
@@ -20,7 +20,6 @@ import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.generator.specs.DurationGeneratorSpec;
 import org.instancio.generator.specs.NumberGeneratorSpec;
 import org.instancio.generator.specs.StringGeneratorSpec;
-import org.instancio.internal.generator.lang.AbstractRandomNumberGeneratorSpec;
 import org.instancio.internal.generator.lang.LongGenerator;
 import org.instancio.internal.generator.lang.StringGenerator;
 import org.instancio.internal.generator.specs.InternalLengthGeneratorSpec;
@@ -132,7 +131,7 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final Function<Long, Number> fromLongConverter = NumberUtils.longConverter(targetClass);
 
-                final AbstractRandomNumberGeneratorSpec<Number> numSpec = (AbstractRandomNumberGeneratorSpec<Number>) spec;
+                final NumberGeneratorSpec<Number> numSpec = (NumberGeneratorSpec<Number>) spec;
                 numSpec
                         .min(fromLongConverter.apply(range.min()))
                         .max(fromLongConverter.apply(range.max()));

--- a/instancio-core/src/main/java/org/instancio/internal/generator/AbstractGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/AbstractGenerator.java
@@ -84,7 +84,7 @@ public abstract class AbstractGenerator<T> implements Generator<T>, NullableGene
         return this;
     }
 
-    public final boolean isNullable() {
+    public boolean isNullable() {
         return nullable;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/AbstractRandomNumberGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/AbstractRandomNumberGeneratorSpec.java
@@ -20,13 +20,14 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.NumberGeneratorSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.generator.specs.InternalNumberGeneratorSpec;
 import org.instancio.internal.util.Range;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractRandomNumberGeneratorSpec<T extends Number>
-        extends AbstractGenerator<T> implements NumberGeneratorSpec<T> {
+        extends AbstractGenerator<T> implements InternalNumberGeneratorSpec<T> {
 
     private T min;
     private T max;
@@ -41,11 +42,13 @@ public abstract class AbstractRandomNumberGeneratorSpec<T extends Number>
         this.max = max;
     }
 
-    protected final T getMin() {
+    @Override
+    public final T getMin() {
         return min;
     }
 
-    protected final T getMax() {
+    @Override
+    public final T getMax() {
         return max;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/DoubleGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/DoubleGenerator.java
@@ -18,16 +18,25 @@ package org.instancio.internal.generator.lang;
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.DoubleSpec;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.generator.math.BigDecimalGenerator;
+import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.settings.Keys;
 
-public class DoubleGenerator extends AbstractRandomComparableNumberGeneratorSpec<Double>
-        implements DoubleSpec {
+import java.math.BigDecimal;
+
+public class DoubleGenerator extends AbstractGenerator<Double>
+        implements DoubleSpec, InternalFractionalNumberGeneratorSpec<Double> {
+
+    private final BigDecimalGenerator delegate;
 
     public DoubleGenerator(final GeneratorContext context) {
-        super(context,
-                context.getSettings().get(Keys.DOUBLE_MIN),
-                context.getSettings().get(Keys.DOUBLE_MAX),
-                context.getSettings().get(Keys.DOUBLE_NULLABLE));
+        super(context);
+        delegate = new BigDecimalGenerator(context)
+                .min(new BigDecimal(String.valueOf(context.getSettings().get(Keys.DOUBLE_MIN))))
+                .max(new BigDecimal(String.valueOf(context.getSettings().get(Keys.DOUBLE_MAX))))
+                .nullable(context.getSettings().get(Keys.DOUBLE_NULLABLE));
     }
 
     @Override
@@ -36,37 +45,70 @@ public class DoubleGenerator extends AbstractRandomComparableNumberGeneratorSpec
     }
 
     @Override
+    public Double getMin() {
+        return delegate.getMin().doubleValue();
+    }
+
+    @Override
+    public Double getMax() {
+        return delegate.getMax().doubleValue();
+    }
+
+    @Override
+    public DoubleGenerator scale(final int scale) {
+        delegate.scale(scale);
+        return this;
+    }
+
+    @Override
+    public DoubleGenerator precision(final int precision) {
+        delegate.precision(precision);
+        return this;
+    }
+
+    @Override
     public DoubleGenerator min(final Double min) {
-        super.min(min);
+        ApiValidator.notNull(min, "'min' must not be null");
+        delegate.min(new BigDecimal(String.valueOf(min)));
         return this;
     }
 
     @Override
     public DoubleGenerator max(final Double max) {
-        super.max(max);
+        ApiValidator.notNull(max, "'max' must not be null");
+        delegate.max(new BigDecimal(String.valueOf(max)));
         return this;
     }
 
     @Override
     public DoubleGenerator range(final Double min, final Double max) {
-        super.range(min, max);
+        ApiValidator.notNull(min, "'min' must not be null");
+        ApiValidator.notNull(max, "'max' must not be null");
+        delegate.range(
+                new BigDecimal(String.valueOf(min)),
+                new BigDecimal(String.valueOf(max)));
         return this;
     }
 
     @Override
     public DoubleGenerator nullable() {
-        super.nullable();
+        delegate.nullable();
         return this;
     }
 
     @Override
     public DoubleGenerator nullable(final boolean isNullable) {
-        super.nullable(isNullable);
+        delegate.nullable(isNullable);
         return this;
     }
 
     @Override
+    public boolean isNullable() {
+        return delegate.isNullable();
+    }
+
+    @Override
     protected Double tryGenerateNonNull(final Random random) {
-        return random.doubleRange(getMin(), getMax());
+        return delegate.tryGenerateNonNull(random).doubleValue();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/FloatGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/FloatGenerator.java
@@ -18,16 +18,25 @@ package org.instancio.internal.generator.lang;
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.FloatSpec;
+import org.instancio.internal.ApiValidator;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.generator.math.BigDecimalGenerator;
+import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.settings.Keys;
 
-public class FloatGenerator extends AbstractRandomComparableNumberGeneratorSpec<Float>
-        implements FloatSpec {
+import java.math.BigDecimal;
+
+public class FloatGenerator extends AbstractGenerator<Float>
+        implements FloatSpec, InternalFractionalNumberGeneratorSpec<Float> {
+
+    private final BigDecimalGenerator delegate;
 
     public FloatGenerator(final GeneratorContext context) {
-        super(context,
-                context.getSettings().get(Keys.FLOAT_MIN),
-                context.getSettings().get(Keys.FLOAT_MAX),
-                context.getSettings().get(Keys.FLOAT_NULLABLE));
+        super(context);
+        delegate = new BigDecimalGenerator(context)
+                .min(new BigDecimal(String.valueOf(context.getSettings().get(Keys.FLOAT_MIN))))
+                .max(new BigDecimal(String.valueOf(context.getSettings().get(Keys.FLOAT_MAX))))
+                .nullable(context.getSettings().get(Keys.FLOAT_NULLABLE));
     }
 
     @Override
@@ -36,37 +45,70 @@ public class FloatGenerator extends AbstractRandomComparableNumberGeneratorSpec<
     }
 
     @Override
+    public Float getMin() {
+        return delegate.getMin().floatValue();
+    }
+
+    @Override
+    public Float getMax() {
+        return delegate.getMax().floatValue();
+    }
+
+    @Override
+    public FloatGenerator scale(final int scale) {
+        delegate.scale(scale);
+        return this;
+    }
+
+    @Override
+    public FloatGenerator precision(final int precision) {
+        delegate.precision(precision);
+        return this;
+    }
+
+    @Override
     public FloatGenerator min(final Float min) {
-        super.min(min);
+        ApiValidator.notNull(min, "'min' must not be null");
+        delegate.min(new BigDecimal(String.valueOf(min)));
         return this;
     }
 
     @Override
     public FloatGenerator max(final Float max) {
-        super.max(max);
+        ApiValidator.notNull(max, "'max' must not be null");
+        delegate.max(new BigDecimal(String.valueOf(max)));
         return this;
     }
 
     @Override
     public FloatGenerator range(final Float min, final Float max) {
-        super.range(min, max);
+        ApiValidator.notNull(min, "'min' must not be null");
+        ApiValidator.notNull(max, "'max' must not be null");
+        delegate.range(
+                new BigDecimal(String.valueOf(min)),
+                new BigDecimal(String.valueOf(max)));
         return this;
     }
 
     @Override
     public FloatGenerator nullable() {
-        super.nullable();
+        delegate.nullable();
         return this;
     }
 
     @Override
     public FloatGenerator nullable(final boolean isNullable) {
-        super.nullable(isNullable);
+        delegate.nullable(isNullable);
         return this;
     }
 
     @Override
+    public boolean isNullable() {
+        return delegate.isNullable();
+    }
+
+    @Override
     protected Float tryGenerateNonNull(final Random random) {
-        return random.floatRange(getMin(), getMax());
+        return delegate.tryGenerateNonNull(random).floatValue();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/math/BigDecimalGenerator.java
@@ -20,6 +20,7 @@ import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.BigDecimalSpec;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.generator.lang.AbstractRandomComparableNumberGeneratorSpec;
+import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.settings.Keys;
 
 import java.math.BigDecimal;
@@ -27,7 +28,7 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 
 public class BigDecimalGenerator extends AbstractRandomComparableNumberGeneratorSpec<BigDecimal>
-        implements BigDecimalSpec {
+        implements BigDecimalSpec, InternalFractionalNumberGeneratorSpec<BigDecimal> {
 
     private static final BigDecimal DEFAULT_MIN = new BigDecimal("0.01");
     private static final BigDecimal DEFAULT_MAX = new BigDecimal("10000.00");
@@ -107,7 +108,7 @@ public class BigDecimalGenerator extends AbstractRandomComparableNumberGenerator
     }
 
     @Override
-    protected BigDecimal tryGenerateNonNull(final Random random) {
+    public BigDecimal tryGenerateNonNull(final Random random) {
         // If precision is not set, generate a value in the [min, max] range
         if (precision == 0) {
             final BigDecimal delta = getMax().subtract(getMin());

--- a/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalFractionalNumberGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalFractionalNumberGeneratorSpec.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.specs;
+
+import org.instancio.documentation.InternalApi;
+
+/**
+ * Internal API for setting the  scale and precision when generating
+ * {@code BigDecimal}, {@code float}, and {@code double}.
+ *
+ * <p>Currently, only {@code BigDecimal} spec exposes this method via public API.
+ *
+ * @since 5.3.0
+ */
+@InternalApi
+public interface InternalFractionalNumberGeneratorSpec<T extends Number> extends InternalNumberGeneratorSpec<T> {
+
+    InternalFractionalNumberGeneratorSpec<T> scale(int scale);
+
+    InternalFractionalNumberGeneratorSpec<T> precision(int precision);
+}

--- a/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalNumberGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/specs/InternalNumberGeneratorSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.specs;
+
+import org.instancio.documentation.InternalApi;
+import org.instancio.generator.specs.NumberGeneratorSpec;
+
+/**
+ * Internal spec for generating numbers.
+ *
+ * @since 5.3.0
+ */
+@InternalApi
+public interface InternalNumberGeneratorSpec<T extends Number> extends NumberGeneratorSpec<T> {
+
+    /**
+     * Returns the lower bound (inclusive) for generating values.
+     */
+    T getMin();
+
+    /**
+     * Returns the upper bound (inclusive) for generating values.
+     */
+    T getMax();
+
+}

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDigitsBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NumbersDigitsBVTest.java
@@ -41,15 +41,29 @@ class NumbersDigitsBVTest {
         assertThat(result.getPrimitiveShort()).isBetween((short) 10, (short) 99);
         assertThat(result.getPrimitiveInt()).isBetween(100, 999);
         assertThat(result.getPrimitiveLong()).isBetween(1000L, 9999L);
-        assertThat(result.getPrimitiveFloat()).isBetween(10000f, 99999f);
-        assertThat(result.getPrimitiveDouble()).isBetween(100000d, 999999d);
+        assertThat(result.getPrimitiveFloat())
+                .isBetween(10000f, 99999f)
+                .asString()
+                .matches("\\d{5}.0$");
+
+        assertThat(result.getPrimitiveDouble())
+                .isBetween(100000d, 999999d)
+                .asString()
+                .matches("\\d{6}.0$");
 
         assertThat(result.getByteWrapper()).isBetween((byte) 1, (byte) 9);
         assertThat(result.getShortWrapper()).isBetween((short) 10, (short) 99);
         assertThat(result.getIntegerWrapper()).isBetween(100, 999);
         assertThat(result.getLongWrapper()).isBetween(1000L, 9999L);
-        assertThat(result.getFloatWrapper()).isBetween(10000f, 99999f);
-        assertThat(result.getDoubleWrapper()).isBetween(100000d, 999999d);
+        assertThat(result.getFloatWrapper())
+                .isBetween(10000f, 99999f)
+                .asString()
+                .matches("\\d{5}.0$");
+
+        assertThat(result.getDoubleWrapper())
+                .isBetween(100000d, 999999d)
+                .asString()
+                .matches("\\d{6}.0$");
 
         assertThat(result.getBigInteger()).isBetween(
                 new BigInteger("10000000000"),
@@ -64,11 +78,25 @@ class NumbersDigitsBVTest {
     void withFraction() {
         final NumbersDigitsBV.WithFraction result = Instancio.create(NumbersDigitsBV.WithFraction.class);
 
-        assertThat(result.getPrimitiveFloat()).isBetween(100f, 999.9f);
-        assertThat(result.getPrimitiveDouble()).isBetween(1000d, 9999.99d);
+        assertThat(result.getPrimitiveFloat())
+                .isBetween(100f, 999.9f)
+                .asString()
+                .matches("\\d{3}.\\d$");
 
-        assertThat(result.getFloatWrapper()).isBetween(10000f, 99999.999f);
-        assertThat(result.getDoubleWrapper()).isBetween(100000d, 999999.9999d);
+        assertThat(result.getPrimitiveDouble())
+                .isBetween(1000d, 9999.99d)
+                .asString()
+                .matches("^\\d{4}(\\.\\d{1,2})?$");
+
+        assertThat(result.getFloatWrapper())
+                .isBetween(10000f, 99999.999f)
+                .asString()
+                .matches("^\\d{5}(\\.\\d{1,3})?$");
+
+        assertThat(result.getDoubleWrapper())
+                .isBetween(100000d, 999999.9999d)
+                .asString()
+                .matches("^\\d{6}(\\.\\d{1,4})?$");
 
         assertThat(result.getBigDecimal())
                 .isBetween(
@@ -80,8 +108,16 @@ class NumbersDigitsBVTest {
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withZeroInteger() {
         final NumbersDigitsBV.WithZeroInteger result = Instancio.create(NumbersDigitsBV.WithZeroInteger.class);
-        assertThat(result.getPrimitiveFloat()).isBetween(0f, 0.999999f);
-        assertThat(result.getPrimitiveDouble()).isBetween(0d, 0.999999d);
+
+        assertThat(result.getPrimitiveFloat())
+                .isBetween(0f, 0.9f)
+                .asString()
+                .matches("^0.\\d$");
+
+        assertThat(result.getPrimitiveDouble())
+                .isBetween(0d, 0.99d)
+                .asString()
+                .matches("^0.\\d{1,2}$");
 
         assertThat(result.getBigDecimal())
                 .isBetween(

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorSpecTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorSpecTest.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.generator.lang;
 
 import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.generator.specs.InternalNumberGeneratorSpec;
 import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +30,7 @@ class NumberGeneratorSpecTest {
     @Nested
     class ByteGeneratorTest extends NumberGeneratorSpecTestTemplate<Byte> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Byte> createGenerator() {
+        protected InternalNumberGeneratorSpec<Byte> createGenerator() {
             return new ByteGenerator(context);
         }
 
@@ -42,7 +43,7 @@ class NumberGeneratorSpecTest {
     @Nested
     class ShortGeneratorTest extends NumberGeneratorSpecTestTemplate<Short> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Short> createGenerator() {
+        protected InternalNumberGeneratorSpec<Short> createGenerator() {
             return new ShortGenerator(context);
         }
 
@@ -55,7 +56,7 @@ class NumberGeneratorSpecTest {
     @Nested
     class IntegerGeneratorTest extends NumberGeneratorSpecTestTemplate<Integer> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Integer> createGenerator() {
+        protected InternalNumberGeneratorSpec<Integer> createGenerator() {
             return new IntegerGenerator(context);
         }
 
@@ -68,7 +69,7 @@ class NumberGeneratorSpecTest {
     @Nested
     class LongGeneratorTest extends NumberGeneratorSpecTestTemplate<Long> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Long> createGenerator() {
+        protected InternalNumberGeneratorSpec<Long> createGenerator() {
             return new LongGenerator(context);
         }
 
@@ -81,7 +82,7 @@ class NumberGeneratorSpecTest {
     @Nested
     class FloatGeneratorTest extends NumberGeneratorSpecTestTemplate<Float> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Float> createGenerator() {
+        protected InternalNumberGeneratorSpec<Float> createGenerator() {
             return new FloatGenerator(context);
         }
 
@@ -92,18 +93,18 @@ class NumberGeneratorSpecTest {
 
         @Test
         void rangeWithFractionalValues() {
-            final AbstractRandomNumberGeneratorSpec<Float> generator = getGenerator();
+            final InternalNumberGeneratorSpec<Float> generator = getGenerator();
             final Float min = 1.2f;
             final Float max = 1.4f;
             generator.range(min, max);
-            assertThat(generator.generate(new DefaultRandom())).isBetween(min, max);
+            assertThat(generate()).isBetween(min, max);
         }
     }
 
     @Nested
     class DoubleGeneratorTest extends NumberGeneratorSpecTestTemplate<Double> {
         @Override
-        protected AbstractRandomNumberGeneratorSpec<Double> createGenerator() {
+        protected InternalNumberGeneratorSpec<Double> createGenerator() {
             return new DoubleGenerator(context);
         }
 
@@ -114,11 +115,11 @@ class NumberGeneratorSpecTest {
 
         @Test
         void rangeWithFractionalValues() {
-            final AbstractRandomNumberGeneratorSpec<Double> generator = getGenerator();
+            final InternalNumberGeneratorSpec<Double> generator = getGenerator();
             final Double min = 1.2;
             final Double max = 1.4;
             generator.range(min, max);
-            assertThat(generator.generate(new DefaultRandom())).isBetween(min, max);
+            assertThat(generate()).isBetween(min, max);
         }
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorSpecTestTemplate.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorSpecTestTemplate.java
@@ -16,7 +16,10 @@
 package org.instancio.internal.generator.lang;
 
 import org.instancio.exception.InstancioApiException;
+import org.instancio.generator.Generator;
 import org.instancio.generator.specs.NumberGeneratorSpec;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.instancio.internal.generator.specs.InternalNumberGeneratorSpec;
 import org.instancio.internal.util.Constants;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.internal.util.TypeUtils;
@@ -44,14 +47,14 @@ public abstract class NumberGeneratorSpecTestTemplate<T extends Number & Compara
     private static final long INITIAL_MAX = 50;
     private static final DefaultRandom RANDOM = new DefaultRandom();
 
-    private AbstractRandomNumberGeneratorSpec<T> generator;
+    private InternalNumberGeneratorSpec<T> generator;
 
     private T initialMin, initialMax;
 
     /**
      * @return generator under test
      */
-    protected abstract AbstractRandomNumberGeneratorSpec<T> createGenerator();
+    protected abstract InternalNumberGeneratorSpec<T> createGenerator();
 
     protected abstract String apiMethod();
 
@@ -64,13 +67,17 @@ public abstract class NumberGeneratorSpecTestTemplate<T extends Number & Compara
         generator.max(initialMax);
     }
 
-    protected final AbstractRandomNumberGeneratorSpec<T> getGenerator() {
+    protected final InternalNumberGeneratorSpec<T> getGenerator() {
         return generator;
+    }
+
+    protected final T generate() {
+        return ((Generator<T>) generator).generate(RANDOM);
     }
 
     @Test
     final void verifyApiMethod() {
-        assertThat(generator.apiMethod()).isEqualTo(apiMethod());
+        assertThat(((AbstractGenerator<?>) generator).apiMethod()).isEqualTo(apiMethod());
     }
 
     @Test
@@ -113,7 +120,7 @@ public abstract class NumberGeneratorSpecTestTemplate<T extends Number & Compara
                 .isEqualTo(initialMax)
                 .isEqualTo(generator.getMax());
 
-        final T result = generator.generate(RANDOM);
+        final T result = generate();
         // Not using isEqualTo() here because BigDecimal equality check includes the scale field,
         // therefore 50 and 50.0 are not equal, which fails the test
         assertThat(result).isEqualByComparingTo(newMin);
@@ -138,7 +145,7 @@ public abstract class NumberGeneratorSpecTestTemplate<T extends Number & Compara
                 .range(range1, range1)
                 .range(range2, range2);
 
-        final T result = generator.generate(RANDOM);
+        final T result = generate();
 
         assertThat(result.compareTo(range1) == 0 || result.compareTo(range2) == 0)
                 .as("Expected %s to be within %s-%s or %s-%s", result, range1, range1, range2, range2)
@@ -196,7 +203,7 @@ public abstract class NumberGeneratorSpecTestTemplate<T extends Number & Compara
 
         generator.nullable();
         for (int i = 0; i < 1000; i++) {
-            results.add(generator.generate(RANDOM));
+            results.add(generate());
         }
 
         assertThat(results).hasSizeGreaterThan(1).containsNull();

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/NumberGeneratorTest.java
@@ -135,16 +135,6 @@ class NumberGeneratorTest {
     }
 
     @Test
-    void floatGenerator() {
-        new FractionalNumberGeneratorTestTemplate<FloatGenerator>().verifyGenerate(new FloatGenerator(context));
-    }
-
-    @Test
-    void doubleGenerator() {
-        new FractionalNumberGeneratorTestTemplate<DoubleGenerator>().verifyGenerate(new DoubleGenerator(context));
-    }
-
-    @Test
     void bigDecimalGenerator() {
         final BigDecimalGenerator generator = new BigDecimalGenerator(context,
                 BigDecimal.valueOf(MIN), BigDecimal.valueOf(MAX), true);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/math/BigDecimalGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/math/BigDecimalGeneratorTest.java
@@ -20,6 +20,7 @@ import org.instancio.exception.InstancioApiException;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.internal.generator.lang.AbstractRandomNumberGeneratorSpec;
 import org.instancio.internal.generator.lang.NumberGeneratorSpecTestTemplate;
+import org.instancio.internal.generator.specs.InternalNumberGeneratorSpec;
 import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
 import org.instancio.test.support.util.Constants;
@@ -59,11 +60,10 @@ class BigDecimalGeneratorTest extends NumberGeneratorSpecTestTemplate<BigDecimal
     })
     @ParameterizedTest
     void rangeWithFractionalValues(final BigDecimal min, final BigDecimal max) {
-        final AbstractRandomNumberGeneratorSpec<BigDecimal> generator = getGenerator();
+        final InternalNumberGeneratorSpec<BigDecimal> generator = getGenerator();
         generator.range(min, max);
 
-        final BigDecimal result = generator.generate(random);
-        assertThat(result)
+        assertThat(generate())
                 .isNotNull()
                 .isGreaterThanOrEqualTo(min)
                 .isLessThanOrEqualTo(max);

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/math/BigIntegerGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/math/BigIntegerGeneratorTest.java
@@ -18,6 +18,7 @@ package org.instancio.internal.generator.math;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.internal.generator.lang.AbstractRandomNumberGeneratorSpec;
 import org.instancio.internal.generator.lang.NumberGeneratorSpecTestTemplate;
+import org.instancio.internal.generator.specs.InternalNumberGeneratorSpec;
 import org.instancio.settings.Settings;
 import org.instancio.support.DefaultRandom;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,12 +50,10 @@ class BigIntegerGeneratorTest extends NumberGeneratorSpecTestTemplate<BigInteger
     })
     @ParameterizedTest
     void bigIntegerRange(final BigInteger min, final BigInteger max) {
-        final AbstractRandomNumberGeneratorSpec<BigInteger> generator = getGenerator();
+        final InternalNumberGeneratorSpec<BigInteger> generator = getGenerator();
         generator.range(min, max);
 
-        final BigInteger result = generator.generate(new DefaultRandom());
-
-        assertThat(result)
+        assertThat(generate())
                 .isNotNull()
                 .isGreaterThanOrEqualTo(min)
                 .isLessThanOrEqualTo(max);

--- a/instancio-tests/jpa-jakarta-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
+++ b/instancio-tests/jpa-jakarta-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
@@ -29,6 +29,15 @@ import java.math.BigDecimal;
 public class ColumnScaleAndPrecisionJPA {
 
     @Data
+    public static class FloatAndDoubleWithScaleAndPrecision {
+        @Column(precision = 4, scale = 2)
+        private Float f;
+
+        @Column(precision = 6, scale = 3)
+        private Double d;
+    }
+
+    @Data
     public static class WithDefaultPrecision {
         @Column
         private BigDecimal d;

--- a/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
+++ b/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
@@ -17,6 +17,7 @@ package org.instancio.test.jpa;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.FloatAndDoubleWithScaleAndPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithDefaultPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecisionScale;
@@ -38,6 +39,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 @FeatureTag(Feature.JPA)
 @ExtendWith(InstancioExtension.class)
 class ColumnScaleAndPrecisionJPATest {
+
+    @RepeatedTest(Constants.SAMPLE_SIZE_DDD)
+    void floatAndDoubleWithScaleAndPrecision() {
+        final FloatAndDoubleWithScaleAndPrecision result = Instancio.create(FloatAndDoubleWithScaleAndPrecision.class);
+
+        assertThat(result.getF())
+                .isBetween(0f, 99.99f)
+                .asString()
+                .matches("^\\d{2}\\.\\d{1,2}$");
+
+        assertThat(result.getD())
+                .isBetween(100d, 999.999d)
+                .asString()
+                .matches("^\\d{3}\\.\\d{1,3}$");
+    }
 
     @RepeatedTest(Constants.SAMPLE_SIZE_D)
     void withDefaultPrecision() {

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2659,7 +2659,7 @@ Anything not listed is unsupported, including `*.List` annotations.
 - `@AssertTrue`
 - `@DecimalMax`
 - `@DecimalMin`
-- `@Digits` (`fraction()` is supported by `BigDecimal`, but not `float` or `double`)
+- `@Digits`
 - `@Email`
 - `@Future` (not supported by `MonthDay`)
 - `@FutureOrPresent` (delegates to `Future`)
@@ -2746,8 +2746,8 @@ or
 
 The following `@Column` attributes are supported:
 
-- `precision` -  supported by `BigDecimal` fields (with limitations described below)
-- `scale` - supported by `BigDecimal` fields
+- `precision` - supported by `Float`, `Double`, and `BigDecimal` fields (with limitations described below)
+- `scale` - supported by `Float`, `Double`, and `BigDecimal` fields
 - `length` - supported by `String` fields
 
 #### Limitations


### PR DESCRIPTION
Internal support for specifying the scale and precision when generating floats and doubles. This improves generated data when using:

- `Keys.BEAN_VALIDATION_ENABLED`
- `Keys.JPA_ENABLED`