### PR TITLE
Experimental API breaking change: renamed `@DataSpec` to `@AliasSpec`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/feed/FeedSpecAnnotations.java
+++ b/instancio-core/src/main/java/org/instancio/feed/FeedSpecAnnotations.java
@@ -34,19 +34,25 @@ import java.util.function.Function;
 public interface FeedSpecAnnotations {
 
     /**
-     * Allows mapping a property name from an external
-     * data source to a spec method in a {@link Feed}.
+     * Annotation used to specify the mapping between a method in
+     * a {@link Feed} and a property in an external data source.
+     * This allows methods in a feed interface to be explicitly
+     * associated with properties by name.
+     *
+     * <p>The {@link AliasSpec} annotation should be placed on methods
+     * within a {@link Feed} interface that return {@link FeedSpec}, enabling
+     * explicit binding of the method to a named data source property.
      *
      * @since 5.0.0
      */
     @ExperimentalApi
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
-    @interface DataSpec {
+    @interface AliasSpec {
 
         /**
-         * Specifies the name of a property that a spec method
-         * in a {@link Feed} should map to.
+         * Specifies the name of the property in the external data source
+         * to which the annotated method is explicitly mapped.
          *
          * @return property name defined in an external data source
          * @since 5.0.0

--- a/instancio-core/src/main/java/org/instancio/internal/feed/SpecMethod.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/SpecMethod.java
@@ -17,7 +17,7 @@ package org.instancio.internal.feed;
 
 import org.instancio.feed.Feed;
 import org.instancio.feed.FeedSpec;
-import org.instancio.feed.FeedSpecAnnotations.DataSpec;
+import org.instancio.feed.FeedSpecAnnotations.AliasSpec;
 import org.instancio.feed.FeedSpecAnnotations.FunctionSpec;
 import org.instancio.feed.FeedSpecAnnotations.GeneratedSpec;
 import org.instancio.feed.FeedSpecAnnotations.NullableSpec;
@@ -51,8 +51,8 @@ public final class SpecMethod {
         this.generatedSpec = getAnnotation(GeneratedSpec.class);
         this.functionSpec = getAnnotation(FunctionSpec.class);
         this.templateSpec = getAnnotation(TemplateSpec.class);
-        final DataSpec dataSpec = getAnnotation(DataSpec.class);
-        this.dataPropertyName = dataSpec == null ? method.getName() : dataSpec.value();
+        final AliasSpec aliasSpec = getAnnotation(AliasSpec.class);
+        this.dataPropertyName = aliasSpec == null ? method.getName() : aliasSpec.value();
     }
 
     public Method getMethod() {
@@ -75,7 +75,7 @@ public final class SpecMethod {
      * Returns the name of the property key in the data file
      * that maps to this spec method.
      *
-     * <p>If {@link DataSpec} annotation is defined, the mapping is done
+     * <p>If {@link AliasSpec} annotation is defined, the mapping is done
      * using the annotation's attributed, otherwise the mapping is done
      * using the name of the method that returns the {@link FeedSpec}.
      */

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedAliasSpecNameTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedAliasSpecNameTest.java
@@ -28,12 +28,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @FeatureTag(Feature.FEED)
 @ExtendWith(InstancioExtension.class)
-class FeedDataSpecNameTest {
+class FeedAliasSpecNameTest {
 
     @Feed.Source(string = "number\n123")
     private interface SampleFeed extends Feed {
 
-        @DataSpec("number")
+        @AliasSpec("number")
         FeedSpec<Integer> someOtherNameThatDoesNotMatchCsvColumnName();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedErrorHandlingTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedErrorHandlingTest.java
@@ -46,7 +46,7 @@ class FeedErrorHandlingTest {
         FeedSpec<Item<String>> value();
 
         @SuppressWarnings("UnusedReturnValue")
-        @DataSpec("value")
+        @AliasSpec("value")
         FeedSpec<byte[]> unmappableType();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedNullableSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedNullableSpecTest.java
@@ -47,7 +47,7 @@ class FeedNullableSpecTest {
     private interface SampleFeed extends Feed {
 
         @NullableSpec
-        @DataSpec("number")
+        @AliasSpec("number")
         FeedSpec<Integer> number();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedWithPostProcessorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedWithPostProcessorTest.java
@@ -49,7 +49,7 @@ class FeedWithPostProcessorTest {
     private interface SampleFeed extends Feed {
 
         @WithPostProcessor({MultiplyBy10.class, IncrementBy1.class})
-        @DataSpec("number")
+        @AliasSpec("number")
         FeedSpec<Integer> number();
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedWithStringMapperTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/FeedWithStringMapperTest.java
@@ -53,17 +53,17 @@ class FeedWithStringMapperTest {
         FeedSpec<byte[]> a();
 
         @WithStringMapper(ToByteArrayMapper.class)
-        @DataSpec("b")
+        @AliasSpec("b")
         FeedSpec<byte[]> b();
 
         @WithStringMapper(ToSingletonSetMapper.class)
-        @DataSpec("c")
+        @AliasSpec("c")
         FeedSpec<Set<String>> cAsSingletonSet();
 
         // The post-processor should be applied after the converter
         @WithPostProcessor(ToEmptyStringPostProcessor.class)
         @WithStringMapper(ToByteArrayMapper.class)
-        @DataSpec("c")
+        @AliasSpec("c")
         FeedSpec<byte[]> cAsEmptyByteArray();
 
         class ToEmptyStringPostProcessor implements PostProcessor<byte[]> {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedAdhocWithRootSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedAdhocWithRootSelectorTest.java
@@ -41,10 +41,10 @@ class ApplyFeedAdhocWithRootSelectorTest {
     @Feed.Source(string = "givenName,surname,age,username,heightCm\nJohn,Doe,99,jdoe,178")
     private interface PersonFeed extends Feed {
 
-        @DataSpec("givenName")
+        @AliasSpec("givenName")
         FeedSpec<String> firstName();
 
-        @DataSpec("surname")
+        @AliasSpec("surname")
         FeedSpec<String> lastName();
 
         @TemplateSpec("${firstName} ${lastName}")
@@ -53,7 +53,7 @@ class ApplyFeedAdhocWithRootSelectorTest {
         @WithPostProcessor(IntegerNegator.class)
         FeedSpec<Integer> age();
 
-        @DataSpec("heightCm")
+        @AliasSpec("heightCm")
         @WithPostProcessor(IntegerNegator.class)
         FeedSpec<Integer> height();
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedAliasSpecAndWithPostProcessorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedAliasSpecAndWithPostProcessorTest.java
@@ -19,7 +19,7 @@ import org.instancio.Instancio;
 import org.instancio.Random;
 import org.instancio.feed.Feed;
 import org.instancio.feed.FeedSpec;
-import org.instancio.feed.FeedSpecAnnotations.DataSpec;
+import org.instancio.feed.FeedSpecAnnotations.AliasSpec;
 import org.instancio.feed.FeedSpecAnnotations.WithPostProcessor;
 import org.instancio.feed.PostProcessor;
 import org.instancio.junit.InstancioExtension;
@@ -43,7 +43,7 @@ import static org.instancio.Select.field;
 
 @FeatureTag({Feature.FEED, Feature.APPLY_FEED})
 @ExtendWith(InstancioExtension.class)
-class ApplyFeedDataSpecAndWithPostProcessorTest {
+class ApplyFeedAliasSpecAndWithPostProcessorTest {
 
     @SuppressWarnings("unused")
     @Feed.Source(string = "countryCode,_number_\nc1,n1\nc2,n2\nc3,n3\n")
@@ -54,7 +54,7 @@ class ApplyFeedDataSpecAndWithPostProcessorTest {
 
         // The mapping should be done based on the FeedSpec method name,
         // which takes precedence over the data property key.
-        @DataSpec("_number_")
+        @AliasSpec("_number_")
         @WithPostProcessor(ZeroAppender.class)
         FeedSpec<String> number();
 
@@ -75,7 +75,7 @@ class ApplyFeedDataSpecAndWithPostProcessorTest {
      * </ul>
      *
      * <p>methods when populating the objects, taking into account
-     * {@link DataSpec} and {@link WithPostProcessor} annotations.
+     * {@link AliasSpec} and {@link WithPostProcessor} annotations.
      */
     @RepeatedTest(5)
     void shouldPopulateObjectsUsingDeclaredFeedSpecMethods() {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedOnFeedPropertyUnmatchedTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedOnFeedPropertyUnmatchedTest.java
@@ -45,7 +45,7 @@ class ApplyFeedOnFeedPropertyUnmatchedTest {
 
         void unrelated2();
 
-        @DataSpec("value")
+        @AliasSpec("value")
         FeedSpec<Integer> unmatchedProperty2();
 
         @GeneratedSpec(SomeIntegerGenerator.class)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedTemplateAndFunctionSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/feed/applyfeed/ApplyFeedTemplateAndFunctionSpecTest.java
@@ -44,11 +44,11 @@ class ApplyFeedTemplateAndFunctionSpecTest {
     @Feed.Source(string = "a,b\na1,b1\na2,b2\na3,b3\na4,b4")
     private interface StringFieldsFeed extends Feed {
 
-        @DataSpec("a")
+        @AliasSpec("a")
         @WithPostProcessor(UnderscoreAppender.class)
         FeedSpec<String> one();
 
-        @DataSpec("b")
+        @AliasSpec("b")
         @WithPostProcessor(UnderscoreAppender.class)
         FeedSpec<String> two();
 

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2959,7 +2959,7 @@ int yearOfBirth = personFeed.dateOfBirth().map(LocalDate::getYear);
 
 In addition, feed spec methods support the following annotations:
 
-- [`@DataSpec`](#dataspec)
+- [`@AliasSpec`](#aliasspec)
 - [`@TemplateSpec`](#templatespec)
 - [`@GeneratedSpec`](#generatedspec)
 - [`@FunctionSpec`](#functionspec)
@@ -2967,7 +2967,7 @@ In addition, feed spec methods support the following annotations:
 - [`@WithPostProcessor`](#withpostprocessor)
 - [`@NullableSpec`](#nullablespec)
 
-### `@DataSpec`
+### `@AliasSpec`
 
 This annotation allows mapping a data property using the annotation attribute instead
 of the spec method name. This decouples method names from specific data properties:
@@ -2975,7 +2975,7 @@ of the spec method name. This decouples method names from specific data properti
 ```java linenums="1" hl_lines="3"
 @Feed.Source(resource = "persons.csv")
 interface PersonFeed extends Feed {
-    @DataSpec("lastName")
+    @AliasSpec("lastName")
     FeedSpec<String> surname();
 }
 ```
@@ -2991,7 +2991,7 @@ The `@TemplateSpec` annotation enables the definition of spec methods using stri
 ```java linenums="1" hl_lines="6"
 @Feed.Source(resource = "persons.csv")
 interface PersonFeed extends Feed {
-    @DataSpec("lastName")
+    @AliasSpec("lastName")
     FeedSpec<String> surname();
 
     @TemplateSpec("Hello ${firstName} ${surname}")
@@ -3112,7 +3112,7 @@ interface PersonFeed extends Feed {
     <lnum>4</lnum> Specifies the function class for the mapping.<br/>
     <lnum>5</lnum> The type `byte[]` is the type returned by the mapping function.<br/>
 
-`@WithStringMapper` can also be used with methods annotated with `@DataSpec`:
+`@WithStringMapper` can also be used with methods annotated with `@AliasSpec`:
 
 ```java linenums="1" hl_lines="4 8"
 @Feed.Source(resource = "persons.csv")
@@ -3121,7 +3121,7 @@ interface PersonFeed extends Feed {
     FeedSpec<String> firstName();
 
     @WithStringMapper(StringByteArrayMapper.class)
-    @DataSpec("firstName")
+    @AliasSpec("firstName")
     FeedSpec<byte[]> firstNameAsBytes();
 }
 ```


### PR DESCRIPTION
This PR renames the `@DataSpec` annotation introduced in `5.0.0` to `@AliasSpec` to better reflect the purpose of the annotation.

Note: this is an experimental API