### PR TITLE
Bug fix: bean validation uses default `Settings`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/annotation/AbstractAnnotationLibraryFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/AbstractAnnotationLibraryFacade.java
@@ -57,7 +57,8 @@ abstract class AbstractAnnotationLibraryFacade implements AnnotationLibraryFacad
     @Override
     public final void consumeAnnotations(final AnnotationMap annotationMap,
                                          final GeneratorSpec<?> spec,
-                                         final Class<?> targetClass) {
+                                         final Class<?> targetClass,
+                                         final GeneratorContext generatorContext) {
 
         final AnnotationHandlerMap annotationHandlerMap = getAnnotationHandlerMap();
         final Collection<Annotation> annotations = annotationMap.getAnnotations();
@@ -65,7 +66,7 @@ abstract class AbstractAnnotationLibraryFacade implements AnnotationLibraryFacad
         for (Annotation annotation : annotations) {
             final FieldAnnotationHandler handler = annotationHandlerMap.get(annotation);
             if (handler != null) {
-                handler.process(annotation, spec, targetClass);
+                handler.process(annotation, spec, targetClass, generatorContext);
                 annotationMap.remove(annotation.annotationType());
             }
         }

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/AnnotationLibraryFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/AnnotationLibraryFacade.java
@@ -55,14 +55,16 @@ public interface AnnotationLibraryFacade {
      * starting with the primary annotation. Consumed annotations are removed
      * from the map.
      *
-     * @param map         from which annotations will be consumed
-     * @param spec        generator spec for the given field
-     * @param targetClass type being generated
+     * @param map              from which annotations will be consumed
+     * @param spec             generator spec for the given field
+     * @param targetClass      type being generated
+     * @param generatorContext the generator context containing current settings
      * @since 2.7.0
      */
     void consumeAnnotations(AnnotationMap map,
                             GeneratorSpec<?> spec,
-                            Class<?> targetClass);
+                            Class<?> targetClass,
+                            GeneratorContext generatorContext);
 
     /**
      * Resolves a generator for the given primary annotation.

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.annotation;
 
 import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.specs.ArrayGeneratorSpec;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
@@ -34,6 +35,7 @@ import org.instancio.internal.generator.util.MapGenerator;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.internal.util.Range;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
@@ -53,7 +55,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             final int fraction = getFraction(annotation);
 
@@ -91,7 +94,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final Function<Long, Number> fromLongConverter = NumberUtils.longConverter(targetClass);
@@ -108,7 +112,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final Function<Long, Number> fromLongConverter = NumberUtils.longConverter(targetClass);
@@ -125,7 +130,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final String value = getValue(annotation);
@@ -145,7 +151,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             if (spec instanceof NumberGeneratorSpec<?>) {
                 final String value = getValue(annotation);
@@ -167,7 +174,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof InternalNumberGeneratorSpec<?>) {
                 ((InternalNumberGeneratorSpec<Number>) spec).ensureMinIsGreaterThanOrEqualTo(min);
@@ -186,7 +194,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof InternalNumberGeneratorSpec<?>) {
                 ((InternalNumberGeneratorSpec<Number>) spec).ensureMaxIsLessThanOrEqualTo(max);
@@ -199,7 +208,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof TemporalGeneratorSpec<?>) {
                 ((TemporalGeneratorSpec<?>) spec).past();
@@ -211,7 +221,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof TemporalGeneratorSpec<?>) {
                 ((TemporalGeneratorSpec<?>) spec).future();
@@ -228,11 +239,14 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
+
+            final Settings settings = generatorContext.getSettings();
 
             if (spec instanceof InternalLengthGeneratorSpec<?>) {
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        getMin(annotation), getMax(annotation), Keys.STRING_MAX_LENGTH.defaultValue());
+                        getMin(annotation), getMax(annotation), settings.get(Keys.STRING_MAX_LENGTH));
 
                 ((InternalLengthGeneratorSpec<?>) spec).length(range.min(), range.max());
 
@@ -241,17 +255,17 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
                 }
             } else if (spec instanceof CollectionGeneratorSpec<?>) {
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        getMin(annotation), getMax(annotation), Keys.COLLECTION_MAX_SIZE.defaultValue());
+                        getMin(annotation), getMax(annotation), settings.get(Keys.COLLECTION_MAX_SIZE));
 
                 ((CollectionGeneratorSpec<?>) spec).minSize(range.min()).maxSize(range.max());
             } else if (spec instanceof MapGeneratorSpec<?, ?>) {
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        getMin(annotation), getMax(annotation), Keys.MAP_MAX_SIZE.defaultValue());
+                        getMin(annotation), getMax(annotation), settings.get(Keys.MAP_MAX_SIZE));
 
                 ((MapGeneratorSpec<?, ?>) spec).minSize(range.min()).maxSize(range.max());
             } else if (spec instanceof ArrayGeneratorSpec<?>) {
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        getMin(annotation), getMax(annotation), Keys.ARRAY_MAX_LENGTH.defaultValue());
+                        getMin(annotation), getMax(annotation), settings.get(Keys.ARRAY_MAX_LENGTH));
 
                 ((ArrayGeneratorSpec<?>) spec).minLength(range.min()).maxLength(range.max());
             }
@@ -262,7 +276,10 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
+
+            final Settings settings = generatorContext.getSettings();
 
             if (spec instanceof StringGenerator) {
                 final StringGenerator generator = (StringGenerator) spec;
@@ -273,17 +290,17 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
             } else if (spec instanceof ArrayGenerator<?>) {
                 ((ArrayGenerator<?>) spec)
                         .nullable(false)
-                        .minLength(Keys.ARRAY_MIN_LENGTH.defaultValue());
+                        .minLength(settings.get(Keys.ARRAY_MIN_LENGTH));
 
             } else if (spec instanceof CollectionGenerator<?>) {
                 ((CollectionGenerator<?>) spec)
                         .nullable(false)
-                        .minSize(Keys.COLLECTION_MIN_SIZE.defaultValue());
+                        .minSize(settings.get(Keys.COLLECTION_MIN_SIZE));
 
             } else if (spec instanceof MapGenerator<?, ?>) {
                 ((MapGenerator<?, ?>) spec)
                         .nullable(false)
-                        .minSize(Keys.MAP_MIN_SIZE.defaultValue());
+                        .minSize(settings.get(Keys.MAP_MIN_SIZE));
             }
         }
     }
@@ -292,7 +309,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             AnnotationUtils.setSpecNullableToFalse(spec);
         }
@@ -308,7 +326,8 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof BooleanGenerator) {
                 ((BooleanGenerator) spec).probability(generatedValue ? 1 : 0);

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/CommonPersistenceAnnotationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/CommonPersistenceAnnotationHandlerMap.java
@@ -15,11 +15,13 @@
  */
 package org.instancio.internal.annotation;
 
+import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.specs.StringGeneratorSpec;
 import org.instancio.internal.generator.specs.InternalFractionalNumberGeneratorSpec;
 import org.instancio.internal.util.Range;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 
 import java.lang.annotation.Annotation;
 
@@ -39,16 +41,18 @@ class CommonPersistenceAnnotationHandlerMap extends AnnotationHandlerMap {
         @Override
         public final void process(final Annotation annotation,
                                   final GeneratorSpec<?> spec,
-                                  final Class<?> targetClass) {
+                                  final Class<?> targetClass,
+                                  final GeneratorContext generatorContext) {
 
             if (spec instanceof StringGeneratorSpec) {
+                final Settings settings = generatorContext.getSettings();
                 final int maxLength = getLength(annotation);
-                final int minLength = Math.min(maxLength, Keys.STRING_MIN_LENGTH.defaultValue());
+                final int minLength = Math.min(maxLength, settings.get(Keys.STRING_MIN_LENGTH));
 
                 // The default value of Column.length is 255. For this reason,
                 // use STRING_MAX_LENGTH as the limit to avoid generating large strings.
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        minLength, maxLength, Keys.STRING_MAX_LENGTH.defaultValue());
+                        minLength, maxLength, settings.get(Keys.STRING_MAX_LENGTH));
 
                 final StringGeneratorSpec stringSpec = (StringGeneratorSpec) spec;
                 stringSpec.length(range.min(), range.max());

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/FieldAnnotationHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/FieldAnnotationHandler.java
@@ -16,6 +16,7 @@
 package org.instancio.internal.annotation;
 
 import org.instancio.documentation.InternalApi;
+import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 
 import java.lang.annotation.Annotation;
@@ -32,12 +33,17 @@ interface FieldAnnotationHandler {
     /**
      * Processes the specified annotation.
      *
-     * @param annotation  annotation to process
-     * @param spec        for customising generated values
-     * @param targetClass actual type that will be generated; provided for cases
-     *                    where field is declared as a {@link java.lang.reflect.TypeVariable},
-     *                    which would result in {@code Object} being returned by {@link Field#getType()}.
+     * @param annotation       annotation to process
+     * @param spec             for customising generated values
+     * @param targetClass      actual type that will be generated; provided for cases
+     *                         where field is declared as a {@link java.lang.reflect.TypeVariable},
+     *                         which would result in {@code Object} being returned by {@link Field#getType()}.
+     * @param generatorContext the generator context containing current settings
      * @since 2.7.0
      */
-    void process(Annotation annotation, GeneratorSpec<?> spec, Class<?> targetClass);
+    void process(
+            Annotation annotation,
+            GeneratorSpec<?> spec,
+            Class<?> targetClass,
+            GeneratorContext generatorContext);
 }

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationHandlerMap.java
@@ -15,6 +15,7 @@
  */
 package org.instancio.internal.annotation;
 
+import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.GeneratorSpec;
 import org.instancio.generator.specs.CollectionGeneratorSpec;
 import org.instancio.generator.specs.DurationGeneratorSpec;
@@ -26,6 +27,7 @@ import org.instancio.internal.generator.specs.InternalLengthGeneratorSpec;
 import org.instancio.internal.util.NumberUtils;
 import org.instancio.internal.util.Range;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 
 import java.lang.annotation.Annotation;
 import java.time.Duration;
@@ -53,7 +55,8 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof DurationGeneratorSpec) {
                 final org.hibernate.validator.constraints.time.DurationMin d =
@@ -77,7 +80,8 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof DurationGeneratorSpec) {
                 final org.hibernate.validator.constraints.time.DurationMax d =
@@ -102,13 +106,16 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             final org.hibernate.validator.constraints.Length length =
                     (org.hibernate.validator.constraints.Length) annotation;
 
+            final Settings settings = generatorContext.getSettings();
+
             final Range<Integer> range = AnnotationUtils.calculateRange(
-                    length.min(), length.max(), Keys.STRING_MAX_LENGTH.defaultValue());
+                    length.min(), length.max(), settings.get(Keys.STRING_MAX_LENGTH));
 
             if (spec instanceof InternalLengthGeneratorSpec<?>) {
                 ((InternalLengthGeneratorSpec<?>) spec).length(range.min(), range.max());
@@ -123,7 +130,8 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             final org.hibernate.validator.constraints.Range range =
                     (org.hibernate.validator.constraints.Range) annotation;
@@ -154,7 +162,8 @@ final class HibernateBeanValidationHandlerMap extends AnnotationHandlerMap {
         @Override
         public void process(final Annotation annotation,
                             final GeneratorSpec<?> spec,
-                            final Class<?> targetClass) {
+                            final Class<?> targetClass,
+                            final GeneratorContext generatorContext) {
 
             if (spec instanceof CollectionGeneratorSpec<?>) {
                 ((CollectionGeneratorSpec<?>) spec).unique();

--- a/instancio-core/src/main/java/org/instancio/internal/generation/AnnotationNodeHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generation/AnnotationNodeHandler.java
@@ -110,7 +110,7 @@ final class AnnotationNodeHandler implements NodeHandler {
             generator = getGenerator(node, annotations, annotationMap);
 
             for (AnnotationLibraryFacade lib : annotationLibraryFacades) {
-                lib.consumeAnnotations(annotationMap, generator, node.getTargetClass());
+                lib.consumeAnnotations(annotationMap, generator, node.getTargetClass(), generatorContext);
             }
         } else {
             generator = generatorResolver.get(node);

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/StringLengthBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/StringLengthBVTest.java
@@ -18,6 +18,7 @@ package org.instancio.test.beanvalidation;
 import org.instancio.Instancio;
 import org.instancio.junit.Given;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
 import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.StringLengthBV;
@@ -35,15 +36,19 @@ import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 @ExtendWith(InstancioExtension.class)
 class StringLengthBVTest {
 
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.STRING_MAX_LENGTH, 3);
+
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize(@Given StringLengthBV.WithMinSize result) {
         HibernateValidatorUtil.assertValid(result);
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
-    void withMinSizeZeo(@Given StringLengthBV.WithMinSizeZero result) {
+    void withMinSizeZero(@Given StringLengthBV.WithMinSizeZero result) {
         HibernateValidatorUtil.assertValid(result);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.STRING_MAX_LENGTH.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.STRING_MAX_LENGTH));
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
@@ -17,7 +17,9 @@ package org.instancio.test.beanvalidation;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.ArraySizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -31,6 +33,10 @@ import static org.instancio.test.support.util.Constants.SAMPLE_SIZE_DD;
 @ExtendWith(InstancioExtension.class)
 class ArraySizeBVTest {
 
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.ARRAY_MAX_LENGTH, 3);
+
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
         final ArraySizeBV.WithMinSize result = Instancio.create(ArraySizeBV.WithMinSize.class);
@@ -38,9 +44,9 @@ class ArraySizeBVTest {
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final ArraySizeBV.WithMinSizeZero result = Instancio.create(ArraySizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.ARRAY_MAX_LENGTH.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.ARRAY_MAX_LENGTH));
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
@@ -37,7 +37,8 @@ class CollectionBVTest {
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
-            .set(Keys.STRING_MAX_LENGTH, 10);
+            .set(Keys.STRING_MAX_LENGTH, 10)
+            .set(Keys.COLLECTION_MAX_SIZE, 3);
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
@@ -46,9 +47,9 @@ class CollectionBVTest {
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final CollectionBV.WithMinSizeZero result = Instancio.create(CollectionBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.COLLECTION_MAX_SIZE));
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
@@ -41,7 +41,8 @@ class MapBVTest {
             .set(Keys.LONG_NULLABLE, false)
             .set(Keys.CHARACTER_NULLABLE, false)
             .set(Keys.DOUBLE_NULLABLE, false)
-            .set(Keys.STRING_MAX_LENGTH, 10);
+            .set(Keys.STRING_MAX_LENGTH, 10)
+            .set(Keys.MAP_MAX_SIZE, 3);
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
@@ -50,9 +51,9 @@ class MapBVTest {
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final MapBV.WithMinSizeZero result = Instancio.create(MapBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.MAP_MAX_SIZE));
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
@@ -40,7 +40,10 @@ class NotEmptyBVTest {
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, true)
             .set(Keys.STRING_ALLOW_EMPTY, true)
-            .set(Keys.STRING_MAX_LENGTH, 20);
+            .set(Keys.STRING_MAX_LENGTH, 20)
+            .set(Keys.ARRAY_MIN_LENGTH, 1)
+            .set(Keys.COLLECTION_MIN_SIZE, 1)
+            .set(Keys.MAP_MIN_SIZE, 1);
 
     @Test
     void notEmptyWithEmptyAllowedViaSettings() {

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
@@ -47,7 +47,7 @@ class StringSizeBVTest {
     }
 
     @RepeatedTest(SAMPLE_SIZE_D)
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final StringSizeBV.WithMinSizeZero result = Instancio.create(StringSizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.STRING_MAX_LENGTH.defaultValue());
     }

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/adhoc/GH1278Test.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/adhoc/GH1278Test.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.beanvalidation.adhoc;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.types;
+import static org.instancio.settings.Keys.BEAN_VALIDATION_ENABLED;
+import static org.instancio.settings.Keys.COLLECTION_MAX_SIZE;
+import static org.instancio.settings.Keys.COLLECTION_MIN_SIZE;
+
+/**
+ * See: https://github.com/instancio/instancio/issues/1278
+ */
+@ExtendWith(InstancioExtension.class)
+class GH1278Test {
+
+    @Data
+    private static final class SampleClass {
+        @NotEmpty
+        private Collection<String> notEmptyCollection;
+
+        @Size(min = 1)
+        private Collection<String> collectionWithMinSize;
+
+        private Collection<String> collection;
+    }
+
+    /**
+     * This Maven module uses instancio.properties with custom settings.
+     * Revert to defaults for this test class.
+     */
+    @WithSettings
+    private static final Settings settings = Settings.defaults();
+
+    @Test
+    void collectionSizeValidationEnabled() {
+        final SampleClass result = Instancio.of(SampleClass.class)
+                .withSetting(COLLECTION_MIN_SIZE, 1)
+                .withSetting(COLLECTION_MAX_SIZE, 1)
+                .withSetting(BEAN_VALIDATION_ENABLED, true)
+                .create();
+
+        assertCollectionsOfSizeOne(result);
+    }
+
+    @Test
+    void collectionSizeValidationDisabled() {
+        final SampleClass result = Instancio.of(SampleClass.class)
+                .withSetting(COLLECTION_MIN_SIZE, 1)
+                .withSetting(COLLECTION_MAX_SIZE, 1)
+                .withSetting(BEAN_VALIDATION_ENABLED, false)
+                .create();
+
+        assertCollectionsOfSizeOne(result);
+    }
+
+    @Test
+    void collectionSizeInGeneratorValidationEnabled() {
+        final SampleClass result = Instancio.of(SampleClass.class)
+                .withSetting(BEAN_VALIDATION_ENABLED, true)
+                .generate(types().of(Collection.class), gen -> gen.collection().size(1))
+                .create();
+
+        assertCollectionsOfSizeOne(result);
+    }
+
+    @Test
+    void collectionSizeInGeneratorValidationDisabledTest() {
+        final SampleClass result = Instancio.of(SampleClass.class)
+                .withSetting(BEAN_VALIDATION_ENABLED, false)
+                .generate(types().of(Collection.class), gen -> gen.collection().size(1))
+                .create();
+
+        assertCollectionsOfSizeOne(result);
+    }
+
+    private static void assertCollectionsOfSizeOne(final SampleClass result) {
+        assertThat(result.getNotEmptyCollection()).hasSize(1);
+        assertThat(result.getCollectionWithMinSize()).hasSize(1);
+        assertThat(result.getCollection()).hasSize(1);
+    }
+}

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
@@ -17,7 +17,9 @@ package org.instancio.test.beanvalidation;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.WithSettings;
 import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
 import org.instancio.test.pojo.beanvalidation.ArraySizeBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -30,6 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(InstancioExtension.class)
 class ArraySizeBVTest {
 
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.ARRAY_MAX_LENGTH, 3);
+
     @Test
     void withMinSize() {
         final ArraySizeBV.WithMinSize result = Instancio.create(ArraySizeBV.WithMinSize.class);
@@ -37,9 +43,9 @@ class ArraySizeBVTest {
     }
 
     @Test
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final ArraySizeBV.WithMinSizeZero result = Instancio.create(ArraySizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.ARRAY_MAX_LENGTH.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.ARRAY_MAX_LENGTH));
     }
 
     @Test

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/CollectionBVTest.java
@@ -37,7 +37,8 @@ class CollectionBVTest {
     @WithSettings
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, false)
-            .set(Keys.STRING_MAX_LENGTH, 10);
+            .set(Keys.STRING_MAX_LENGTH, 10)
+            .set(Keys.COLLECTION_MAX_SIZE, 3);
 
     @Test
     void withMinSize() {
@@ -46,9 +47,9 @@ class CollectionBVTest {
     }
 
     @Test
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final CollectionBV.WithMinSizeZero result = Instancio.create(CollectionBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.COLLECTION_MAX_SIZE.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.COLLECTION_MAX_SIZE));
     }
 
     @Test

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/MapBVTest.java
@@ -41,7 +41,8 @@ class MapBVTest {
             .set(Keys.LONG_NULLABLE, false)
             .set(Keys.CHARACTER_NULLABLE, false)
             .set(Keys.DOUBLE_NULLABLE, false)
-            .set(Keys.STRING_MAX_LENGTH, 10);
+            .set(Keys.STRING_MAX_LENGTH, 10)
+            .set(Keys.MAP_MAX_SIZE, 3);
 
     @Test
     void withMinSize() {
@@ -50,9 +51,9 @@ class MapBVTest {
     }
 
     @Test
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final MapBV.WithMinSizeZero result = Instancio.create(MapBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, Keys.MAP_MAX_SIZE.defaultValue());
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.MAP_MAX_SIZE));
     }
 
     @Test

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
@@ -40,7 +40,10 @@ class NotEmptyBVTest {
     private final Settings settings = Settings.create()
             .set(Keys.STRING_NULLABLE, true)
             .set(Keys.STRING_ALLOW_EMPTY, true)
-            .set(Keys.STRING_MAX_LENGTH, 20);
+            .set(Keys.STRING_MAX_LENGTH, 20)
+            .set(Keys.ARRAY_MIN_LENGTH, 1)
+            .set(Keys.COLLECTION_MIN_SIZE, 1)
+            .set(Keys.MAP_MIN_SIZE, 1);
 
     @Test
     void notEmptyWithEmptyAllowedViaSettings() {

--- a/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
+++ b/instancio-tests/bean-validation-javax-tests/src/test/java/org/instancio/test/beanvalidation/StringSizeBVTest.java
@@ -45,7 +45,7 @@ class StringSizeBVTest {
     }
 
     @Test
-    void withMinSizeZeo() {
+    void withMinSizeZero() {
         final StringSizeBV.WithMinSizeZero result = Instancio.create(StringSizeBV.WithMinSizeZero.class);
         assertThat(result.getValue()).hasSizeBetween(0, Keys.STRING_MAX_LENGTH.defaultValue());
     }


### PR DESCRIPTION
Closes #1278