### PR TITLE
It allows the generated number to be very close to or even equal to the limits configured for the interval

### DIFF
--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/math/BigDecimalGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/math/BigDecimalGeneratorTest.java
@@ -15,18 +15,23 @@
  */
 package org.instancio.test.features.generator.math;
 
+import org.assertj.core.api.SoftAssertions;
 import org.instancio.Instancio;
+import org.instancio.generator.specs.BigDecimalSpec;
 import org.instancio.generator.specs.NumberGeneratorSpec;
 import org.instancio.generators.Generators;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.support.BaseNumericGeneratorTest;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.root;
@@ -82,4 +87,39 @@ class BigDecimalGeneratorTest extends BaseNumericGeneratorTest<BigDecimal> {
                 .isGreaterThanOrEqualTo(min)
                 .isLessThanOrEqualTo(max);
     }
+
+    public static void main(String[] args) {
+        System.out.println(new BigDecimal("10000.07").setScale(1, RoundingMode.HALF_UP));
+    }
+
+    @Test
+    void rangeWithScaleSmallerThanThoseOfMinAndMax() {
+        final BigDecimal min = new BigDecimal("0.01");
+        final BigDecimal max = new BigDecimal("0.99");
+
+        final int scale = 1;
+
+        final BigDecimal minWithScale1 = new BigDecimal("0.0");
+        final BigDecimal maxWithScale1 = new BigDecimal("1.0");
+
+        final BigDecimalSpec rangedSpec = Instancio.gen().math().bigDecimal().range(min, max).scale(scale);
+
+        BigDecimal minGenerated = rangedSpec.get();
+        BigDecimal maxGenerated = rangedSpec.get();
+        for (int i = 1; i < Constants.SAMPLE_SIZE_DDD; i++) {
+            final BigDecimal generated = rangedSpec.get();
+            if (generated.compareTo(minGenerated) < 0) {
+                minGenerated = generated;
+            } else if (generated.compareTo(maxGenerated) > 0) {
+                maxGenerated = generated;
+            }
+        }
+
+        final SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(minGenerated).isEqualByComparingTo(minWithScale1);
+        softAssertions.assertThat(maxGenerated).isEqualByComparingTo(maxWithScale1);
+
+        softAssertions.assertAll();
+    }
+
 }

--- a/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
+++ b/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,21 +83,24 @@ class ColumnScaleAndPrecisionJPATest {
         assertThat(result.getD3()).hasScaleOf(0);
     }
 
-    @RepeatedTest(Constants.SAMPLE_SIZE_DD)
+    @RepeatedTest(Constants.SAMPLE_SIZE_DDD)
     void withScale() {
+        final BigDecimal defaultMin = new BigDecimal("0.01");
+        final BigDecimal defaultMax = new BigDecimal("10000");
+
         final WithScale result = Instancio.create(WithScale.class);
 
+        final BigDecimal scaledMinD1 = defaultMin.setScale(-2, RoundingMode.HALF_UP);
+        final BigDecimal scaledMaxD1 = defaultMax.setScale(-2, RoundingMode.HALF_UP);
         assertThat(result.getD1())
                 .hasScaleOf(-2)
-                .isBetween(
-                        new BigDecimal("10"),
-                        new BigDecimal("10000"));
+                .isBetween(scaledMinD1, scaledMaxD1);
 
+        final BigDecimal scaledMinD2 = defaultMin.setScale(9, RoundingMode.HALF_UP);
+        final BigDecimal scaledMaxD2 = defaultMax.setScale(9, RoundingMode.HALF_UP);
         assertThat(result.getD2())
                 .hasScaleOf(9)
-                .isBetween(
-                        new BigDecimal("1"),
-                        new BigDecimal("10000"));
+                .isBetween(scaledMinD2, scaledMaxD2);
     }
 
     @RepeatedTest(Constants.SAMPLE_SIZE_DD)

--- a/instancio-tests/jpa-javax-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
+++ b/instancio-tests/jpa-javax-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,21 +67,24 @@ class ColumnScaleAndPrecisionJPATest {
         assertThat(result.getD3()).hasScaleOf(0);
     }
 
-    @RepeatedTest(Constants.SAMPLE_SIZE_DD)
+    @RepeatedTest(Constants.SAMPLE_SIZE_DDD)
     void withScale() {
+        final BigDecimal defaultMin = new BigDecimal("0.01");
+        final BigDecimal defaultMax = new BigDecimal("10000");
+
         final WithScale result = Instancio.create(WithScale.class);
 
+        final BigDecimal scaledMinD1 = defaultMin.setScale(-2, RoundingMode.HALF_UP);
+        final BigDecimal scaledMaxD1 = defaultMax.setScale(-2, RoundingMode.HALF_UP);
         assertThat(result.getD1())
                 .hasScaleOf(-2)
-                .isBetween(
-                        new BigDecimal("10"),
-                        new BigDecimal("10000"));
+                .isBetween(scaledMinD1, scaledMaxD1);
 
+        final BigDecimal scaledMinD2 = defaultMin.setScale(9, RoundingMode.HALF_UP);
+        final BigDecimal scaledMaxD2 = defaultMax.setScale(9, RoundingMode.HALF_UP);
         assertThat(result.getD2())
                 .hasScaleOf(9)
-                .isBetween(
-                        new BigDecimal("1"),
-                        new BigDecimal("10000"));
+                .isBetween(scaledMinD2, scaledMaxD2);
     }
 
     @RepeatedTest(Constants.SAMPLE_SIZE_DD)


### PR DESCRIPTION
1. Changes how rndDelta is calculated, allowing for a delta of zero to be generated.
2. After scaling to the configured scale, the value is compared against the interval bounds. If it is out of bounds, than the proper bound is returned **after** scaling it using the same rule applied to the generated value so the configured scale is honored.
3. Test `org.instancio.test.jpa.ColumnScaleAndPrecisionJPATest#withScale` in `instancio-tests/jpa-jakarta-tests` had to be modified because before the fix, the minimum value was always above 1000, so it would always pass the `isBetween` assertion. After the fix it is now possible that the generated value is `0.01`, which, with a configured scale of `-2` is equal to `0`.

We talked about item 3, that the returned value should be equal to the interval limit if somehow the value was out of bounds. However I thought about the expectation that the returned value has the configured scale. With a configured scale of `-2` is it reasonable to expect a value of `0.01` to be returned? My train of thought was: generate the value using the configured the interval and **after that** apply the configured scale.

Let me know what you think.