### PR TITLE
Upgrade build to java 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 24
           cache: maven
 
       - name: 'Build project'

--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 23
+          java-version: 24
           server-id: sonatype-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -26,7 +26,7 @@ jobs:
     needs: deploy
     strategy:
       matrix:
-        java: [ 8, 11, 17, 21, 23 ]
+        java: [ 8, 11, 17, 21, 24 ]
     runs-on: ubuntu-latest
     name: "Verify snapshots JDK ${{ matrix.java }}"
     steps:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,7 +15,7 @@ jobs:
         uses: evaristegalois11/sonar-fork-analysis@v1
         with:
           distribution: temurin
-          java-version: 23
+          java-version: 24
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           project-key: instancio_instancio

--- a/build-tools/src/main/resources/pmd-rules.xml
+++ b/build-tools/src/main/resources/pmd-rules.xml
@@ -29,6 +29,7 @@
         <exclude name="AvoidStringBufferField"/>
         <exclude name="ForLoopVariableCount"/>
         <exclude name="GuardLogStatement"/>
+        <exclude name="ImplicitFunctionalInterface"/>
     </rule>
 
     <rule ref="category/java/codestyle.xml">

--- a/instancio-core/src/main/java/org/instancio/Instancio.java
+++ b/instancio-core/src/main/java/org/instancio/Instancio.java
@@ -152,6 +152,7 @@ import static org.instancio.internal.util.TypeUtils.cast;
  * @see Select
  * @since 1.0.1
  */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 public final class Instancio {
 
     private Instancio() {

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/DefaultSetterMethodResolver.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/DefaultSetterMethodResolver.java
@@ -49,6 +49,7 @@ final class DefaultSetterMethodResolver {
         return null;
     }
 
+    @SuppressWarnings("PMD.ExhaustiveSwitchHasDefault")
     private static MethodNameResolver getMethodNameResolver(final SetterStyle style) {
         switch (style) {
             case SET:

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.enforcer.require.java.version>[23,)</maven.enforcer.require.java.version>
+        <maven.enforcer.require.java.version>[24,)</maven.enforcer.require.java.version>
         <sonar.organization>instancio</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <!--suppress UnresolvedMavenProperty -->
@@ -86,6 +86,7 @@
         <version.maven-jar-plugin>3.4.2</version.maven-jar-plugin>
         <version.maven-javadoc-plugin>3.11.2</version.maven-javadoc-plugin>
         <version.maven-pmd-plugin>3.26.0</version.maven-pmd-plugin>
+        <pmdVersion>7.12.0</pmdVersion>
         <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
         <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
         <version.maven-source-plugin>3.3.1</version.maven-source-plugin>
@@ -357,6 +358,26 @@
                             <groupId>org.instancio</groupId>
                             <artifactId>build-tools</artifactId>
                             <version>${project.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-core</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-java</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-javascript</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-jsp</artifactId>
+                            <version>${pmdVersion}</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/website/docs/building.md
+++ b/website/docs/building.md
@@ -8,7 +8,7 @@ hide:
 
 Instancio is packaged as a [multi-release JAR](https://openjdk.java.net/jeps/238).
 It can be used with Java 8 or higher.
-Building Instancio from sources requires JDK 23 or higher:
+Building Instancio from sources requires JDK 24 or higher:
 
 ```sh
 git clone https://github.com/instancio/instancio.git


### PR DESCRIPTION
Upgrade the build process to java 24.

Unfortunately the pmd version shipped with the maven plugin doesn't support java 24, so I manually upgrade it following [this guide](https://maven.apache.org/plugins/maven-pmd-plugin/examples/upgrading-PMD-at-runtime.html).

For now I just suppressed the new rules and everything seems to work nice :D