### PR TITLE
Rework release process to accomodate new plugin limitations

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -14,11 +14,11 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 24
-          server-id: sonatype-snapshots
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: "Deploy snapshots"
-        run: mvn -Pdeploy-test-dependencies -B deploy --no-transfer-progress
+        run: mvn -Dsnapshot -B deploy --no-transfer-progress
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -14,7 +14,6 @@
         <sonar.skip>true</sonar.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
-        <skipPublishing>true</skipPublishing>
         <pmd.skip>true</pmd.skip>
         <gpg.skip>true</gpg.skip>
     </properties>

--- a/instancio-tests/instancio-test-support/pom.xml
+++ b/instancio-tests/instancio-test-support/pom.xml
@@ -15,15 +15,6 @@
         <jacoco.skip>true</jacoco.skip>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>deploy-test-dependencies</id>
-            <properties>
-                <skipPublishing>false</skipPublishing>
-            </properties>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -16,7 +16,6 @@
         <maven.enforcer.require.java.version>8</maven.enforcer.require.java.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
-        <skipPublishing>true</skipPublishing>
         <gpg.skip>true</gpg.skip>
         <version.apache.commons>3.17.0</version.apache.commons>
         <version.archunit>1.4.0</version.archunit>
@@ -31,30 +30,43 @@
         <version.maven-surefire-plugin>3.5.3</version.maven-surefire-plugin>
     </properties>
 
-    <!-- These test modules are run against Java 8 and higher.
-         Other test modules require Java 16 or higher (see profiles).
-     -->
     <modules>
         <module>instancio-test-support</module>
-        <module>feature-tests</module>
-        <module>instancio-guava-tests</module>
-        <module>default-package-tests</module>
-        <module>global-seed-tests</module>
-        <module>groovy-tests</module>
-        <module>kotlin-tests</module>
-        <module>jpa-javax-tests</module>
-        <module>jpa-jakarta-tests</module>
-        <module>bean-validation-javax-tests</module>
-        <module>bean-validation-jakarta-tests</module>
-        <module>bean-validation-hibernate5-tests</module>
-        <module>packaging-tests</module>
-        <module>report-aggregate</module>
     </modules>
 
     <profiles>
         <profile>
+            <id>java-8</id>
+            <!-- These test modules are run against Java 8 and higher.
+                 Other test modules require Java 16 or higher (see other profiles).
+            -->
+            <activation>
+                <property>
+                    <name>!snapshot</name>
+                </property>
+            </activation>
+            <modules>
+                <module>feature-tests</module>
+                <module>instancio-guava-tests</module>
+                <module>default-package-tests</module>
+                <module>global-seed-tests</module>
+                <module>groovy-tests</module>
+                <module>kotlin-tests</module>
+                <module>jpa-javax-tests</module>
+                <module>jpa-jakarta-tests</module>
+                <module>bean-validation-javax-tests</module>
+                <module>bean-validation-jakarta-tests</module>
+                <module>bean-validation-hibernate5-tests</module>
+                <module>packaging-tests</module>
+                <module>report-aggregate</module>
+            </modules>
+        </profile>
+        <profile>
             <id>java-16</id>
             <activation>
+                <property>
+                    <name>!snapshot</name>
+                </property>
                 <jdk>[16,)</jdk>
             </activation>
             <modules>
@@ -64,6 +76,9 @@
         <profile>
             <id>java-17</id>
             <activation>
+                <property>
+                    <name>!snapshot</name>
+                </property>
                 <jdk>[17,)</jdk>
             </activation>
             <modules>
@@ -78,6 +93,9 @@
         <profile>
             <id>java-21</id>
             <activation>
+                <property>
+                    <name>!snapshot</name>
+                </property>
                 <jdk>[21,)</jdk>
             </activation>
             <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-snapshots</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-staging</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -105,17 +94,20 @@
         <module>instancio-core</module>
         <module>instancio-junit</module>
         <module>instancio-guava</module>
-        <module>instancio-tests</module>
     </modules>
 
     <profiles>
         <profile>
-            <id>release</id>
+            <id>tests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <modules>
-                <module>instancio-core</module>
-                <module>instancio-junit</module>
-                <module>instancio-guava</module>
+                <module>instancio-tests</module>
             </modules>
+        </profile>
+        <profile>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -510,7 +502,9 @@
                     <version>${version.central-publishing-maven-plugin}</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <publishingServerId>central</publishingServerId>
+                        <excludeArtifacts>
+                            <excludeArtifact>build-tools</excludeArtifact>
+                        </excludeArtifacts>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -668,8 +662,8 @@
 
     <repositories>
         <repository>
-            <id>oss-snapshot-repository</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
Sadly the new maven plugin is very limited and has no support to easily exclude projects with a simple property like maven-deploy-plugin does.

The only set up I found working that isn't terrible is to preemptively cut out all the projects that shouldn't be deployed with maven profiles.

Tested from my pc the snapshots are uploading correctly to the [new repository](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/instancio/) :partying_face: .

I didn't test a release deploy, but it should hopefully work in the same way.

