### PR TITLE
Use toolchains to compile instancio-test-support

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -18,7 +18,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: "Deploy snapshots"
-        run: mvn -Dsnapshot -B deploy --no-transfer-progress
+        run: mvn -Prelease -B deploy --no-transfer-progress
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
@@ -35,8 +35,9 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: ${{ matrix.java }}
+          java-version: |
+            24
+            ${{ matrix.java }}
       - name: "Test"
-        # use the deployed snapshot of instancio-test-support
-        # because it cannot be compiled with Java 8
-        run: cd instancio-tests && mvn -B -pl -:instancio-test-support verify
+        # Java 8 will use Java 24 through the maven-toolchains-plugin to compile instancio-test-support
+        run: cd instancio-tests && mvn -B verify

--- a/instancio-tests/instancio-test-support/pom.xml
+++ b/instancio-tests/instancio-test-support/pom.xml
@@ -30,6 +30,20 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>select-jdk-toolchain</goal>
+                        </goals>
+                        <configuration>
+                            <version>[9,)</version>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -30,43 +30,30 @@
         <version.maven-surefire-plugin>3.5.3</version.maven-surefire-plugin>
     </properties>
 
+    <!-- These test modules are run against Java 8 and higher.
+      Other test modules require Java 16 or higher (see profiles).
+    -->
     <modules>
         <module>instancio-test-support</module>
+        <module>feature-tests</module>
+        <module>instancio-guava-tests</module>
+        <module>default-package-tests</module>
+        <module>global-seed-tests</module>
+        <module>groovy-tests</module>
+        <module>kotlin-tests</module>
+        <module>jpa-javax-tests</module>
+        <module>jpa-jakarta-tests</module>
+        <module>bean-validation-javax-tests</module>
+        <module>bean-validation-jakarta-tests</module>
+        <module>bean-validation-hibernate5-tests</module>
+        <module>packaging-tests</module>
+        <module>report-aggregate</module>
     </modules>
 
     <profiles>
         <profile>
-            <id>java-8</id>
-            <!-- These test modules are run against Java 8 and higher.
-                 Other test modules require Java 16 or higher (see other profiles).
-            -->
-            <activation>
-                <property>
-                    <name>!snapshot</name>
-                </property>
-            </activation>
-            <modules>
-                <module>feature-tests</module>
-                <module>instancio-guava-tests</module>
-                <module>default-package-tests</module>
-                <module>global-seed-tests</module>
-                <module>groovy-tests</module>
-                <module>kotlin-tests</module>
-                <module>jpa-javax-tests</module>
-                <module>jpa-jakarta-tests</module>
-                <module>bean-validation-javax-tests</module>
-                <module>bean-validation-jakarta-tests</module>
-                <module>bean-validation-hibernate5-tests</module>
-                <module>packaging-tests</module>
-                <module>report-aggregate</module>
-            </modules>
-        </profile>
-        <profile>
             <id>java-16</id>
             <activation>
-                <property>
-                    <name>!snapshot</name>
-                </property>
                 <jdk>[16,)</jdk>
             </activation>
             <modules>
@@ -76,9 +63,6 @@
         <profile>
             <id>java-17</id>
             <activation>
-                <property>
-                    <name>!snapshot</name>
-                </property>
                 <jdk>[17,)</jdk>
             </activation>
             <modules>
@@ -93,9 +77,6 @@
         <profile>
             <id>java-21</id>
             <activation>
-                <property>
-                    <name>!snapshot</name>
-                </property>
                 <jdk>[21,)</jdk>
             </activation>
             <modules>

--- a/justfile
+++ b/justfile
@@ -21,8 +21,8 @@ javadoc:
     mvn javadoc:javadoc
 
 release:
-    mvn release:clean release:prepare -Darguments="-Dmaven.test.skip=true -DskipITs -DskipTests"
-    mvn release:perform -Darguments="-Dmaven.test.skip=true -DskipITs -DskipTests"
+    mvn release:clean release:prepare
+    mvn release:perform
     echo "Close, Release: https://central.sonatype.com/publishing/deployments"
 
 pip-install-mkdocs:

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,13 @@
         <version.maven-javadoc-plugin>3.11.2</version.maven-javadoc-plugin>
         <version.maven-pmd-plugin>3.26.0</version.maven-pmd-plugin>
         <pmdVersion>7.13.0</pmdVersion>
-        <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
+        <version.maven-release-plugin>3.1.1</version.maven-release-plugin>
         <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
         <version.maven-source-plugin>3.3.1</version.maven-source-plugin>
         <version.sonar-maven-plugin>5.1.0.4751</version.sonar-maven-plugin>
         <version.spotbugs-maven-plugin>4.9.3.0</version.spotbugs-maven-plugin>
         <version.versions-maven-plugin>2.18.0</version.versions-maven-plugin>
+        <version.maven-toolchains-plugin>3.2.0</version.maven-toolchains-plugin>
     </properties>
 
     <issueManagement>
@@ -508,9 +509,10 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${version.maven-release-plugin}</version>
                     <configuration>
-                        <preparationGoals>versions:set-property verify</preparationGoals>
+                        <preparationGoals>clean versions:set-property verify</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <localCheckout>true</localCheckout>
+                        <preparationProfiles>!tests</preparationProfiles>
                         <releaseProfiles>release,sign</releaseProfiles>
                     </configuration>
                 </plugin>
@@ -557,6 +559,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${version.maven-site-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>${version.maven-toolchains-plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Ok this should be it :sweat_smile: 

Bulding on #1347 and #1350 it avoids publishing instancio-test-support to the snapshot repo with the use of toolchains. This simplifies modules management and allows to publish snapshot sources too.

Also I updated the release plugin to use a new property to exclude test modules during release.