### PR TITLE
Update jooq to 3.20

### DIFF
--- a/instancio-tests/instancio-jooq-tests/pom.xml
+++ b/instancio-tests/instancio-jooq-tests/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.enforcer.require.java.version>[17,)</maven.enforcer.require.java.version>
         <animal.sniffer.skip>true</animal.sniffer.skip>
-        <version.jooq>3.19.23</version.jooq>
+        <version.jooq>3.20.4</version.jooq>
     </properties>
 
     <build>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -68,7 +68,6 @@
             <modules>
                 <module>instancio-core-tests</module>
                 <module>instancio-junit-tests</module>
-                <module>instancio-jooq-tests</module>
                 <module>java17-tests</module>
                 <module>bean-validation-hibernate-tests</module>
                 <module>spi-tests</module>
@@ -80,6 +79,7 @@
                 <jdk>[21,)</jdk>
             </activation>
             <modules>
+                <module>instancio-jooq-tests</module>
                 <module>java21-tests</module>
                 <module>jackson-tests</module>
                 <module>arch-tests</module>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -163,12 +163,6 @@
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>org.instancio</groupId>
-                    <artifactId>instancio-jooq-tests</artifactId>
-                    <version>${project.version}</version>
-                    <scope>test</scope>
-                </dependency>
             </dependencies>
         </profile>
         <profile>
@@ -222,6 +216,12 @@
                 <dependency>
                     <groupId>org.instancio</groupId>
                     <artifactId>jpms-guava-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>instancio-jooq-tests</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>


### PR DESCRIPTION
Update jooq to 3.20

The new baseline is jdk 21 so I moved all the jooq tests to the jdk 21 modules