### PR TITLE
Update equalsverifier to 4.0

### DIFF
--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -18,7 +18,7 @@
         <version.apache.commons>3.17.0</version.apache.commons>
         <version.archunit>1.4.1</version.archunit>
         <version.assertj>3.27.3</version.assertj>
-        <version.equalsverifier>3.19.4</version.equalsverifier>
+        <version.equalsverifier>4.0</version.equalsverifier>
         <version.junit.pioneer>1.9.1</version.junit.pioneer>
         <version.logback>1.3.12</version.logback>
         <version.lombok>1.18.38</version.lombok>


### PR DESCRIPTION
Update equalsverifier to the new major version, the new jdk 17 requirement doesn't seem to have any impact