### PR TITLE
Update mockito to 5.18.0

### DIFF
--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -11,8 +11,6 @@
     <name>Instancio Tests: Tests Parent</name>
 
     <properties>
-        <!-- prevents Mockito error when building with Java 21 -->
-        <argLine>-Dnet.bytebuddy.experimental=true</argLine>
         <maven.enforcer.require.java.version>8</maven.enforcer.require.java.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <maven.source.skip>true</maven.source.skip>
@@ -24,7 +22,7 @@
         <version.junit.pioneer>1.9.1</version.junit.pioneer>
         <version.logback>1.3.12</version.logback>
         <version.lombok>1.18.38</version.lombok>
-        <version.mockito>4.11.0</version.mockito>
+        <version.mockito>5.18.0</version.mockito>
         <!-- plugins -->
         <version.maven-failsafe-plugin>3.5.3</version.maven-failsafe-plugin>
         <version.maven-surefire-plugin>3.5.3</version.maven-surefire-plugin>


### PR DESCRIPTION
Update mockito to version 5, new baseline is jdk 11 with a new inline mockmaker. Tested with java 8, 17 and 24 and everything seems to work fine :grin: 