### PR TITLE
Fix tests for JPA `@Column` with default scale and precision (#1372)

### DIFF
--- a/instancio-tests/jpa-jakarta-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
+++ b/instancio-tests/jpa-jakarta-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
@@ -38,7 +38,7 @@ public class ColumnScaleAndPrecisionJPA {
     }
 
     @Data
-    public static class WithDefaultPrecision {
+    public static class WithDefaultScaleAndPrecision {
         @Column
         private BigDecimal d;
     }

--- a/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
+++ b/instancio-tests/jpa-jakarta-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
@@ -18,7 +18,7 @@ package org.instancio.test.jpa;
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.FloatAndDoubleWithScaleAndPrecision;
-import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithDefaultPrecision;
+import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithDefaultScaleAndPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecisionScale;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecisionScaleAndDecimalMinMax;
@@ -57,12 +57,11 @@ class ColumnScaleAndPrecisionJPATest {
     }
 
     @RepeatedTest(Constants.SAMPLE_SIZE_D)
-    void withDefaultPrecision() {
-        final WithDefaultPrecision result = Instancio.create(WithDefaultPrecision.class);
+    void withDefaultScaleAndPrecision() {
+        final WithDefaultScaleAndPrecision result = Instancio.create(WithDefaultScaleAndPrecision.class);
 
-        // default precision of zero should be ignored
         assertThat(result.getD()).isBetween(
-                new BigDecimal("1"),
+                new BigDecimal("0.01"),
                 new BigDecimal("10000"));
     }
 

--- a/instancio-tests/jpa-javax-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
+++ b/instancio-tests/jpa-javax-tests/src/main/java/org/instancio/test/pojo/jpa/ColumnScaleAndPrecisionJPA.java
@@ -29,7 +29,7 @@ import java.math.BigDecimal;
 public class ColumnScaleAndPrecisionJPA {
 
     @Data
-    public static class WithDefaultPrecision {
+    public static class WithDefaultScaleAndPrecision {
         @Column
         private BigDecimal d;
     }

--- a/instancio-tests/jpa-javax-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
+++ b/instancio-tests/jpa-javax-tests/src/test/java/org/instancio/test/jpa/ColumnScaleAndPrecisionJPATest.java
@@ -17,7 +17,7 @@ package org.instancio.test.jpa;
 
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
-import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithDefaultPrecision;
+import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithDefaultScaleAndPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecision;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecisionScale;
 import org.instancio.test.pojo.jpa.ColumnScaleAndPrecisionJPA.WithPrecisionScaleAndDecimalMinMax;
@@ -41,12 +41,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ColumnScaleAndPrecisionJPATest {
 
     @RepeatedTest(Constants.SAMPLE_SIZE_D)
-    void withDefaultPrecision() {
-        final WithDefaultPrecision result = Instancio.create(WithDefaultPrecision.class);
+    void withDefaultScaleAndPrecision() {
+        final WithDefaultScaleAndPrecision result = Instancio.create(WithDefaultScaleAndPrecision.class);
 
-        // default precision of zero should be ignored
         assertThat(result.getD()).isBetween(
-                new BigDecimal("1"),
+                new BigDecimal("0.01"),
                 new BigDecimal("10000"));
     }
 


### PR DESCRIPTION
- #1372

This fixes a failing test:

```
Test method 'withDefaultPrecision' failed with seed: 2853220327791096423 (seed source: random seed)

Error:  org.instancio.test.jpa.ColumnScaleAndPrecisionJPATest.withDefaultPrecision()

Expecting actual:
  0.15
to be between:
  [1, 10000]

	at org.instancio.test.jpa.ColumnScaleAndPrecisionJPATest.withDefaultPrecision(ColumnScaleAndPrecisionJPATest.java:64)
```

@EvaristeGalois11 initially i thought this might be a bug, but it seems to me if `scale` and `precision` are not specified (both zero) then any positive value should be accepted. What do you think?

