### PR TITLE
Support for ignoring field names using regexes via a setting

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/Sonar.java
@@ -20,24 +20,25 @@ public final class Sonar {
     public static final String ACCESSIBILITY_UPDATE_SHOULD_BE_REMOVED = "java:S3011";
     public static final String ADD_ASSERTION = "java:S2699";
     public static final String CATCH_EXCEPTION_INSTEAD_OF_THROWABLE = "java:S1181";
-    public static final String DEFINE_DEDICATED_EXCEPTION = "java:S112";
     public static final String COGNITIVE_COMPLEXITY_OF_METHOD = "java:S3776";
+    public static final String DEFINE_DEDICATED_EXCEPTION = "java:S112";
     public static final String DISABLED_TEST = "java:S1607";
+    public static final String FIELD_NAMING_CONVENTION =  "java:S116";
+    public static final String FUNCTIONAL_INTERFACES_SHOULD_BE_SPECIALISED = "java:S4276";
     public static final String GENERIC_WILDCARD_IN_RETURN = "java:S1452";
+    // avoid computeIfAbsent() in hot paths as it has a minor performance hit
+    public static final String MAP_COMPUTE_IF_ABSENT = "java:S3824";
     public static final String METHODS_RETURNS_SHOULD_NOT_BE_INVARIANT = "java:S3516";
     public static final String NULL_OPTIONAL = "java:S2789";
     public static final String NUMBER_OF_PARENTS = "java:S110";
+    public static final String ONE_METHOD_WHEN_TESTING_EXCEPTIONS = "java:S5778";
+    public static final String OVERRIDE_EQUALS = "java:S2160";
     public static final String RAW_USE_OF_PARAMETERIZED_CLASS = "java:S3740";
     public static final String RETURN_EMPTY_COLLECTION = "java:S1168";
-    public static final String ONE_METHOD_WHEN_TESTING_EXCEPTIONS = "java:S5778";
     public static final String STRING_LITERALS_DUPLICATED = "java:S1192";
-    public static final String USE_INSTANCEOF = "java:S1872";
-    public static final String FUNCTIONAL_INTERFACES_SHOULD_BE_SPECIALISED = "java:S4276";
-    public static final String USING_SLOW_REGEX = "java:S5852";
-    public static final String OVERRIDE_EQUALS = "java:S2160";
     public static final String TOO_MANY_PARAMETERS = "java:S107";
-    // avoid computeIfAbsent() in hot paths as it has a minor performance hit
-    public static final String MAP_COMPUTE_IF_ABSENT = "java:S3824";
+    public static final String USE_INSTANCEOF = "java:S1872";
+    public static final String USING_SLOW_REGEX = "java:S5852";
 
     private Sonar() {
         // non-instantiable

--- a/instancio-core/src/main/java/org/instancio/internal/util/StringUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/StringUtils.java
@@ -19,11 +19,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
 import static org.instancio.internal.util.ErrorMessageUtils.invalidStringTemplate;
 
+@SuppressWarnings("PMD.GodClass")
 public final class StringUtils {
 
     public static boolean isEmpty(@Nullable final String s) {
@@ -148,6 +150,46 @@ public final class StringUtils {
             }
         }
         return results;
+    }
+
+    /**
+     * Splits given string using {@code ','} as the separator.
+     * Trims whitespace from the split tokens.
+     *
+     * <p>This is a slightly modified version of the {@code split()}
+     * method copied from {@code org.apache.commons.lang3.StringUtils}.
+     *
+     * @param str to split
+     * @return an immutable list of tokens or an empty list if none
+     */
+    public static List<String> split(@Nullable String str) {
+        if (isBlank(str)) {
+            return Collections.emptyList();
+        }
+
+        final char separatorChar = ',';
+        final int len = str.length();
+        final List<String> tokens = new ArrayList<>();
+
+        int i = 0;
+        int start = 0;
+        while (i < len) {
+            if (str.charAt(i) == separatorChar) {
+                final String token = str.substring(start, i).trim();
+                if (!token.isEmpty()) {
+                    tokens.add(token);
+                }
+                start = ++i;
+                continue;
+            }
+            i++;
+        }
+
+        final String token = str.substring(start, i).trim();
+        if (!token.isEmpty()) {
+            tokens.add(token);
+        }
+        return Collections.unmodifiableList(tokens);
     }
 
     private StringUtils() {

--- a/instancio-core/src/main/java/org/instancio/settings/Keys.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Keys.java
@@ -260,6 +260,17 @@ public final class Keys {
             "float.nullable", Boolean.class, false);
 
     /**
+     * Specifies a comma-separated list of regexes for field names that
+     * should be ignored; default is an empty string (no fields ignored);
+     * property name {@code ignore.field.name.regexes}.
+     *
+     * @since 5.5.0
+     */
+    @ExperimentalApi
+    public static final SettingKey<String> IGNORE_FIELD_NAME_REGEXES = registerRequiredNonAdjustable(
+            "ignore.field.name.regexes", String.class, "");
+
+    /**
      * Specifies the number of samples for the {@code @InstancioSource}
      * annotation from the {@code instancio-junit} module;
      * default is 100; property name {@code instancio.source.samples}.

--- a/instancio-core/src/main/resources/instancio-sample.properties
+++ b/instancio-core/src/main/resources/instancio-sample.properties
@@ -23,6 +23,7 @@ fill.type=POPULATE_NULLS_AND_DEFAULT_PRIMITIVES
 float.max=10000
 float.min=1
 float.nullable=false
+ignore.field.name.regexes=foo.*,bar.*
 instancio.source.samples=100
 integer.max=10000
 integer.min=1

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/IgnoreFieldNameRegexesTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/IgnoreFieldNameRegexesTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.settings;
+
+import org.instancio.Instancio;
+import org.instancio.internal.util.Sonar;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.test.support.conditions.Conditions;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.SETTINGS)
+@ExtendWith(InstancioExtension.class)
+class IgnoreFieldNameRegexesTest {
+
+    @SuppressWarnings(Sonar.FIELD_NAMING_CONVENTION)
+    private static class Pojo {
+        private String $$_ignoreField1;
+        private String _ignoredField2;
+        private String $_nonIgnoredField;
+    }
+
+    @Test
+    void shouldIgnoreFieldsWithSpecifiedRegexes() {
+        final Pojo result = Instancio.of(Pojo.class)
+                .withSetting(Keys.IGNORE_FIELD_NAME_REGEXES, "\\$\\$_.*, _.*")
+                .create();
+
+        assertThat(result.$$_ignoreField1).isNull();
+        assertThat(result._ignoredField2).isNull();
+        assertThat(result.$_nonIgnoredField).is(Conditions.RANDOM_STRING);
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/StringUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/StringUtilsTest.java
@@ -120,6 +120,19 @@ class StringUtilsTest {
         assertThat(StringUtils.startsWithAny("foo", "x", "foo")).isTrue();
     }
 
+    @Test
+    void split() {
+        assertThat(StringUtils.split(null)).isEmpty();
+        assertThat(StringUtils.split("")).isEmpty();
+        assertThat(StringUtils.split("\n , \r\n  \t  ,, ,")).isEmpty();
+        assertThat(StringUtils.split("\n \r\n  \t  ")).isEmpty();
+
+        assertThat(StringUtils.split("foo")).containsExactly("foo");
+        assertThat(StringUtils.split("foo,bar")).containsExactly("foo", "bar");
+        assertThat(StringUtils.split(" foo , bar ")).containsExactly("foo", "bar");
+        assertThat(StringUtils.split(" , bar , , , ")).containsExactly("bar");
+    }
+
     @Nested
     class GetTemplatePropertiesTest {
 

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -2846,6 +2846,10 @@ or
 </dependency>
 ```
 
+!!! warning
+    If you are using Hibernate with [bytecode enhancement](https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#BytecodeEnhancement)
+    enabled, you may need to ignore fields with names starting with `$$_`.
+
 ## Supported Attributes
 
 The following `@Column` attributes are supported:
@@ -3619,7 +3623,7 @@ Instancio will automatically load this file from the root of the classpath.
 The following listing shows all the property keys that can be configured.
 
 
-```properties linenums="1" title="Sample configuration properties" hl_lines="1 4 11 30 31 37 48 60"
+```properties linenums="1" title="Sample configuration properties" hl_lines="1 4 11 31 32 38 49 61"
 array.elements.nullable=false
 array.max.length=6
 array.min.length=2
@@ -3642,6 +3646,7 @@ fill.type=POPULATE_NULLS_AND_DEFAULT_PRIMITIVES
 float.max=10000
 float.min=1
 float.nullable=false
+ignore.field.name.regexes=foo.*,bar.*
 instancio.source.samples=100
 integer.max=10000
 integer.min=1
@@ -3686,11 +3691,11 @@ subtype.java.util.SortedMap=java.util.TreeMap
 ```
 
 !!! attention ""
-    <lnum>1,11,30-31</lnum> The `*.elements.nullable`, `map.keys.nullable`, `map.values.nullable` specify whether Instancio can generate `null` values for array/collection elements and map keys and values.<br/>
+    <lnum>1,11,31-32</lnum> The `*.elements.nullable`, `map.keys.nullable`, `map.values.nullable` specify whether Instancio can generate `null` values for array/collection elements and map keys and values.<br/>
     <lnum>4</lnum> The other `*.nullable` properties specifies whether Instancio can generate `null` values for a given type.<br/>
-    <lnum>37</lnum> Specifies the mode, either `STRICT` (default) or `LENIENT`. See [Selector Strictness](#selector-strictness).<br/>
-    <lnum>48</lnum> Specifies a global seed value.<br/>
-    <lnum>60</lnum> Properties prefixed with `subtype` are used to specify default implementations for abstract types, or map types to subtypes in general.
+    <lnum>38</lnum> Specifies the mode, either `STRICT` (default) or `LENIENT`. See [Selector Strictness](#selector-strictness).<br/>
+    <lnum>49</lnum> Specifies a global seed value.<br/>
+    <lnum>61</lnum> Properties prefixed with `subtype` are used to specify default implementations for abstract types, or map types to subtypes in general.
     This is the same mechanism as [subtype mapping](#subtype-mapping), but configured via properties.
 
 


### PR DESCRIPTION
The setting can be set at runtime using `Keys.IGNORE_FIELD_NAME_REGEXES` or through `instancio.properties`, e.g.:

```
ignore.field.name.regexes=foo.*,bar.*
```

will ignore field names that start with `foo` or `bar`.

Resolves #1401 