### PR TITLE
Bug fix: `EnumSet` generator error when enum value `getClass()` returns an anonymous subclass

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/EnumSetGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/EnumSetGenerator.java
@@ -47,16 +47,17 @@ public class EnumSetGenerator<E extends Enum<E>> extends AbstractGenerator<Set<E
         this.generateEntriesHint = 0;
     }
 
-    @Override
-    public String apiMethod() {
-        return "enumSet()";
-    }
-
+    @SuppressWarnings("unused") // used via reflection
     public EnumSetGenerator(final GeneratorContext context) {
         super(context);
         this.enumClass = null;
         // Without knowing the enum class size cannot be determined, so just default to 1
         this.generateEntriesHint = 1;
+    }
+
+    @Override
+    public String apiMethod() {
+        return "enumSet()";
     }
 
     @Override
@@ -159,10 +160,12 @@ public class EnumSetGenerator<E extends Enum<E>> extends AbstractGenerator<Set<E
         return Hints.builder()
                 .with(InternalContainerHint.builder()
                         .generateEntries(generateEntriesHint)
-                        .createFunction(args -> EnumSet.noneOf((Class<E>) args[0].getClass()))
+                        .createFunction(args -> {
+                            final Class<E> klass = ((E) args[0]).getDeclaringClass();
+                            return EnumSet.noneOf(klass);
+                        })
                         .addFunction((Set<E> enumSet, Object... args) -> enumSet.add((E) args[0]))
                         .build())
                 .build();
     }
-
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/enumset/GH1413Test.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/enumset/GH1413Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.enumset;
+
+import org.instancio.Instancio;
+import org.instancio.TypeToken;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * See https://github.com/instancio/instancio/issues/1413
+ */
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class GH1413Test {
+
+    private enum EnumWithAnonymousClass {
+        ANONYMOUS_CLASS_VALUE {}
+    }
+
+    @Test
+    void enumValueAnonymousClass() {
+        final EnumSet<EnumWithAnonymousClass> result = Instancio.of(new TypeToken<EnumSet<EnumWithAnonymousClass>>() {})
+                .withSetting(Keys.FAIL_ON_ERROR, true)
+                .create();
+
+        assertThat(result).containsOnly(EnumWithAnonymousClass.ANONYMOUS_CLASS_VALUE);
+    }
+}


### PR DESCRIPTION
Resolves #1413 