### PR TITLE
Skip ci for maven release commits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,7 @@
                         <preparationGoals>clean versions:set-property verify</preparationGoals>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <localCheckout>true</localCheckout>
+                        <scmCommentPrefix>[skip ci][maven-release-plugin]</scmCommentPrefix>
                         <preparationProfiles>!tests</preparationProfiles>
                         <releaseProfiles>release,sign</releaseProfiles>
                     </configuration>


### PR DESCRIPTION
Super minor thing but I found a way to not have a workflow failure during release :grin: 

This way workflows are skipped for commits produced by the plugin.