### PR TITLE
Avoid usage of unsafe terminally deprecated methods during test

### DIFF
--- a/instancio-tests/feature-tests/pom.xml
+++ b/instancio-tests/feature-tests/pom.xml
@@ -45,6 +45,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <instancio.assignmentType>FIELD</instancio.assignmentType>
+                                <net.bytebuddy.safe>true</net.bytebuddy.safe>
                             </systemPropertyVariables>
                             <summaryFile>target/failsafe-reports/failsafe-summary-assignment-field.xml</summaryFile>
                         </configuration>
@@ -57,6 +58,7 @@
                         <configuration>
                             <systemPropertyVariables>
                                 <instancio.assignmentType>METHOD</instancio.assignmentType>
+                                <net.bytebuddy.safe>true</net.bytebuddy.safe>
                             </systemPropertyVariables>
                             <summaryFile>target/failsafe-reports/failsafe-summary-assignment-method.xml</summaryFile>
                         </configuration>

--- a/instancio-tests/instancio-core-tests/pom.xml
+++ b/instancio-tests/instancio-core-tests/pom.xml
@@ -10,6 +10,19 @@
     <packaging>jar</packaging>
     <name>Instancio tests: instancio-core Tests</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <!-- Note: core tests should NOT import any optional dependencies,
          such as JPA, Bean Validation, or Jackson. This module contains
          tests that verify the absence of class-not-found errors when

--- a/instancio-tests/instancio-junit-tests/pom.xml
+++ b/instancio-tests/instancio-junit-tests/pom.xml
@@ -10,6 +10,19 @@
     <packaging>jar</packaging>
     <name>Instancio tests: instancio-junit Tests</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.instancio</groupId>

--- a/instancio-tests/instancio-test-support/pom.xml
+++ b/instancio-tests/instancio-test-support/pom.xml
@@ -13,11 +13,6 @@
     <properties>
         <sonar.skip>true</sonar.skip>
         <jacoco.skip>true</jacoco.skip>
-        <!-- This is necessary because of https://github.com/apache/maven-surefire/issues/2757 -->
-        <argLine>
-            --add-opens org.junit.platform.commons/org.junit.platform.commons.util=ALL-UNNAMED
-            --add-opens org.junit.platform.commons/org.junit.platform.commons.logging=ALL-UNNAMED
-        </argLine>
     </properties>
 
     <build>
@@ -33,6 +28,18 @@
                             <version>${version.lombok}</version>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- This is necessary because of https://github.com/apache/maven-surefire/issues/2757 -->
+                    <argLine>
+                        @{argLine}
+                        --add-opens org.junit.platform.commons/org.junit.platform.commons.util=ALL-UNNAMED
+                        --add-opens org.junit.platform.commons/org.junit.platform.commons.logging=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -17,6 +17,7 @@
         <maven.source.skip>true</maven.source.skip>
         <gpg.skip>true</gpg.skip>
         <animal.sniffer.skip>true</animal.sniffer.skip>
+        <argLine/>
         <version.apache.commons>3.18.0</version.apache.commons>
         <version.archunit>1.4.1</version.archunit>
         <version.assertj>3.27.4</version.assertj>
@@ -28,6 +29,7 @@
         <!-- plugins -->
         <version.maven-failsafe-plugin>3.5.3</version.maven-failsafe-plugin>
         <version.maven-surefire-plugin>3.5.3</version.maven-surefire-plugin>
+        <version.maven-dependency-plugin>3.8.1</version.maven-dependency-plugin>
     </properties>
 
     <!-- These test modules are run against Java 17 and higher.
@@ -72,11 +74,34 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${version.maven-dependency-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.maven-surefire-plugin}</version>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <net.bytebuddy.safe>true</net.bytebuddy.safe>
+                        </systemPropertyVariables>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <maven.enforcer.require.java.version>[24,)</maven.enforcer.require.java.version>
         <sonar.organization>instancio</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>
             ${maven.multiModuleProjectDirectory}/instancio-tests/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
@@ -86,6 +85,9 @@
         <version.sonar-maven-plugin>5.2.0.4988</version.sonar-maven-plugin>
         <version.spotbugs-maven-plugin>4.9.4.1</version.spotbugs-maven-plugin>
         <version.versions-maven-plugin>2.18.0</version.versions-maven-plugin>
+        <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
+        <version.maven-install-plugin>3.1.4</version.maven-install-plugin>
+        <version.maven-deploy-plugin>3.1.4</version.maven-deploy-plugin>
     </properties>
 
     <issueManagement>
@@ -286,6 +288,21 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${version.maven-compiler-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.maven-resources-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${version.maven-install-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${version.maven-deploy-plugin}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
To make Instancio more compatible with future jdks, remove all the terminally deprecated Unsafe methods called during test:
- Explicitly load mockito as a java agent (https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3)
- Forbid bytebuddy to use `Unsafe` (not 100% sure why this is necessary, but it's probably because Instancio is making use of Unsafe and that makes it discoverable to bytebuddy too) (https://javadoc.io/static/net.bytebuddy/byte-buddy/1.17.6/constant-values.html#net.bytebuddy.dynamic.loading.ClassInjector.UsingUnsafe.SAFE_PROPERTY)