### PR TITLE
Update dependencies (hibernate and groovy)

### DIFF
--- a/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationAnnotationLibraryFacade.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/HibernateBeanValidationAnnotationLibraryFacade.java
@@ -29,7 +29,6 @@ import org.instancio.internal.generator.domain.id.pol.NipGenerator;
 import org.instancio.internal.generator.domain.id.pol.PeselGenerator;
 import org.instancio.internal.generator.domain.id.pol.RegonGenerator;
 import org.instancio.internal.generator.domain.id.rus.InnGenerator;
-import org.instancio.internal.generator.domain.internet.EmailGenerator;
 import org.instancio.internal.generator.net.URLGenerator;
 import org.instancio.internal.generator.util.UUIDGenerator;
 import org.instancio.internal.util.StringUtils;
@@ -42,10 +41,6 @@ final class HibernateBeanValidationAnnotationLibraryFacade extends AbstractAnnot
                 (annotation, context) -> getEanGenerator(
                         (org.hibernate.validator.constraints.EAN) annotation, context)
         );
-        // Instancio aims to support Hibernate validator 5.x, in which Email is not deprecated
-        //noinspection deprecation
-        putPrimary(() -> org.hibernate.validator.constraints.Email.class, // NOSONAR
-                (annotation, context) -> new EmailGenerator(context));
 
         putPrimary(() -> org.hibernate.validator.constraints.LuhnCheck.class,
                 (annotation, context) -> getLuhnGenerator(

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/NipGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/NipGenerator.java
@@ -15,15 +15,20 @@
  */
 package org.instancio.internal.generator.domain.id.pol;
 
+import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.pol.NipSpec;
 import org.instancio.internal.util.CollectionUtils;
+import org.instancio.settings.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class NipGenerator extends WeightsModCheckGenerator implements NipSpec {
-
+    private static final Logger LOG = LoggerFactory.getLogger(NipGenerator.class);
     private static final List<Integer> NIP_WEIGHTS = CollectionUtils.asUnmodifiableList(6, 5, 7, 2, 3, 4, 5, 6, 7);
+    private static final String FALLBACK = "123456321";
 
     public NipGenerator(final GeneratorContext context) {
         super(context);
@@ -38,6 +43,24 @@ public class NipGenerator extends WeightsModCheckGenerator implements NipSpec {
     public NipGenerator nullable() {
         super.nullable();
         return this;
+    }
+
+    @Override
+    protected String payload(final Random random) {
+        final int maxGenerationAttempts = getContext().getSettings().get(Keys.MAX_GENERATION_ATTEMPTS);
+        for (int count = 0; count < maxGenerationAttempts; count++) {
+            final String payload = super.payload(random);
+            if (modulo(payload) < 10) {
+                return payload;
+            }
+        }
+        LOG.atWarn()
+                .setMessage("Max attempts reached {} (configurable with the setting {}), " +
+                        "returning a static fallback to guarantee a valid Nip code")
+                .addArgument(maxGenerationAttempts)
+                .addArgument(Keys.MAX_GENERATION_ATTEMPTS::propertyKey)
+                .log();
+        return FALLBACK;
     }
 
     @Override

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/NipBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/NipBVTest.java
@@ -15,8 +15,10 @@
  */
 package org.instancio.test.beanvalidation;
 
+import org.instancio.Instancio;
 import org.instancio.junit.Given;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
 import org.instancio.test.pojo.beanvalidation.NipBV;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
@@ -38,5 +40,18 @@ class NipBVTest {
         assertThat(results.limit(SAMPLE_SIZE_DDD))
                 .hasSize(SAMPLE_SIZE_DDD)
                 .allSatisfy(HibernateValidatorUtil::assertValid);
+    }
+
+    @Test
+    void nipMaxAttemptsReached() {
+        var results = Instancio.ofList(NipBV.class)
+                .size(SAMPLE_SIZE_DDD)
+                .withSetting(Keys.MAX_GENERATION_ATTEMPTS, 0)
+                .withSetting(Keys.COLLECTION_NULLABLE, false)
+                .create();
+        assertThat(results)
+                .hasSize(SAMPLE_SIZE_DDD)
+                .allSatisfy(HibernateValidatorUtil::assertValid)
+                .allSatisfy(n -> assertThat(n.getNip()).isEqualTo("1234563218"));
     }
 }

--- a/instancio-tests/groovy-tests/pom.xml
+++ b/instancio-tests/groovy-tests/pom.xml
@@ -61,6 +61,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <targetBytecode>${maven.compiler.release}</targetBytecode>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,11 @@
         </sonar.coverage.jacoco.xmlReportPaths>
         <latest.release.version>5.5.1</latest.release.version>
         <version.guava>33.4.0-jre</version.guava>
-        <version.hibernate.validator>8.0.2.Final</version.hibernate.validator>
+        <version.hibernate.validator>9.0.1.Final</version.hibernate.validator>
         <version.highlight.js>11.9.0</version.highlight.js>
         <version.jackson>2.20.0</version.jackson>
-        <version.groovy>4.0.28</version.groovy>
-        <version.jakarta.persistence>3.0.0</version.jakarta.persistence>
+        <version.groovy>5.0.0</version.groovy>
+        <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
         <version.jakarta.validation>3.1.1</version.jakarta.validation>
         <version.jetbrains.annotations>26.0.2-1</version.jetbrains.annotations>
         <version.junit>5.13.4</version.junit>


### PR DESCRIPTION
Update the remaining dependencies from https://github.com/instancio/instancio/wiki/Dependencies

In particular updating to hibernate 9 required to:
- Drop support for the `@Email` annotation
- Align `NipGenerator` with upstream: the generation process is retried until a value that passes the check is found.