### PR TITLE
Test snapshots against different junit versions and early access jdk

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  MAVEN_ARGS: "-B -ntp"
+  MAVEN_ARGS: "-B -ntp -U"
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 24
+          cache: maven
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -24,13 +25,13 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
-  verify:
+  jdk:
     needs: deploy
     strategy:
       matrix:
         java: [ 17, 21, 24 ]
     runs-on: ubuntu-latest
-    name: "Verify snapshots JDK ${{ matrix.java }}"
+    name: "Verify snapshots with JDK ${{ matrix.java }}"
     steps:
       - uses: actions/checkout@v5
       - name: "Set up JDK"
@@ -38,5 +39,37 @@ jobs:
         with:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
+          cache: maven
+      - name: "Test"
+        run: cd instancio-tests && mvn verify
+  junit:
+    needs: deploy
+    strategy:
+      matrix:
+        junit: [ 5.11.4, 5.12.2, 6.0.0-RC2 ]
+    runs-on: ubuntu-latest
+    name: "Verify snapshots with Junit ${{ matrix.junit }}"
+    steps:
+      - uses: actions/checkout@v5
+      - name: "Set up JDK"
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 21
+          cache: maven
+      - name: "Test"
+        run: cd instancio-tests && mvn verify -Dversion.junit=${{ matrix.junit }}
+  experimental:
+    needs: deploy
+    runs-on: ubuntu-latest
+    name: "Verify snapshots with early access JDK"
+    steps:
+      - uses: actions/checkout@v5
+      - name: "Set up JDK"
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 25-ea
+          cache: maven
       - name: "Test"
         run: cd instancio-tests && mvn verify

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -25,6 +25,7 @@
         <version.maven-failsafe-plugin>3.5.3</version.maven-failsafe-plugin>
         <version.maven-surefire-plugin>3.5.3</version.maven-surefire-plugin>
         <version.maven-dependency-plugin>3.8.1</version.maven-dependency-plugin>
+        <version.byte.buddy>1.17.7</version.byte.buddy>
     </properties>
 
     <!-- These test modules are run against Java 17 and higher.
@@ -135,6 +136,12 @@
                 <groupId>org.junit-pioneer</groupId>
                 <artifactId>junit-pioneer</artifactId>
                 <version>${version.junit.pioneer}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.byte.buddy}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Testing against different versions of junit, we should already be compatible with junit 6 :partying_face: 

For java 25 I had to pin the byte buddy dependency because assertj was pulling an older and incompatible version. Also I kept it as a separate job instead of adding it to the jdk matrix because in the future this could give us more freedom to experiment with it changing distribution or disabling it entirely if something broke.

I already tested it [here](https://github.com/EvaristeGalois11/instancio/actions/runs/17709662191) and everything should work nicely, the runtime doesn't increase much because everything runs in parallel.