### PR TITLE
Scan the whole test hierarchy to populate Given fields

### DIFF
--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.TestInstances;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -39,6 +40,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +72,9 @@ class InstancioExtensionTest {
     @Mock
     private ExtensionContext context;
 
+    @Mock
+    private TestInstances testInstances;
+
     @Captor
     private ArgumentCaptor<Random> randomCaptor;
 
@@ -99,13 +104,14 @@ class InstancioExtensionTest {
     void beforeEachWithSeedAnnotation() throws Exception {
         final Method method = DummyTest.class.getDeclaredMethod(METHOD_WITH_SEED_ANNOTATION);
         doReturn(Optional.of(method)).when(context).getTestMethod();
-        doReturn(DummyTest.class).when(context).getRequiredTestClass();
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyTest())).when(testInstances).getAllInstances();
 
         final ExtensionContext.Store store = mock(ExtensionContext.Store.class);
         doReturn(store).when(context).getStore(create("org.instancio"));
         doReturn(new FieldAnnotationMap(DummyTest.class))
                 .when(store)
-                .get("annotationMap", FieldAnnotationMap.class);
+                .get(DummyTest.class, FieldAnnotationMap.class);
 
         // Method under test
         extension.beforeEach(context);
@@ -121,13 +127,14 @@ class InstancioExtensionTest {
     void beforeEachWithSettingsAnnotation() throws IllegalAccessException {
         doReturn(Optional.of(DummyTest.class)).when(context).getTestClass();
         doReturn(Optional.of(new DummyTest())).when(context).getTestInstance();
-        doReturn(DummyTest.class).when(context).getRequiredTestClass();
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyTest())).when(testInstances).getAllInstances();
 
         final ExtensionContext.Store store = mock(ExtensionContext.Store.class);
         doReturn(store).when(context).getStore(create("org.instancio"));
         doReturn(new FieldAnnotationMap(DummyTest.class))
                 .when(store)
-                .get("annotationMap", FieldAnnotationMap.class);
+                .get(DummyTest.class, FieldAnnotationMap.class);
 
         // Method under test
         extension.beforeEach(context);

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/given/GivenNestedTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/given/GivenNestedTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit.given;
+
+import org.instancio.junit.Given;
+import org.instancio.junit.InstancioExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class GivenNestedTest {
+
+    private @Given String string;
+
+    @Test
+    void everyStringShouldBePopulated() {
+        assertThat(string).isNotBlank();
+    }
+
+    @Nested
+    class NestedTestClass {
+        private @Given String stringNested;
+
+        @Test
+        void everyStringShouldBePopulated() {
+            assertThat(string).isNotBlank();
+            assertThat(stringNested).isNotBlank();
+        }
+
+        @Nested
+        class DeepNestedTestClass {
+            private @Given String stringDeepNested;
+
+            @Test
+            void everyStringShouldBePopulated() {
+                assertThat(string).isNotBlank();
+                assertThat(stringNested).isNotBlank();
+                assertThat(stringDeepNested).isNotBlank();
+            }
+        }
+    }
+}


### PR DESCRIPTION
I took a peek at how `MockitoExtension` does its magic :eyes: 

It's a bit annoying that in the `beforeAll` and `afterAll` the test instances aren't present in the context, so the scan is slightly  more verbose but it should work the same.

Fix #1456 