### PR TITLE
Restrict junit matrix testing to only instancio-junit-tests module

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -58,7 +58,7 @@ jobs:
           java-version: 21
           cache: maven
       - name: "Test"
-        run: cd instancio-tests && mvn verify -Dversion.junit=${{ matrix.junit }}
+        run: cd instancio-tests && mvn verify -pl instancio-junit-tests -am -Dversion.junit=${{ matrix.junit }}
   experimental:
     needs: deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
It should not be necessary to run the whole test suite with every junit version, just the small module to test the actual integration with junit.

This should free us from maintaining a strict compatibility to older junit versions in all the other modules :grin: 