### PR TITLE
Upgrade java used to 25 and relax enforcer setting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 24
+          java-version: 25
           cache: maven
 
       - name: 'Build project'

--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 24
+          java-version: 25
           cache: maven
           server-id: central
           server-username: MAVEN_USERNAME
@@ -29,7 +29,7 @@ jobs:
     needs: deploy
     strategy:
       matrix:
-        java: [ 17, 21, 24 ]
+        java: [ 17, 21, 25 ]
     runs-on: ubuntu-latest
     name: "Verify snapshots with JDK ${{ matrix.java }}"
     steps:
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
           cache: maven
       - name: "Test"
         run: cd instancio-tests && mvn verify -pl instancio-junit-tests -am -Dversion.junit=${{ matrix.junit }}
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: "temurin"
-          java-version: 25-ea
+          java-version: 26-ea
           cache: maven
       - name: "Test"
         run: cd instancio-tests && mvn verify

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
         uses: evaristegalois11/sonar-fork-analysis@v1
         with:
           distribution: temurin
-          java-version: 24
+          java-version: 25
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           project-key: instancio_instancio

--- a/instancio-tests/instancio-jooq-tests/pom.xml
+++ b/instancio-tests/instancio-jooq-tests/pom.xml
@@ -11,7 +11,8 @@
     <name>Instancio tests: jOOQ Tests</name>
 
     <properties>
-        <maven.enforcer.require.java.version>[17,)</maven.enforcer.require.java.version>
+        <maven.enforcer.require.java.version>[21,)</maven.enforcer.require.java.version>
+        <maven.compiler.release>21</maven.compiler.release>
         <version.jooq>3.20.4</version.jooq>
     </properties>
 

--- a/instancio-tests/jpms-tests/pom.xml
+++ b/instancio-tests/jpms-tests/pom.xml
@@ -11,6 +11,7 @@
     <name>Instancio Tests: JPMS Tests Parent</name>
 
     <properties>
+        <maven.enforcer.require.java.version>[21,)</maven.enforcer.require.java.version>
         <maven.compiler.release>21</maven.compiler.release>
     </properties>
 

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -11,7 +11,6 @@
     <name>Instancio Tests: Tests Parent</name>
 
     <properties>
-        <maven.enforcer.require.java.version>17</maven.enforcer.require.java.version>
         <argLine/>
         <version.apache.commons>3.19.0</version.apache.commons>
         <version.archunit>1.4.1</version.archunit>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <maven.enforcer.require.java.version>[24,)</maven.enforcer.require.java.version>
+        <maven.enforcer.require.java.version>[17,)</maven.enforcer.require.java.version>
         <sonar.organization>instancio</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>

--- a/website/docs/building.md
+++ b/website/docs/building.md
@@ -7,7 +7,7 @@ hide:
 # Building From Sources
 
 Instancio can be used with Java 17 or higher.
-Building Instancio from sources requires JDK 24 or higher:
+Building Instancio from sources requires JDK 17 or higher:
 
 ```sh
 git clone https://github.com/instancio/instancio.git


### PR DESCRIPTION
Temurin binaries are ready :partying_face: (not sure about the 26-ea, but I guess we'll see)

Also not having to rely on multirelease jar anymore I don't thing it's necesarry to enforce a jdk so high just to compile the project, so I lowered it a bit.