### PR TITLE
Accomodate java 26-ea

### DIFF
--- a/instancio-tests/instancio-core-tests/pom.xml
+++ b/instancio-tests/instancio-core-tests/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier-nodep</artifactId>
+            <artifactId>equalsverifier</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -127,7 +127,7 @@
             </dependency>
             <dependency>
                 <groupId>nl.jqno.equalsverifier</groupId>
-                <artifactId>equalsverifier-nodep</artifactId>
+                <artifactId>equalsverifier</artifactId>
                 <version>${version.equalsverifier}</version>
                 <scope>test</scope>
             </dependency>
@@ -139,9 +139,10 @@
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
+                <artifactId>byte-buddy-parent</artifactId>
                 <version>${version.byte.buddy}</version>
-                <scope>test</scope>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
Fixes some incompatibilities with the new class file version 70

Now the only thing missing is jacoco 0.8.14 and everything should work fine :partying_face: 