### PR TITLE
Remove pmd version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
         <version.maven-jar-plugin>3.4.2</version.maven-jar-plugin>
         <version.maven-javadoc-plugin>3.12.0</version.maven-javadoc-plugin>
         <version.maven-pmd-plugin>3.28.0</version.maven-pmd-plugin>
-        <pmdVersion>7.17.0</pmdVersion>
         <version.maven-release-plugin>3.1.1</version.maven-release-plugin>
         <version.maven-site-plugin>3.21.0</version.maven-site-plugin>
         <version.maven-source-plugin>3.3.1</version.maven-source-plugin>
@@ -233,26 +232,6 @@
                             <groupId>org.instancio</groupId>
                             <artifactId>build-tools</artifactId>
                             <version>${project.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-core</artifactId>
-                            <version>${pmdVersion}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-java</artifactId>
-                            <version>${pmdVersion}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-javascript</artifactId>
-                            <version>${pmdVersion}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>net.sourceforge.pmd</groupId>
-                            <artifactId>pmd-jsp</artifactId>
-                            <version>${pmdVersion}</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
pmd-maven-plugin is compatible with java 25 now, it's not necessary anymore to manually override the pmd version used