### PR TITLE
Update guava to 33.5.0-jre

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -58,7 +58,24 @@ jobs:
           java-version: 25
           cache: maven
       - name: "Test"
-        run: cd instancio-tests && mvn verify -pl instancio-junit-tests -am -Dversion.junit=${{ matrix.junit }}
+        run: cd instancio-tests && mvn verify -pl :instancio-junit-tests -am -Dversion.junit=${{ matrix.junit }}
+  guava:
+    needs: deploy
+    strategy:
+      matrix:
+        guava: [ 23.6.1-jre, 24.1.1-jre, 25.1-jre, 26.0-jre, 27.1-jre, 28.2-jre, 29.0-jre, 30.1.1-jre, 31.1-jre, 32.1.3-jre, 33.4.8-jre ]
+    runs-on: ubuntu-latest
+    name: "Verify snapshots with Guava ${{ matrix.guava }}"
+    steps:
+      - uses: actions/checkout@v5
+      - name: "Set up JDK"
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: 25
+          cache: maven
+      - name: "Test"
+        run: cd instancio-tests && mvn verify -pl :instancio-guava-tests,:jpms-guava-tests -am -Dversion.guava=${{ matrix.guava }}
   experimental:
     needs: deploy
     runs-on: ubuntu-latest

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHostAndPortGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaHostAndPortGenerator.java
@@ -17,8 +17,10 @@ package org.instancio.guava.internal.generator;
 
 import com.google.common.net.HostAndPort;
 import org.instancio.Random;
+import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.Hints;
 import org.instancio.internal.generator.domain.internet.Ip4Generator;
 
 public class GuavaHostAndPortGenerator implements Generator<HostAndPort> {
@@ -38,5 +40,10 @@ public class GuavaHostAndPortGenerator implements Generator<HostAndPort> {
         final String host = ip4Generator.generate(random);
         final int port = random.intRange(MIN_PORT, MAX_PORT);
         return HostAndPort.fromParts(host, port);
+    }
+
+    @Override
+    public Hints hints() {
+        return Hints.afterGenerate(AfterGenerate.DO_NOT_MODIFY);
     }
 }

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaInternetDomainNameGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaInternetDomainNameGenerator.java
@@ -17,7 +17,9 @@ package org.instancio.guava.internal.generator;
 
 import com.google.common.net.InternetDomainName;
 import org.instancio.Random;
+import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
+import org.instancio.generator.Hints;
 
 public class GuavaInternetDomainNameGenerator implements Generator<InternetDomainName> {
 
@@ -27,5 +29,10 @@ public class GuavaInternetDomainNameGenerator implements Generator<InternetDomai
         final String tld = random.oneOf(".com", ".net", ".org");
         final String domain = random.lowerCaseAlphabetic(length) + tld;
         return InternetDomainName.from(domain);
+    }
+
+    @Override
+    public Hints hints() {
+        return Hints.afterGenerate(AfterGenerate.DO_NOT_MODIFY);
     }
 }

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaRangeGenerator.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/GuavaRangeGenerator.java
@@ -17,7 +17,9 @@ package org.instancio.guava.internal.generator;
 
 import com.google.common.collect.Range;
 import org.instancio.Random;
+import org.instancio.generator.AfterGenerate;
 import org.instancio.generator.Generator;
+import org.instancio.generator.Hints;
 
 public class GuavaRangeGenerator<C extends Comparable<C>>
         implements Generator<Range<C>> {
@@ -26,5 +28,10 @@ public class GuavaRangeGenerator<C extends Comparable<C>>
     @Override
     public Range<C> generate(final Random random) {
         return Range.all();
+    }
+
+    @Override
+    public Hints hints() {
+        return Hints.afterGenerate(AfterGenerate.DO_NOT_MODIFY);
     }
 }

--- a/instancio-tests/jpms-tests/jpms-guava-tests/pom.xml
+++ b/instancio-tests/jpms-tests/jpms-guava-tests/pom.xml
@@ -22,6 +22,10 @@
             <version>${version.guava}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/instancio-tests/jpms-tests/jpms-guava-tests/src/test/java/org/instancio/tests/jpms/guava/JpmsGuavaTest.java
+++ b/instancio-tests/jpms-tests/jpms-guava-tests/src/test/java/org/instancio/tests/jpms/guava/JpmsGuavaTest.java
@@ -15,36 +15,67 @@
  */
 package org.instancio.tests.jpms.guava;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.*;
+import com.google.common.net.HostAndPort;
 import com.google.common.net.InternetDomainName;
 import org.instancio.Instancio;
 import org.instancio.junit.InstancioExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(InstancioExtension.class)
 class JpmsGuavaTest {
 
-    private static class GuavaPerson {
-        private String name;
-        private InternetDomainName website;
-        private ImmutableList<String> hobbies;
+    private record AllSupportedGuavaTypes(ArrayListMultimap<UUID, String> arrayListMultimap,
+                                          BiMap<UUID, String> biMap,
+                                          HashBiMap<UUID, String> hashBiMap,
+                                          HashMultimap<UUID, String> hashMultimap,
+                                          HashMultiset<UUID> hashMultiset,
+                                          ImmutableBiMap<UUID, String> immutableBiMap,
+                                          ImmutableList<UUID> immutableList,
+                                          ImmutableListMultimap<UUID, String> immutableListMultimap,
+                                          ImmutableMap<UUID, String> immutableMap,
+                                          ImmutableMultimap<UUID, String> immutableMultimap,
+                                          ImmutableMultiset<UUID> immutableMultiset,
+                                          ImmutableSet<UUID> immutableSet,
+                                          ImmutableSetMultimap<UUID, String> immutableSetMultimap,
+                                          ImmutableSortedMap<UUID, String> immutableSortedMap,
+                                          ImmutableSortedMultiset<UUID> immutableSortedMultiset,
+                                          ImmutableSortedSet<UUID> immutableSortedSet,
+                                          ImmutableTable<String, Integer, Long> immutableTable,
+                                          LinkedHashMultimap<UUID, String> linkedHashMultimap,
+                                          LinkedHashMultiset<UUID> linkedHashMultiset,
+                                          LinkedListMultimap<UUID, String> linkedListMultimap,
+                                          ListMultimap<UUID, String> listMultimap,
+                                          Multiset<UUID> multiset,
+                                          Range<Integer> range,
+                                          SetMultimap<UUID, String> setMultimap,
+                                          SortedMultiset<UUID> sortedMultiset,
+                                          SortedSetMultimap<UUID, String> sortedSetMultimap,
+                                          Table<String, Integer, Long> table,
+                                          TreeMultimap<UUID, String> treeMultimap,
+                                          TreeMultiset<UUID> treeMultiset,
+                                          ConcurrentHashMultiset<UUID> concurrentHashMultiset,
+                                          HostAndPort hostAndPort,
+                                          InternetDomainName internetDomainName) {
     }
 
     @Test
     void create() {
-        final GuavaPerson result = Instancio.create(GuavaPerson.class);
+        final AllSupportedGuavaTypes result = Instancio.create(AllSupportedGuavaTypes.class);
 
-        assertThat(result.name).isNotBlank();
+        assertThat(result).hasNoNullFieldsOrProperties();
 
-        assertThat(result.website.toString())
+        assertThat(result.internetDomainName().toString())
                 .matches("[a-z]+\\.[a-z]+");
 
-        assertThat(result.hobbies)
+        assertThat(result.immutableList())
                 .isNotEmpty()
                 .isInstanceOf(ImmutableList.class)
-                .allSatisfy(hobby -> assertThat(hobby).isNotBlank());
+                .doesNotContainNull();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             ${maven.multiModuleProjectDirectory}/instancio-tests/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <latest.release.version>5.5.1</latest.release.version>
-        <version.guava>33.4.0-jre</version.guava>
+        <version.guava>33.5.0-jre</version.guava>
         <version.hibernate.validator>9.0.1.Final</version.hibernate.validator>
         <version.highlight.js>11.9.0</version.highlight.js>
         <version.jackson>2.20.1</version.jackson>


### PR DESCRIPTION
Update guava to 33.5.0-jre

It turns out that the problem was actually pretty simple: instancio was trying to reach into guava internals that are now forbidden with the module system :grin: 

I also added a matrix action like junit to test the compatibility with previous versions. I chose the last version of every major version since 23 which is the minimum requirement.