### PR TITLE
Add `instancio-bom` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ NOTES.md
 .run/
 target/
 src/test/java/experimental/
+.flattened-pom.xml
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -203,6 +203,21 @@ To use Instancio with JUnit 4, TestNG, or standalone, use `instancio-core`:
 </dependency>
 ```
 
+To better manage the different dependencies use `instancio-bom`:
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-bom</artifactId>
+            <version>RELEASE</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
 > [!CAUTION]
 > The `org.instancio:instancio` artifact on Maven central is an older dependency that should no longer be used.
 

--- a/instancio-bom/pom.xml
+++ b/instancio-bom/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-parent</artifactId>
+        <version>6.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>instancio-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Instancio BOM</name>
+    <description>The BOM (Bill Of Materials) of Instancio to easily manage its modules</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.instancio</groupId>
+                <artifactId>instancio-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.instancio</groupId>
+                <artifactId>instancio-junit</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.instancio</groupId>
+                <artifactId>instancio-guava</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <flattenMode>bom</flattenMode>
+                    <pomElements>
+                        <build>remove</build>
+                        <repositories>remove</repositories>
+                        <properties>remove</properties>
+                        <dependencyManagement>extended_interpolate</dependencyManagement>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/instancio-core/pom.xml
+++ b/instancio-core/pom.xml
@@ -66,6 +66,10 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
             </plugin>

--- a/instancio-guava/pom.xml
+++ b/instancio-guava/pom.xml
@@ -27,6 +27,10 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>

--- a/instancio-junit/pom.xml
+++ b/instancio-junit/pom.xml
@@ -28,6 +28,10 @@
 
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
             </plugin>

--- a/instancio-tests/arch-tests/pom.xml
+++ b/instancio-tests/arch-tests/pom.xml
@@ -19,13 +19,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/bean-validation-hibernate-tests/pom.xml
+++ b/instancio-tests/bean-validation-hibernate-tests/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
@@ -60,7 +59,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/bean-validation-jakarta-tests/pom.xml
+++ b/instancio-tests/bean-validation-jakarta-tests/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -55,7 +54,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/default-package-tests/pom.xml
+++ b/instancio-tests/default-package-tests/pom.xml
@@ -14,13 +14,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/feature-tests/pom.xml
+++ b/instancio-tests/feature-tests/pom.xml
@@ -91,13 +91,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/global-seed-tests/pom.xml
+++ b/instancio-tests/global-seed-tests/pom.xml
@@ -14,13 +14,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/groovy-tests/pom.xml
+++ b/instancio-tests/groovy-tests/pom.xml
@@ -21,12 +21,10 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/instancio-core-tests/pom.xml
+++ b/instancio-tests/instancio-core-tests/pom.xml
@@ -32,13 +32,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-core</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/instancio-guava-tests/pom.xml
+++ b/instancio-tests/instancio-guava-tests/pom.xml
@@ -41,19 +41,16 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-guava</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/instancio-tests/instancio-jooq-tests/pom.xml
+++ b/instancio-tests/instancio-jooq-tests/pom.xml
@@ -66,13 +66,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/instancio-tests/instancio-junit-tests/pom.xml
+++ b/instancio-tests/instancio-junit-tests/pom.xml
@@ -27,13 +27,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/jackson-tests/pom.xml
+++ b/instancio-tests/jackson-tests/pom.xml
@@ -24,13 +24,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/java21-tests/pom.xml
+++ b/instancio-tests/java21-tests/pom.xml
@@ -19,13 +19,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/jpa-jakarta-tests/pom.xml
+++ b/instancio-tests/jpa-jakarta-tests/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>
@@ -60,7 +59,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/jpms-tests/jpms-guava-tests/pom.xml
+++ b/instancio-tests/jpms-tests/jpms-guava-tests/pom.xml
@@ -13,7 +13,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-guava</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/jpms-tests/jpms-spi-impl/pom.xml
+++ b/instancio-tests/jpms-tests/jpms-spi-impl/pom.xml
@@ -19,7 +19,6 @@
             <groupId>org.instancio</groupId>
             <artifactId>instancio-core</artifactId>
             <scope>compile</scope>
-            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/instancio-tests/jpms-tests/pom.xml
+++ b/instancio-tests/jpms-tests/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/kotlin-tests/pom.xml
+++ b/instancio-tests/kotlin-tests/pom.xml
@@ -37,12 +37,10 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/packaging-tests/pom.xml
+++ b/instancio-tests/packaging-tests/pom.xml
@@ -13,7 +13,6 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -102,6 +102,18 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.instancio</groupId>
+                <artifactId>instancio-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.instancio</groupId>
+                <artifactId>instancio-test-support</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${version.logback}</version>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -32,17 +32,14 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-guava</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>

--- a/instancio-tests/spi-tests/pom.xml
+++ b/instancio-tests/spi-tests/pom.xml
@@ -32,13 +32,11 @@
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-test-support</artifactId>
-            <version>${project.parent.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <version.sonar-maven-plugin>5.3.0.6276</version.sonar-maven-plugin>
         <version.spotbugs-maven-plugin>4.9.8.1</version.spotbugs-maven-plugin>
         <version.versions-maven-plugin>2.19.1</version.versions-maven-plugin>
+        <version.flatten-maven-plugin>1.7.3</version.flatten-maven-plugin>
         <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
         <version.maven-install-plugin>3.1.4</version.maven-install-plugin>
         <version.maven-deploy-plugin>3.1.4</version.maven-deploy-plugin>
@@ -96,6 +97,7 @@
         <module>instancio-core</module>
         <module>instancio-junit</module>
         <module>instancio-guava</module>
+        <module>instancio-bom</module>
     </modules>
 
     <profiles>
@@ -202,6 +204,33 @@
                         <property>latest.release.version</property>
                         <newVersion>${project.version}</newVersion>
                         <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${version.flatten-maven-plugin}</version>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <phase>process-resources</phase>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>flatten-clean</id>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <flattenMode>ossrh</flattenMode>
+                        <pomElements>
+                            <build>remove</build>
+                            <repositories>remove</repositories>
+                        </pomElements>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -17,11 +17,12 @@ It has a single `compile` dependency on `org.slf4j:slf4j-api`.
 The following dependencies are available from Maven central:
 
 
-| Dependency              | JPMS Module Name            | Description                        |
-|-------------------------|-----------------------------|------------------------------------|
-| `instancio-core`        | `org.instancio.core`        | Core library                       |
-| `instancio-junit`       | `org.instancio.junit`       | JUnit Jupiter integration          |
-| `instancio-guava`       | `org.instancio.guava`       | Support for Google Guava           |
+| Dependency        | JPMS Module Name      | Description               |
+|-------------------|-----------------------|---------------------------|
+| `instancio-core`  | `org.instancio.core`  | Core library              |
+| `instancio-junit` | `org.instancio.junit` | JUnit Jupiter integration |
+| `instancio-guava` | `org.instancio.guava` | Support for Google Guava  |
+| `instancio-bom`   | -                     | Bill Of Materials         |
 
 
 !!! danger "The `org.instancio:instancio` artifact on Maven central is an older dependency that should no longer be used."
@@ -78,6 +79,51 @@ Using `instancio-guava` requires the following dependencies on the classpath:
 
 - either `instancio-core` or `instancio-junit`
 - `com.google.guava:guava` version `23.1-jre` or higher
+
+### **`instancio-bom`**
+
+Use `instancio-bom` to easily manage Instancio dependencies:
+
+=== "Maven"
+```xml linenums="1" title="Maven"
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-bom</artifactId>
+            <version>{{config.latest_release}}</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+<dependencies>
+    <dependency>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-core</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-junit</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-guava</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+=== "Gradle"
+```groovy linenums="1" title="Gradle"
+dependencies {
+    implementation platform('org.instancio:instancio-bom:{{config.latest_release}}')
+    testImplementation 'org.instancio:instancio-core'
+    testImplementation 'org.instancio:instancio-junit'
+    testImplementation 'org.instancio:instancio-guava'
+}
+```
 
 ### Versioning
 


### PR DESCRIPTION
Add `instancio-bom` to provide an easy way to manage all the different modules

I didn't find a clever way of testing the generated bom, so the best I came up with was using it in the test suite and hopefully if something isn't working right the tests will break :sweat_smile: 

I also flattened all the other poms published, it's not strictly necessary and we can keep the old unflattened ones if we want, but they are much more compact now and they don't rely on `instancio-parent` anymore which is nice :grin: 