### PR TITLE
Update to jackson3

### DIFF
--- a/instancio-core/pom.xml
+++ b/instancio-core/pom.xml
@@ -163,7 +163,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
             <optional>true</optional>

--- a/instancio-core/src/main/java/module-info.java
+++ b/instancio-core/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module org.instancio.core {
     requires org.slf4j;
 
-    requires static com.fasterxml.jackson.databind;
+    requires static tools.jackson.databind;
     requires static jakarta.persistence;
     requires static jakarta.validation;
     requires static java.sql;

--- a/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonDataLoader.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonDataLoader.java
@@ -15,11 +15,11 @@
  */
 package org.instancio.internal.feed.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.instancio.feed.DataSource;
 import org.instancio.internal.feed.DataLoader;
 import org.instancio.internal.util.Fail;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ public final class JsonDataLoader implements DataLoader<List<JsonNode>> {
     @Override
     public List<JsonNode> load(final DataSource dataSource) throws Exception {
         try {
-            ObjectMapper mapper = new ObjectMapper();
+            JsonMapper mapper = JsonMapper.builder().build();
             final JsonNode jsonNode = mapper.readTree(getInputStream(dataSource));
             final List<JsonNode> results = new ArrayList<>(jsonNode.size());
             for (int i = 0; i < jsonNode.size(); i++) {

--- a/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonDataStore.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonDataStore.java
@@ -15,8 +15,8 @@
  */
 package org.instancio.internal.feed.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.instancio.internal.feed.AbstractDataStore;
+import tools.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,7 +54,7 @@ public class JsonDataStore extends AbstractDataStore<JsonNode> {
 
         for (JsonNode entry : data) {
             final JsonNode node = entry.get(tagKey);
-            final String tag = node == null ? null : node.textValue();
+            final String tag = node == null ? null : node.asString();
 
             List<JsonNode> tagData = map.get(tag);
 

--- a/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonFeed.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonFeed.java
@@ -15,10 +15,10 @@
  */
 package org.instancio.internal.feed.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.instancio.internal.feed.AbstractFeed;
 import org.instancio.internal.feed.DataStore;
 import org.instancio.internal.feed.InternalFeedContext;
+import tools.jackson.databind.JsonNode;
 
 class JsonFeed extends AbstractFeed<JsonNode> {
 
@@ -36,6 +36,6 @@ class JsonFeed extends AbstractFeed<JsonNode> {
 
         final JsonNode currentEntry = getCurrentEntry();
         final JsonNode node = currentEntry.get(propertyKey);
-        return node == null ? null : node.asText();
+        return node == null ? null : node.asString();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonResourceHandler.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/json/JsonResourceHandler.java
@@ -15,13 +15,13 @@
  */
 package org.instancio.internal.feed.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.instancio.internal.feed.CachingDataLoader;
 import org.instancio.internal.feed.DataLoader;
 import org.instancio.internal.feed.DataStore;
 import org.instancio.internal.feed.InternalFeed;
 import org.instancio.internal.feed.InternalFeedContext;
 import org.instancio.internal.feed.ResourceHandler;
+import tools.jackson.databind.JsonNode;
 
 import java.util.List;
 import java.util.function.BiFunction;

--- a/instancio-core/src/main/java/org/instancio/internal/util/ErrorMessageUtils.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/ErrorMessageUtils.java
@@ -648,7 +648,7 @@ public final class ErrorMessageUtils {
                 .append(NL)
                 .append(" -> Add the following dependency:").append(NL)
                 .append(NL)
-                .append("    https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-databind")
+                .append("    https://central.sonatype.com/artifact/tools.jackson.core/jackson-databind")
                 .toString();
     }
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/FeedJacksonNotOnClasspathErrorMessageTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/FeedJacksonNotOnClasspathErrorMessageTest.java
@@ -44,7 +44,7 @@ class FeedJacksonNotOnClasspathErrorMessageTest extends AbstractErrorMessageTest
 
                  -> Add the following dependency:
 
-                    https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-databind
+                    https://central.sonatype.com/artifact/tools.jackson.core/jackson-databind
 
                 """;
     }

--- a/instancio-tests/jackson-tests/pom.xml
+++ b/instancio-tests/jackson-tests/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <version.guava>33.5.0-jre</version.guava>
         <version.hibernate.validator>9.1.0.Final</version.hibernate.validator>
         <version.highlight.js>11.9.0</version.highlight.js>
-        <version.jackson>2.20.1</version.jackson>
+        <version.jackson>3.0.2</version.jackson>
         <version.groovy>5.0.2</version.groovy>
         <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
         <version.jakarta.validation>3.1.1</version.jakarta.validation>
@@ -447,7 +447,7 @@
                 <optional>true</optional>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${version.jackson}</version>
                 <scope>provided</scope>

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -3432,7 +3432,7 @@ not provide this dependency transitively):
 
 ```xml
 <dependency>
-    <groupId>com.fasterxml.jackson.core</groupId>
+    <groupId>tools.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
     <version>${jackson-databind-version}</version>
 </dependency>


### PR DESCRIPTION
Update to jackson3

This will impose jackson 3.x as a requirement to use the json feed, considering that Instancio 6 is on the horizon it seems an acceptable breaking change.

Technically it should be possible to support both jackson 2 and 3 at the same time given that they have different packages, but maybe it isn't worth the effort for a relatively niche feature. :thinking:  What do you think @armandino?