### PR TITLE
Use skipPublishing instead of profiles to skip test deploy

### DIFF
--- a/.github/workflows/deploy-and-verify-snapshots.yml
+++ b/.github/workflows/deploy-and-verify-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: "Deploy snapshots"
-        run: mvn -Prelease deploy
+        run: mvn -Prelease deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -16,5 +16,6 @@
         <maven.source.skip>true</maven.source.skip>
         <pmd.skip>true</pmd.skip>
         <gpg.skip>true</gpg.skip>
+        <skipPublishing>true</skipPublishing>
     </properties>
 </project>

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -12,6 +12,9 @@
 
     <properties>
         <argLine/>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <skipPublishing>true</skipPublishing>
         <version.apache.commons>3.20.0</version.apache.commons>
         <version.archunit>1.4.1</version.archunit>
         <version.assertj>3.27.6</version.assertj>

--- a/pom.xml
+++ b/pom.xml
@@ -98,18 +98,10 @@
         <module>instancio-junit</module>
         <module>instancio-guava</module>
         <module>instancio-bom</module>
+        <module>instancio-tests</module>
     </modules>
 
     <profiles>
-        <profile>
-            <id>tests</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>instancio-tests</module>
-            </modules>
-        </profile>
         <profile>
             <id>release</id>
             <build>
@@ -391,11 +383,6 @@
                     <artifactId>central-publishing-maven-plugin</artifactId>
                     <version>${version.central-publishing-maven-plugin}</version>
                     <extensions>true</extensions>
-                    <configuration>
-                        <excludeArtifacts>
-                            <excludeArtifact>build-tools</excludeArtifact>
-                        </excludeArtifacts>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Tweaked a little the build structure (this is the last I swear :crossed_fingers:), now it's a little bit more streamlined without a default profile to sidestep the publishing plugin limitation.

Also now tests are run during deploy (and release), which should be helpful during automation ( :eyes: )