### PR TITLE
Add new setting `fail.on.max.generation.attempts.reached`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/BaseApi.java
+++ b/instancio-core/src/main/java/org/instancio/BaseApi.java
@@ -363,7 +363,8 @@ interface BaseApi<T> {
      * If a value is rejected, a new value will be generated,
      * which will also be tested against the {@code predicate}.
      * If no value is accepted after {@link Keys#MAX_GENERATION_ATTEMPTS},
-     * an exception will be thrown.
+     * an exception is thrown by default, unless configured otherwise
+     * using {@link Keys#FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED}.
      *
      * <p>A simple example is to generate a list of even numbers:
      * <pre>{@code
@@ -380,6 +381,7 @@ interface BaseApi<T> {
      * @param predicate that must be satisfied by the generated value
      * @param <V>       the type of object the predicate is evaluated against
      * @return API builder reference
+     * @see Keys#FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED
      * @see Keys#MAX_GENERATION_ATTEMPTS
      * @since 4.6.0
      */
@@ -735,8 +737,9 @@ interface BaseApi<T> {
      * }</pre>
      *
      * <p>If it is impossible to generate a sufficient number of
-     * unique values after a certain number of attempts,
-     * an exception will be thrown:
+     * unique values after {@link Keys#MAX_GENERATION_ATTEMPTS},
+     * an exception is thrown by default, unless configured otherwise
+     * using {@link Keys#FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED}.
      *
      * <pre>{@code
      * List<Boolean> results = Instancio.ofList(Boolean.class)
@@ -747,6 +750,8 @@ interface BaseApi<T> {
      *
      * @param selector for fields and/or classes this method should be applied to
      * @return API builder reference
+     * @see Keys#FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED
+     * @see Keys#MAX_GENERATION_ATTEMPTS
      * @since 4.8.0
      */
     @ExperimentalApi

--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -42,6 +42,7 @@ import org.instancio.internal.util.ObjectUtils;
 import org.instancio.internal.util.RecordUtils;
 import org.instancio.internal.util.ReflectionUtils;
 import org.instancio.settings.Keys;
+import org.instancio.support.Log;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -166,8 +167,18 @@ class InstancioEngine {
 
         while (!context.isAccepted(node, generatorResult.getValue())) {
             if (++retryCount > maxGenerationAttempts) {
-                throw Fail.withUsageError(ErrorMessageUtils.maxGenerationAttemptsExceeded(
-                        node, maxGenerationAttempts));
+
+                if (context.getSettings().get(Keys.FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED)) {
+                    throw Fail.withUsageError(ErrorMessageUtils.maxGenerationAttemptsExceeded(
+                            node, maxGenerationAttempts));
+                } else {
+                    Log.msg(Log.Category.MAX_GENERATION_ATTEMPTS,
+                            "Max generation attempts ({}) reached (configurable via '{}'). " +
+                            "Using random value as fallback.",
+                            maxGenerationAttempts,
+                            Keys.MAX_GENERATION_ATTEMPTS.propertyKey());
+                    break;
+                }
             }
             generatorResult = doCreateObject(node, isNullable);
         }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/NipGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/NipGenerator.java
@@ -18,6 +18,7 @@ package org.instancio.internal.generator.domain.id.pol;
 import org.instancio.Random;
 import org.instancio.generator.GeneratorContext;
 import org.instancio.generator.specs.pol.NipSpec;
+import org.instancio.internal.util.Fail;
 import org.instancio.settings.Keys;
 import org.instancio.support.Log;
 
@@ -51,6 +52,13 @@ public class NipGenerator extends WeightsModCheckGenerator implements NipSpec {
             if (modulo(payload) < 10) {
                 return payload;
             }
+        }
+
+        if (getContext().getSettings().get(Keys.FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED)) {
+            throw Fail.withUsageError(
+                    "Unable to generate a valid NIP within the maximum of %s attempts (configurable via '%s')",
+                    maxGenerationAttempts,
+                    Keys.MAX_GENERATION_ATTEMPTS.propertyKey());
         }
 
         Log.msg(Log.Category.MAX_GENERATION_ATTEMPTS,

--- a/instancio-core/src/main/java/org/instancio/settings/Keys.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Keys.java
@@ -249,6 +249,17 @@ public final class Keys {
             "fail.on.max.depth.reached", Boolean.class, false);
 
     /**
+     * Indicates whether an error should be thrown when a value cannot be
+     * generated within the configured {@link #MAX_GENERATION_ATTEMPTS};
+     * default is {@code false}; property name {@code fail.on.max.generation.attempts.reached}.
+     *
+     * @since 6.0.0
+     */
+    @ExperimentalApi
+    public static final SettingKey<Boolean> FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED = registerRequiredNonAdjustable(
+            "fail.on.max.generation.attempts.reached", Boolean.class, true);
+
+    /**
      * Specifies minimum value for floats;
      * default is 1; property name {@code float.min}.
      */

--- a/instancio-core/src/main/resources/instancio-sample.properties
+++ b/instancio-core/src/main/resources/instancio-sample.properties
@@ -20,6 +20,7 @@ double.min=1
 double.nullable=false
 fail.on.error=false
 fail.on.max.depth.reached=false
+fail.on.max.generation.attempts.reached=true
 fill.type=POPULATE_NULLS_AND_DEFAULT_PRIMITIVES
 float.max=10000
 float.min=1

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/NipBVTest.java
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/java/org/instancio/test/beanvalidation/NipBVTest.java
@@ -43,12 +43,14 @@ class NipBVTest {
     }
 
     @Test
-    void nipMaxAttemptsReached() {
+    void whenFailOnMaxGenerationAttemptsReachedDisabled_shouldGenerateDefaultNip() {
         var results = Instancio.ofList(NipBV.class)
                 .size(SAMPLE_SIZE_DDD)
                 .withSetting(Keys.MAX_GENERATION_ATTEMPTS, 0)
                 .withSetting(Keys.COLLECTION_NULLABLE, false)
+                .withSetting(Keys.FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED, false)
                 .create();
+
         assertThat(results)
                 .hasSize(SAMPLE_SIZE_DDD)
                 .allSatisfy(HibernateValidatorUtil::assertValid)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/filter/FilterBasicTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/filter/FilterBasicTest.java
@@ -18,6 +18,8 @@ package org.instancio.test.features.filter;
 import org.instancio.Instancio;
 import org.instancio.TypeToken;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
+import org.instancio.test.support.conditions.Conditions;
 import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.pojo.generics.basic.Item;
 import org.instancio.test.support.tags.Feature;
@@ -68,5 +70,15 @@ class FilterBasicTest {
                 .create();
 
         assertThat(result).isTrue();
+    }
+
+    @Test
+    void whenFailOnMaxGenerationAttemptsReached_isFalse_shouldFallBackToRandomValue() {
+        final String result = Instancio.of(String.class)
+                .withSetting(Keys.FAIL_ON_MAX_GENERATION_ATTEMPTS_REACHED, false)
+                .filter(root(), (String s) -> s.equals("will never match"))
+                .create();
+
+        assertThat(result).is(Conditions.RANDOM_STRING);
     }
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/pol/NipGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/id/pol/NipGeneratorTest.java
@@ -17,7 +17,10 @@ package org.instancio.test.features.generator.id.pol;
 
 import org.instancio.GeneratorSpecProvider;
 import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.exception.InstancioApiException;
 import org.instancio.junit.InstancioExtension;
+import org.instancio.settings.Keys;
 import org.instancio.test.support.tags.Feature;
 import org.instancio.test.support.tags.FeatureTag;
 import org.instancio.test.support.util.Constants;
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.root;
 
 @FeatureTag(Feature.GENERATOR)
@@ -54,5 +58,16 @@ class NipGeneratorTest {
                 .limit(Constants.SAMPLE_SIZE_DDD);
 
         assertThat(result).containsNull();
+    }
+
+    @Test
+    void whenNipGenerationAttemptsExceeded_shouldThrowException() {
+        final InstancioApi<String> api = Instancio.of(String.class)
+                .withSetting(Keys.MAX_GENERATION_ATTEMPTS, 0)
+                .generate(root(), gen -> gen.id().pol().nip());
+
+        assertThatThrownBy(api::create)
+                .isExactlyInstanceOf(InstancioApiException.class)
+                .hasMessageContaining("Unable to generate a valid NIP within the maximum of 0 attempts (configurable via 'max.generation.attempts')");
     }
 }

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -3608,7 +3608,7 @@ Instancio will automatically load this file from the root of the classpath.
 The following listing shows all the property keys that can be configured.
 
 
-```properties linenums="1" title="Sample configuration properties" hl_lines="1 4 11 32 33 40 50 62"
+```properties linenums="1" title="Sample configuration properties" hl_lines="1 4 11 33 34 41 51 63"
 array.elements.nullable=false
 array.max.length=6
 array.min.length=2
@@ -3628,6 +3628,7 @@ double.min=1
 double.nullable=false
 fail.on.error=false
 fail.on.max.depth.reached=false
+fail.on.max.generation.attempts.reached=true
 fill.type=POPULATE_NULLS_AND_DEFAULT_PRIMITIVES
 float.max=10000
 float.min=1
@@ -3679,9 +3680,9 @@ subtype.java.util.SortedMap=java.util.TreeMap
 !!! attention ""
     <lnum>1,11,32-33</lnum> The `*.elements.nullable`, `map.keys.nullable`, `map.values.nullable` specify whether Instancio can generate `null` values for array/collection elements and map keys and values.<br/>
     <lnum>4</lnum> The other `*.nullable` properties specifies whether Instancio can generate `null` values for a given type.<br/>
-    <lnum>40</lnum> Specifies the mode, either `STRICT` (default) or `LENIENT`. See [Selector Strictness](#selector-strictness).<br/>
-    <lnum>50</lnum> Specifies a global seed value.<br/>
-    <lnum>62</lnum> Properties prefixed with `subtype` are used to specify default implementations for abstract types, or map types to subtypes in general.
+    <lnum>41</lnum> Specifies the mode, either `STRICT` (default) or `LENIENT`. See [Selector Strictness](#selector-strictness).<br/>
+    <lnum>51</lnum> Specifies a global seed value.<br/>
+    <lnum>63</lnum> Properties prefixed with `subtype` are used to specify default implementations for abstract types, or map types to subtypes in general.
     This is the same mechanism as [subtype mapping](#subtype-mapping), but configured via properties.
 
 


### PR DESCRIPTION
This PR adds a new setting `fail.on.max.generation.attempts.reached` that controls whether an exception should be thrown if Instancio fails to generate a value via `filter()` or `withUnique()` method.