### PR TITLE
Fix Javadoc visibility and inheritance after adopting JPMS

### DIFF
--- a/instancio-core/src/main/java/org/instancio/BaseApi.java
+++ b/instancio-core/src/main/java/org/instancio/BaseApi.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  * @param <T> the type of object to create
  * @since 4.0.0
  */
-interface BaseApi<T> {
+public interface BaseApi<T> {
 
     /**
      * Specifies that a class or field should be ignored.

--- a/instancio-core/src/main/java/org/instancio/LenientModeApi.java
+++ b/instancio-core/src/main/java/org/instancio/LenientModeApi.java
@@ -36,7 +36,7 @@ import org.instancio.settings.Keys;
  * @see LenientSelector
  * @since 4.0.0
  */
-interface LenientModeApi {
+public interface LenientModeApi {
 
     /**
      * Disables strict mode in which unused selectors trigger an error.

--- a/instancio-core/src/main/java/org/instancio/SettingsApi.java
+++ b/instancio-core/src/main/java/org/instancio/SettingsApi.java
@@ -24,7 +24,7 @@ import org.instancio.settings.Settings;
  *
  * @since 5.0.0
  */
-interface SettingsApi {
+public interface SettingsApi {
 
     /**
      * Overrides the setting for the given {@code key}

--- a/instancio-core/src/main/java/org/instancio/VerboseModeApi.java
+++ b/instancio-core/src/main/java/org/instancio/VerboseModeApi.java
@@ -22,7 +22,7 @@ import org.instancio.settings.Settings;
  *
  * @since 4.0.0
  */
-interface VerboseModeApi {
+public interface VerboseModeApi {
 
     /**
      * Outputs debug information to {@code System.out}. This includes:

--- a/instancio-core/src/main/java/org/instancio/generator/specs/TruncatableTemporalGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/TruncatableTemporalGeneratorSpec.java
@@ -25,7 +25,7 @@ import java.time.temporal.TemporalUnit;
  * @param <T> temporal type
  * @since 4.2.0
  */
-interface TruncatableTemporalGeneratorSpec<T> extends GeneratorSpec<T> {
+public interface TruncatableTemporalGeneratorSpec<T> extends GeneratorSpec<T> {
 
     /**
      * Truncates generated values to the specified unit.

--- a/instancio-core/src/main/java/org/instancio/generators/CommonGeneratorSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/CommonGeneratorSpecs.java
@@ -37,7 +37,7 @@ import org.instancio.generator.specs.StringGeneratorSpec;
  *
  * @since 5.0.0
  */
-interface CommonGeneratorSpecs {
+public interface CommonGeneratorSpecs {
 
     /**
      * Generator for {@link String} values.

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/PackagePrivateClassesTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/api/PackagePrivateClassesTest.java
@@ -17,18 +17,28 @@ package org.instancio.api;
 
 import org.instancio.InstancioApi;
 import org.instancio.feed.Feed;
+import org.instancio.generators.Generators;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.instancio.test.support.asserts.ClassAssert.assertThatSuperInterface;
 
 class PackagePrivateClassesTest {
 
+    // TODO revert to package-private
+    @Disabled("Base APIs are public due to JPMS/Javadoc limitations")
     @Test
     void instancioApis_shouldNotBePublic() {
         assertThatSuperInterface(InstancioApi.class, "BaseApi").isNotPublic();
         assertThatSuperInterface(InstancioApi.class, "LenientModeApi").isNotPublic();
         assertThatSuperInterface(InstancioApi.class, "SettingsApi").isNotPublic();
         assertThatSuperInterface(InstancioApi.class, "VerboseModeApi").isNotPublic();
+    }
+
+    @Disabled("Base APIs are public due to JPMS/Javadoc limitations")
+    @Test
+    void baseSpecs_shouldNotBePublic() {
+        assertThatSuperInterface(Generators.class, "CommonGeneratorSpecs").isNotPublic();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -364,10 +364,8 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${version.maven-javadoc-plugin}</version>
                     <configuration>
-                        <!-- Some public APIs extend package-private classes.
-                             This ensures {@inheritDoc} works in such cases. -->
                         <release>17</release>
-                        <show>package</show>
+                        <show>public</show>
                         <encoding>UTF-8</encoding>
                         <docencoding>UTF-8</docencoding>
                         <charset>UTF-8</charset>


### PR DESCRIPTION
Before modules, internal packages were hidden using `excludePackageNames` and `<show>package</show>`, allowing public APIs to inherit docs from package-private base interfaces.

With module-info.java, `excludePackageNames` is no longer honoured and internal packages became visible. Switching to `<show>public</show>` hides internals but breaks Javadoc inheritance from package-private types (child docs are blank).

Make shared base interfaces public so documentation inheritance works again while keeping generated docs limited to public API.

Closes #1445

- https://github.com/apache/maven-javadoc-plugin/issues/1271