### PR TITLE
Breaking change: add JSpecify `@NullMarked` to all package-info files

### DIFF
--- a/instancio-core/pom.xml
+++ b/instancio-core/pom.xml
@@ -140,13 +140,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/instancio-core/src/main/java/module-info.java
+++ b/instancio-core/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module org.instancio.core {
+    requires org.jspecify;
     requires org.slf4j;
 
     requires static jakarta.persistence;

--- a/instancio-core/src/main/java/org/instancio/documentation/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/documentation/package-info.java
@@ -16,4 +16,7 @@
 /**
  * API documentation classes.
  */
+@NullMarked
 package org.instancio.documentation;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/exception/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/exception/package-info.java
@@ -16,5 +16,8 @@
 /**
  * Contains exception classes thrown by Instancio.
  */
+@NullMarked
 package org.instancio.exception;
+
+import org.jspecify.annotations.NullMarked;
 

--- a/instancio-core/src/main/java/org/instancio/feed/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/feed/package-info.java
@@ -19,6 +19,9 @@
  * @since 5.0.0
  */
 @ExperimentalApi
+@NullMarked
 package org.instancio.feed;
+
+import org.jspecify.annotations.NullMarked;
 
 import org.instancio.documentation.ExperimentalApi;

--- a/instancio-core/src/main/java/org/instancio/generator/hints/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/hints/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains {@link org.instancio.generator.Hint} implementations.
  */
+@NullMarked
 package org.instancio.generator.hints;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains classes related to generators.
  */
+@NullMarked
 package org.instancio.generator;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/bra/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/bra/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.generator.specs.bra;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/can/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/can/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generator.specs.can;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Defines generator specs.
  */
+@NullMarked
 package org.instancio.generator.specs;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/pol/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/pol/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generator.specs.pol;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/rus/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/rus/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.generator.specs.rus;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generator/specs/usa/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/usa/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generator.specs.usa;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/bra/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/bra/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.generators.bra;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/can/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/can/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generators.can;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Defines classes that provide access to built-in generators.
  */
+@NullMarked
 package org.instancio.generators;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/pol/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/pol/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generators.pol;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/rus/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/rus/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.generators.rus;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/generators/usa/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/generators/usa/package-info.java
@@ -19,4 +19,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.generators.usa;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.7.0
  */
+@NullMarked
 package org.instancio.internal.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/assigners/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assigners/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implements how values are assigned: fields or methods.
  */
+@NullMarked
 package org.instancio.internal.assigners;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/assignment/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/assignment/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.0.0
  */
+@NullMarked
 package org.instancio.internal.assignment;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/context/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains context-related implementation classes.
  */
+@NullMarked
 package org.instancio.internal.context;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/feed/csv/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/csv/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.internal.feed.csv;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/feed/datasource/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/datasource/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains {@link org.instancio.feed.DataSource} implementations.
  */
+@NullMarked
 package org.instancio.internal.feed.datasource;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/feed/json/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/json/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.internal.feed.json;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/feed/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/feed/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.internal.feed;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generation/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generation/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains internal classes for handling nodes.
  */
+@NullMarked
 package org.instancio.internal.generation;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/array/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/array/package-info.java
@@ -16,4 +16,8 @@
 /**
  * Provides array generators.
  */
+@NullMarked
 package org.instancio.internal.generator.array;
+
+import org.jspecify.annotations.NullMarked;
+

--- a/instancio-core/src/main/java/org/instancio/internal/generator/checksum/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/checksum/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for checksum-valid numbers.
  */
+@NullMarked
 package org.instancio.internal.generator.checksum;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/finance/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides finance-related generators.
  */
+@NullMarked
 package org.instancio.internal.generator.domain.finance;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/hash/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/hash/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for various types of hashes.
  */
+@NullMarked
 package org.instancio.internal.generator.domain.hash;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/bra/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/bra/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id.bra;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/can/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/can/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id.can;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for various types of identifiers.
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/pol/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id.pol;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/rus/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/rus/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 5.0.0
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id.rus;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/usa/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/id/usa/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 3.1.0
  */
+@NullMarked
 package org.instancio.internal.generator.domain.id.usa;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/internet/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/internet/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides Internet-related generators.
  */
+@NullMarked
 package org.instancio.internal.generator.domain.internet;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/domain/spatial/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/domain/spatial/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides Spatial-related generators.
  */
+@NullMarked
 package org.instancio.internal.generator.domain.spatial;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/io/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/io/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.io.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.io;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/lang/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/lang/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.lang.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.lang;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/math/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/math/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.math.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.math;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/misc/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/misc/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Miscellaneous generators.
  */
+@NullMarked
 package org.instancio.internal.generator.misc;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/net/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/net/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.3.0
  */
+@NullMarked
 package org.instancio.internal.generator.net;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/nio/file/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/nio/file/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.nio.file.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.nio.file;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains internal classes related to generators.
  */
+@NullMarked
 package org.instancio.internal.generator;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/sequence/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/sequence/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides numeric sequence generators.
  */
+@NullMarked
 package org.instancio.internal.generator.sequence;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/shuffle/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/shuffle/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Generators for shuffling elements.
  */
+@NullMarked
 package org.instancio.internal.generator.shuffle;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/specs/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/specs/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains internal generator specs.
  */
+@NullMarked
 package org.instancio.internal.generator.specs;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/sql/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/sql/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.sql.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.sql;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/text/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/text/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides text generators.
  */
+@NullMarked
 package org.instancio.internal.generator.text;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/time/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/time/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.time.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.time;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/atomic/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.util.concurrent.atomic.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.util.concurrent.atomic;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/concurrent/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.util.concurrent.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.util.concurrent;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/util/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/util/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code java.util.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generator/xml/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/xml/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides generators for {@code javax.xml.*} types.
  */
+@NullMarked
 package org.instancio.internal.generator.xml;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/generators/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generators/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implementations classes for {@code org.instancio.generators}.
  */
+@NullMarked
 package org.instancio.internal.generators;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/instantiation/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/instantiation/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implementation classes providing support for instantiation.
  */
+@NullMarked
 package org.instancio.internal.instantiation;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implementation classes for converting types to node hierarchies.
  */
+@NullMarked
 package org.instancio.internal.nodes;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/resolvers/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/resolvers/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Contains node type resolvers.
  */
+@NullMarked
 package org.instancio.internal.nodes.resolvers;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/package-info.java
@@ -19,6 +19,9 @@
  * <p><b>Classes within this package are not part of the public API.</b></p>
  */
 @InternalApi
+@NullMarked
 package org.instancio.internal;
+
+import org.jspecify.annotations.NullMarked;
 
 import org.instancio.documentation.InternalApi;

--- a/instancio-core/src/main/java/org/instancio/internal/random/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/random/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implementation classes for generating random values.
  */
+@NullMarked
 package org.instancio.internal.random;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/reflect/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/reflect/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Implementation classes providing support for reflection.
  */
+@NullMarked
 package org.instancio.internal.reflect;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/selectors/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/selectors/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides selector API implementation.
  */
+@NullMarked
 package org.instancio.internal.selectors;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/settings/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/package-info.java
@@ -18,4 +18,7 @@
  *
  * <p><b>Classes within this package are not part of the public API.</b></p>
  */
+@NullMarked
 package org.instancio.internal.settings;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/spi/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/spi/package-info.java
@@ -18,4 +18,7 @@
  *
  * <p><b>Classes within this package are not part of the public API.</b></p>
  */
+@NullMarked
 package org.instancio.internal.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/internal/util/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/internal/util/package-info.java
@@ -18,4 +18,7 @@
  *
  * <p><b>Classes within this package are not part of the public API.</b></p>
  */
+@NullMarked
 package org.instancio.internal.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/package-info.java
@@ -19,4 +19,7 @@
  * @see org.instancio.Instancio
  * @see org.instancio.InstancioApi
  */
+@NullMarked
 package org.instancio;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/settings/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/settings/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Provides classes for overriding settings at runtime.
  */
+@NullMarked
 package org.instancio.settings;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/spi/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/spi/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Defines Service Provider Interfaces for providing custom implementations.
  */
+@NullMarked
 package org.instancio.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-core/src/main/java/org/instancio/support/package-info.java
+++ b/instancio-core/src/main/java/org/instancio/support/package-info.java
@@ -19,6 +19,9 @@
  * <p>This package is not part of the public API.
  */
 @InternalApi
+@NullMarked
 package org.instancio.support;
+
+import org.jspecify.annotations.NullMarked;
 
 import org.instancio.documentation.InternalApi;

--- a/instancio-guava/src/main/java/module-info.java
+++ b/instancio-guava/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module org.instancio.guava {
     requires transitive org.instancio.core;
 
     requires com.google.common;
+    requires org.jspecify;
 
     exports org.instancio.guava;
     exports org.instancio.guava.generator.specs;

--- a/instancio-guava/src/main/java/org/instancio/guava/generator/specs/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/generator/specs/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava.generator.specs;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/generator/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/generator/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava.internal.generator;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/spi/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/spi/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava.internal.spi;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-guava/src/main/java/org/instancio/guava/internal/util/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/internal/util/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava.internal.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-guava/src/main/java/org/instancio/guava/package-info.java
+++ b/instancio-guava/src/main/java/org/instancio/guava/package-info.java
@@ -18,4 +18,7 @@
  *
  * @since 2.13.0
  */
+@NullMarked
 package org.instancio.guava;
+
+import org.jspecify.annotations.NullMarked;

--- a/instancio-junit/src/main/java/module-info.java
+++ b/instancio-junit/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module org.instancio.junit {
 
   requires static org.junit.jupiter.params;
 
+  requires org.jspecify;
   requires org.junit.jupiter.api;
   requires org.slf4j;
 

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/package-info.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/package-info.java
@@ -16,5 +16,8 @@
 /**
  * Contains internal classes.
  */
+@NullMarked
 package org.instancio.junit.internal;
+
+import org.jspecify.annotations.NullMarked;
 

--- a/instancio-junit/src/main/java/org/instancio/junit/package-info.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/package-info.java
@@ -16,5 +16,8 @@
 /**
  * Provides Instancio JUnit 5 support.
  */
+@NullMarked
 package org.instancio.junit;
+
+import org.jspecify.annotations.NullMarked;
 

--- a/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/ApiPackageTest.java
+++ b/instancio-tests/arch-tests/src/test/java/org/instancio/test/contract/ApiPackageTest.java
@@ -20,6 +20,7 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import org.instancio.documentation.ExperimentalApi;
 import org.instancio.documentation.InternalApi;
 import org.instancio.test.contract.condition.UnconditionalModuleExportCondition;
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -37,6 +38,13 @@ class ApiPackageTest {
     private static final JavaClasses classes = new ClassFileImporter().importPackages("org.instancio");
 
     private static final UnconditionalModuleExportCondition beUnconditionallyExported = new UnconditionalModuleExportCondition();
+
+    @Test
+    void allPackageInfosShouldBeAnnotatedWithNullMarked() {
+        classes().that().haveSimpleName("package-info")
+                .should().beAnnotatedWith(NullMarked.class)
+                .check(classes);
+    }
 
     @Test
     void internalApisShouldResideWithinInternalPackage() {

--- a/instancio-tests/kotlin-tests/pom.xml
+++ b/instancio-tests/kotlin-tests/pom.xml
@@ -22,6 +22,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-compiler-embeddable</artifactId>
+                <version>${version.kotlin}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -33,6 +39,10 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-compiler-embeddable</artifactId>
         </dependency>
         <dependency>
             <groupId>org.instancio</groupId>

--- a/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KGenericsTest.kt
+++ b/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KGenericsTest.kt
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(InstancioExtension::class)
 internal class KGenericsTest {
 
-    private inline fun <reified T> genericType() = object : TypeToken<T> {}
+    private inline fun <reified T : Any> genericType() = object : TypeToken<T> {}
 
-    private class KPair<L, R>(val left: L, val right: R) {}
+    private class KPair<L, R>(val left: L, val right: R)
 
     @Test
     fun genericPair() {

--- a/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KPersonTest.kt
+++ b/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KPersonTest.kt
@@ -119,14 +119,16 @@ internal class KPersonTest {
         assertThat(callbackCount[0]).isOne()
     }
 
-    @Test
-    fun setNonNullableToNull() {
-        // Note: setting null would not be possible creating an object manually
-        // since UUID is not declared as `UUID?`
-        val result: KPerson = Instancio.of(KPerson::class.java)
-            .set(field("uuid"), null)
-            .create()
-
-        assertThat(result.uuid).isNull()
-    }
+// TODO uncomment once the set() API is updated to accept null
+//
+//    @Test
+//    fun setNonNullableToNull() {
+//        // Note: setting null would not be possible creating an object manually
+//        // since UUID is not declared as `UUID?`
+//        val result: KPerson = Instancio.of(KPerson::class.java)
+//            .set(field("uuid"), null)
+//            .create()
+//
+//        assertThat(result.uuid).isNull()
+//    }
 }

--- a/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KSelectorsTest.kt
+++ b/instancio-tests/kotlin-tests/src/test/kotlin/org/instancio/test/kotlin/KSelectorsTest.kt
@@ -46,11 +46,11 @@ internal class KSelectorsTest {
 
     @Test
     fun selectRoot() {
-        val result = Instancio.of(KPerson::class.java)
-            .set(root(), null)
+        val result = Instancio.of(String::class.java)
+            .set(root(), "foo")
             .create()
 
-        assertThat(result).isNull()
+        assertThat(result).isEqualTo("foo")
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
         <version.jakarta.validation>3.1.1</version.jakarta.validation>
         <version.jetbrains.annotations>26.0.2-1</version.jetbrains.annotations>
+        <version.jspecify>1.0.0</version.jspecify>
         <version.junit>6.0.3</version.junit>
         <version.slf4j>2.0.17</version.slf4j>
         <version.error_prone_core>2.48.0</version.error_prone_core>
@@ -485,6 +486,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${version.jspecify}</version>
+            </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Prep for migrating from JetBrains annotations to JSpecify:

- #1377
- #1604