### PR TITLE
Breaking change: remove default implementation of `SettingKey.defaultValue()`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/settings/SettingKey.java
+++ b/instancio-core/src/main/java/org/instancio/settings/SettingKey.java
@@ -55,9 +55,7 @@ public interface SettingKey<T> {
      * @return default value, or {@code null} if not defined
      * @since 1.0.1
      */
-    default T defaultValue() {
-        return null;
-    }
+    T defaultValue();
 
     /**
      * Indicates whether the value for this key can be set to {@code null}.


### PR DESCRIPTION
This change converts the `defaultValue()` method in the `SettingKey` interface from a default method to a standard abstract interface method.