### PR TITLE
Breaking change: remove deprecated array APIs

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/ArrayGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/ArrayGeneratorSpec.java
@@ -21,33 +21,40 @@ import org.jspecify.annotations.Nullable;
  * Generator spec for arrays.
  *
  * @param <T> array type
+ * @since 1.0.1
  */
 public interface ArrayGeneratorSpec<T extends @Nullable Object>
-        extends NullableGeneratorSpec<T>, SubtypeGeneratorSpec<T> {
+        extends NullableGeneratorSpec<T>, SizeGeneratorSpec<T>, SubtypeGeneratorSpec<T> {
 
     /**
-     * length of array to generate.
+     * Size of array to generate.
      *
-     * @param length of array
+     * @param size of array
      * @return spec builder
+     * @since 5.6.0
      */
-    ArrayGeneratorSpec<T> length(int length);
+    @Override
+    ArrayGeneratorSpec<T> size(int size);
 
     /**
-     * Minimum length of array to generate.
+     * Minimum size of array to generate.
      *
-     * @param length minimum length (inclusive)
+     * @param size minimum size (inclusive)
      * @return spec builder
+     * @since 5.6.0
      */
-    ArrayGeneratorSpec<T> minLength(int length);
+    @Override
+    ArrayGeneratorSpec<T> minSize(int size);
 
     /**
-     * Maximum length of array to generate.
+     * Maximum size of array to generate.
      *
-     * @param length maximum length (inclusive)
+     * @param size maximum size (inclusive)
      * @return spec builder
+     * @since 5.6.0
      */
-    ArrayGeneratorSpec<T> maxLength(int length);
+    @Override
+    ArrayGeneratorSpec<T> maxSize(int size);
 
     /**
      * Indicates that {@code null} value can be generated for the array.

--- a/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/annotation/CommonBeanValidationHandlerMap.java
@@ -264,9 +264,9 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
                 mapSpec.minSize(range.min()).maxSize(range.max());
             } else if (spec instanceof ArrayGeneratorSpec<?> arraySpec) {
                 final Range<Integer> range = AnnotationUtils.calculateRange(
-                        getMin(annotation), getMax(annotation), settings.get(Keys.ARRAY_MAX_LENGTH));
+                        getMin(annotation), getMax(annotation), settings.get(Keys.ARRAY_MAX_SIZE));
 
-                arraySpec.minLength(range.min()).maxLength(range.max());
+                arraySpec.minSize(range.min()).maxSize(range.max());
             }
         }
     }
@@ -288,7 +288,7 @@ class CommonBeanValidationHandlerMap extends AnnotationHandlerMap {
             } else if (spec instanceof ArrayGenerator<?> arraySpec) {
                 arraySpec
                         .nullable(false)
-                        .minLength(settings.get(Keys.ARRAY_MIN_LENGTH));
+                        .minSize(settings.get(Keys.ARRAY_MIN_SIZE));
 
             } else if (spec instanceof CollectionGenerator<?> collectionSpec) {
                 collectionSpec

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -547,7 +547,7 @@ public final class ModelContext {
             withSupplier(BlankSelectors.leafSelector().within(scopes), () -> null);
             withGeneratorSpec(BlankSelectors.collectionSelector().within(scopes).lenient(), gen -> gen.collection().size(0));
             withGeneratorSpec(BlankSelectors.mapSelector().within(scopes).lenient(), gen -> gen.map().size(0));
-            withGeneratorSpec(BlankSelectors.arraySelector().within(scopes).lenient(), gen -> gen.array().length(0));
+            withGeneratorSpec(BlankSelectors.arraySelector().within(scopes).lenient(), gen -> gen.array().size(0));
         }
 
         public Builder lenient() {

--- a/instancio-core/src/main/java/org/instancio/internal/generator/array/ArrayGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/array/ArrayGenerator.java
@@ -38,16 +38,16 @@ import static java.util.Objects.requireNonNull;
 
 public class ArrayGenerator<T> extends AbstractGenerator<T> implements ArrayGeneratorSpec<T> {
 
-    protected int minLength;
-    protected int maxLength;
+    protected int minSize;
+    protected int maxSize;
     private boolean nullableElements;
     private @Nullable Class<?> arrayType;
     private @Nullable List<Object> withElements;
 
     public ArrayGenerator(final GeneratorContext context) {
         super(context);
-        this.minLength = context.settings().get(Keys.ARRAY_MIN_LENGTH);
-        this.maxLength = context.settings().get(Keys.ARRAY_MAX_LENGTH);
+        this.minSize = context.settings().get(Keys.ARRAY_MIN_SIZE);
+        this.maxSize = context.settings().get(Keys.ARRAY_MAX_SIZE);
         super.nullable(context.settings().get(Keys.ARRAY_NULLABLE));
         this.nullableElements = context.settings().get(Keys.ARRAY_ELEMENTS_NULLABLE);
     }
@@ -63,23 +63,23 @@ public class ArrayGenerator<T> extends AbstractGenerator<T> implements ArrayGene
     }
 
     @Override
-    public ArrayGenerator<T> minLength(final int length) {
-        this.minLength = ApiValidator.validateLength(length);
-        this.maxLength = NumberUtils.calculateNewMaxSize(maxLength, minLength);
+    public ArrayGenerator<T> minSize(int size) {
+        this.minSize = ApiValidator.validateSize(size);
+        this.maxSize = NumberUtils.calculateNewMaxSize(maxSize, minSize);
         return this;
     }
 
     @Override
-    public ArrayGenerator<T> maxLength(final int length) {
-        this.maxLength = ApiValidator.validateLength(length);
-        this.minLength = NumberUtils.calculateNewMinSize(minLength, maxLength);
+    public ArrayGenerator<T> maxSize(int size) {
+        this.maxSize = ApiValidator.validateSize(size);
+        this.minSize = NumberUtils.calculateNewMinSize(minSize, maxSize);
         return this;
     }
 
     @Override
-    public ArrayGenerator<T> length(final int length) {
-        this.maxLength = ApiValidator.validateLength(length);
-        this.minLength = length;
+    public ArrayGenerator<T> size(int size) {
+        this.maxSize = ApiValidator.validateSize(size);
+        this.minSize = size;
         return this;
     }
 
@@ -124,8 +124,8 @@ public class ArrayGenerator<T> extends AbstractGenerator<T> implements ArrayGene
     @Override
     @SuppressWarnings("unchecked")
     protected T tryGenerateNonNull(final Random random) {
-        final int length = random.intRange(minLength, maxLength)
-                           + (withElements == null ? 0 : withElements.size());
+        final int length = random.intRange(minSize, maxSize)
+                + (withElements == null ? 0 : withElements.size());
 
         requireNonNull(arrayType);
         return (T) Array.newInstance(arrayType.getComponentType(), length);

--- a/instancio-core/src/main/java/org/instancio/internal/settings/SettingsSupport.java
+++ b/instancio-core/src/main/java/org/instancio/internal/settings/SettingsSupport.java
@@ -17,12 +17,11 @@ package org.instancio.internal.settings;
 
 import org.instancio.settings.Keys;
 import org.instancio.settings.SettingKey;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.jspecify.annotations.Nullable;
 
 final class SettingsSupport {
 
@@ -36,8 +35,8 @@ final class SettingsSupport {
 
     private static Map<SettingKey<?>, SettingKey<?>> getAutoAdjustableKeys() {
         final Map<SettingKey<?>, SettingKey<?>> map = new HashMap<>();
-        map.put(Keys.ARRAY_MAX_LENGTH, Keys.ARRAY_MIN_LENGTH);
-        map.put(Keys.ARRAY_MIN_LENGTH, Keys.ARRAY_MAX_LENGTH);
+        map.put(Keys.ARRAY_MAX_SIZE, Keys.ARRAY_MIN_SIZE);
+        map.put(Keys.ARRAY_MIN_SIZE, Keys.ARRAY_MAX_SIZE);
         map.put(Keys.BYTE_MAX, Keys.BYTE_MIN);
         map.put(Keys.BYTE_MIN, Keys.BYTE_MAX);
         map.put(Keys.COLLECTION_MAX_SIZE, Keys.COLLECTION_MIN_SIZE);

--- a/instancio-core/src/main/java/org/instancio/settings/Keys.java
+++ b/instancio-core/src/main/java/org/instancio/settings/Keys.java
@@ -91,17 +91,21 @@ public final class Keys {
 
     /**
      * Specifies minimum length for arrays;
-     * default is 2; property name {@code array.min.length}.
+     * default is 2; property name {@code array.min.size}.
+     *
+     * @since 5.6.0
      */
-    public static final SettingKey<Integer> ARRAY_MIN_LENGTH = registerRequiredAdjustable(
-            "array.min.length", Integer.class, MIN_SIZE, MIN_ADJUSTER, false);
+    public static final SettingKey<Integer> ARRAY_MIN_SIZE = registerRequiredAdjustable(
+            "array.min.size", Integer.class, MIN_SIZE, MIN_ADJUSTER, false);
 
     /**
      * Specifies maximum length for arrays;
-     * default is 6; property name {@code array.max.length}.
+     * default is 6; property name {@code array.max.size}.
+     *
+     * @since 5.6.0
      */
-    public static final SettingKey<Integer> ARRAY_MAX_LENGTH = registerRequiredAdjustable(
-            "array.max.length", Integer.class, MAX_SIZE, MAX_ADJUSTER, false);
+    public static final SettingKey<Integer> ARRAY_MAX_SIZE = registerRequiredAdjustable(
+            "array.max.size", Integer.class, MAX_SIZE, MAX_ADJUSTER, false);
 
     /**
      * Specifies whether a null can be generated for arrays;

--- a/instancio-tests/bean-validation-hibernate-tests/src/test/resources/instancio.properties
+++ b/instancio-tests/bean-validation-hibernate-tests/src/test/resources/instancio.properties
@@ -2,8 +2,8 @@ bean.validation.enabled=true
 
 # relax the defaults for testing
 # bean validation
-array.min.length=0
-array.max.length=1000
+array.min.size=0
+array.max.size=1000
 array.nullable=true
 boolean.nullable=true
 byte.max=127

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/ArraySizeBVTest.java
@@ -35,7 +35,7 @@ class ArraySizeBVTest {
 
     @WithSettings
     private final Settings settings = Settings.create()
-            .set(Keys.ARRAY_MAX_LENGTH, 3);
+            .set(Keys.ARRAY_MAX_SIZE, 3);
 
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSize() {
@@ -46,7 +46,7 @@ class ArraySizeBVTest {
     @RepeatedTest(SAMPLE_SIZE_DD)
     void withMinSizeZero() {
         final ArraySizeBV.WithMinSizeZero result = Instancio.create(ArraySizeBV.WithMinSizeZero.class);
-        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.ARRAY_MAX_LENGTH));
+        assertThat(result.getValue()).hasSizeBetween(0, settings.get(Keys.ARRAY_MAX_SIZE));
     }
 
     @RepeatedTest(SAMPLE_SIZE_DD)

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/java/org/instancio/test/beanvalidation/NotEmptyBVTest.java
@@ -41,7 +41,7 @@ class NotEmptyBVTest {
             .set(Keys.STRING_NULLABLE, true)
             .set(Keys.STRING_ALLOW_EMPTY, true)
             .set(Keys.STRING_MAX_LENGTH, 20)
-            .set(Keys.ARRAY_MIN_LENGTH, 1)
+            .set(Keys.ARRAY_MIN_SIZE, 1)
             .set(Keys.COLLECTION_MIN_SIZE, 1)
             .set(Keys.MAP_MIN_SIZE, 1);
 

--- a/instancio-tests/bean-validation-jakarta-tests/src/test/resources/instancio.properties
+++ b/instancio-tests/bean-validation-jakarta-tests/src/test/resources/instancio.properties
@@ -3,8 +3,8 @@ bean.validation.enabled=true
 
 # relax the defaults for testing
 # bean validation
-array.min.length=0
-array.max.length=1000
+array.min.size=0
+array.max.size=1000
 array.nullable=true
 boolean.nullable=true
 byte.max=127

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignAdhocRecordsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignAdhocRecordsTest.java
@@ -105,7 +105,7 @@ class AssignAdhocRecordsTest {
 
         final List<A> results = Instancio.ofList(A.class)
                 .size(100)
-                .generate(field(A::array), gen -> gen.array().length(2))
+                .generate(field(A::array), gen -> gen.array().size(2))
                 .generate(field(A::val), gen -> gen.ints().range(1, 3))
                 .assign(Assign.given(A::val).is(1).supply(all(B.class), r -> new B(r.intRange(-199, -100))))
                 .assign(Assign.given(A::val).is(2).supply(all(B.class), r -> new B(r.intRange(-299, -200))))

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignPojoAndRecordTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/assign/AssignPojoAndRecordTest.java
@@ -207,7 +207,7 @@ class AssignPojoAndRecordTest {
         final Root result = Instancio.of(Root.class)
                 .set(field(PojoB::getString), "B")
                 .assign(Assign.given(PojoB::getString).is("B")
-                        .generate(field(PojoA::getArray), gen -> gen.array().length(2)))
+                        .generate(field(PojoA::getArray), gen -> gen.array().size(2)))
                 .create();
 
         assertThat(result.pojoA.array)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankRootObjectTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/blank/BlankRootObjectTest.java
@@ -107,15 +107,15 @@ class BlankRootObjectTest {
                 .set(Keys.FAIL_ON_ERROR, true);
 
         @Test
-        void overrideArrayLength() {
-            final int length = 5;
+        void overrideArraySize() {
+            final int size = 5;
             final Pojo result = Instancio.ofBlank(Pojo.class)
-                    .generate(field(Pojo::getArrayString), gen -> gen.array().length(length))
-                    .generate(field(Pojo::getArrayStringHolder), gen -> gen.array().length(length))
+                    .generate(field(Pojo::getArrayString), gen -> gen.array().size(size))
+                    .generate(field(Pojo::getArrayStringHolder), gen -> gen.array().size(size))
                     .create();
 
-            assertThat(result.getArrayString()).hasSize(length).doesNotContainNull();
-            assertThat(result.getArrayStringHolder()).hasSize(length)
+            assertThat(result.getArrayString()).hasSize(size).doesNotContainNull();
+            assertThat(result.getArrayStringHolder()).hasSize(size)
                     .allSatisfy(e -> assertThat(e.getValue()).isNull());
         }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/BuiltInArrayGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/BuiltInArrayGeneratorTest.java
@@ -15,7 +15,6 @@
  */
 package org.instancio.test.features.generator;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.instancio.Instancio;
 import org.instancio.Model;
 import org.instancio.TypeToken;
@@ -38,7 +37,7 @@ import static org.instancio.Select.field;
 @FeatureTag(Feature.GENERATE)
 @ExtendWith(InstancioExtension.class)
 class BuiltInArrayGeneratorTest {
-    private static final int EXPECTED_LENGTH = RandomUtils.insecure().randomInt(0, 10);
+    private static final int EXPECTED_SIZE = Instancio.gen().ints().range(0, 10).get();
 
     @Nested
     class UsingOfClassAPITest {
@@ -47,10 +46,10 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("Array of the target field should have expected size and be fully populated")
         void arrayShouldHaveExpectedSize() {
             final TwoArraysOfItemString result = Instancio.of(TwoArraysOfItemString.class)
-                    .generate(field("array1"), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(field("array1"), gen -> gen.array().size(EXPECTED_SIZE))
                     .create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
             assertArray(result.getArray2(), Constants.MIN_SIZE, Constants.MAX_SIZE);
         }
 
@@ -58,11 +57,11 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("All arrays should have expected size and be fully populated")
         void allArraysShouldHaveExpectedSize() {
             final TwoArraysOfItemString result = Instancio.of(TwoArraysOfItemString.class)
-                    .generate(all(Item[].class), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(all(Item[].class), gen -> gen.array().size(EXPECTED_SIZE))
                     .create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
-            assertArray(result.getArray2(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
+            assertArray(result.getArray2(), EXPECTED_SIZE, EXPECTED_SIZE);
         }
 
         @Test
@@ -83,10 +82,10 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("Array of the target field should have expected size and be fully populated")
         void arrayShouldHaveExpectedSize() {
             final TwoArraysOfItemString result = Instancio.of(new TypeToken<TwoArraysOfItemString>() {})
-                    .generate(field("array1"), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(field("array1"), gen -> gen.array().size(EXPECTED_SIZE))
                     .create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
             assertArray(result.getArray2(), Constants.MIN_SIZE, Constants.MAX_SIZE);
         }
 
@@ -94,11 +93,11 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("All arrays should have expected size and be fully populated")
         void allArraysShouldHaveExpectedSize() {
             final TwoArraysOfItemString result = Instancio.of(new TypeToken<TwoArraysOfItemString>() {})
-                    .generate(all(Item[].class), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(all(Item[].class), gen -> gen.array().size(EXPECTED_SIZE))
                     .create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
-            assertArray(result.getArray2(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
+            assertArray(result.getArray2(), EXPECTED_SIZE, EXPECTED_SIZE);
         }
     }
 
@@ -109,12 +108,12 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("Array of the target field should have expected size and be fully populated")
         void arrayShouldHaveExpectedSize() {
             final Model<TwoArraysOfItemString> model = Instancio.of(TwoArraysOfItemString.class)
-                    .generate(field("array1"), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(field("array1"), gen -> gen.array().size(EXPECTED_SIZE))
                     .toModel();
 
             final TwoArraysOfItemString result = Instancio.of(model).create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
             assertArray(result.getArray2(), Constants.MIN_SIZE, Constants.MAX_SIZE);
         }
 
@@ -122,13 +121,13 @@ class BuiltInArrayGeneratorTest {
         @DisplayName("All arrays should have expected size and be fully populated")
         void allArraysShouldHaveExpectedSize() {
             final Model<TwoArraysOfItemString> model = Instancio.of(TwoArraysOfItemString.class)
-                    .generate(all(Item[].class), gen -> gen.array().length(EXPECTED_LENGTH))
+                    .generate(all(Item[].class), gen -> gen.array().size(EXPECTED_SIZE))
                     .toModel();
 
             final TwoArraysOfItemString result = Instancio.of(model).create();
 
-            assertArray(result.getArray1(), EXPECTED_LENGTH, EXPECTED_LENGTH);
-            assertArray(result.getArray2(), EXPECTED_LENGTH, EXPECTED_LENGTH);
+            assertArray(result.getArray1(), EXPECTED_SIZE, EXPECTED_SIZE);
+            assertArray(result.getArray2(), EXPECTED_SIZE, EXPECTED_SIZE);
         }
     }
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorNullableElementsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorNullableElementsTest.java
@@ -34,16 +34,16 @@ import static org.instancio.Select.all;
 @FeatureTag({Feature.GENERATE, Feature.ARRAY_GENERATOR_NULLABLE_ELEMENTS})
 @ExtendWith(InstancioExtension.class)
 class ArrayGeneratorNullableElementsTest {
-    private static final int ARRAY_LENGTH = 1000;
+    private static final int ARRAY_SIZE = 1000;
 
     @Test
     void nullableElements() {
         final ArrayLong result = Instancio.of(ArrayLong.class)
-                .generate(all(Long[].class), gen -> gen.array().length(ARRAY_LENGTH).nullableElements())
+                .generate(all(Long[].class), gen -> gen.array().size(ARRAY_SIZE).nullableElements())
                 .create();
 
-        assertThat(result.getWrapper()).hasSize(ARRAY_LENGTH).containsNull();
-        assertThat(new HashSet<>(Arrays.asList(result.getWrapper()))).hasSizeGreaterThan(ARRAY_LENGTH / 2);
+        assertThat(result.getWrapper()).hasSize(ARRAY_SIZE).containsNull();
+        assertThat(new HashSet<>(Arrays.asList(result.getWrapper()))).hasSizeGreaterThan(ARRAY_SIZE / 2);
     }
 
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorSizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorSizeTest.java
@@ -42,28 +42,28 @@ class ArrayGeneratorSizeTest {
 
     @Test
     void size() {
-        assertSize(spec -> spec.length(EXPECTED_SIZE), EXPECTED_SIZE);
+        assertSize(spec -> spec.size(EXPECTED_SIZE), EXPECTED_SIZE);
     }
 
     @Test
     void sizeZero() {
-        assertSize(spec -> spec.length(0), 0);
+        assertSize(spec -> spec.size(0), 0);
     }
 
     @Test
     void minLength() {
         final int maxSize = EXPECTED_SIZE + EXPECTED_SIZE * Constants.RANGE_ADJUSTMENT_PERCENTAGE / 100;
-        assertSizeBetween(spec -> spec.minLength(EXPECTED_SIZE), EXPECTED_SIZE, maxSize);
+        assertSizeBetween(spec -> spec.minSize(EXPECTED_SIZE), EXPECTED_SIZE, maxSize);
     }
 
     @Test
     void maxLength() {
-        assertSize(spec -> spec.maxLength(1), 1);
+        assertSize(spec -> spec.maxSize(1), 1);
     }
 
     @Test
     void minLengthEqualToMaxLength() {
-        assertSizeBetween(spec -> spec.minLength(EXPECTED_SIZE).maxLength(EXPECTED_SIZE), EXPECTED_SIZE, EXPECTED_SIZE);
+        assertSizeBetween(spec -> spec.minSize(EXPECTED_SIZE).maxSize(EXPECTED_SIZE), EXPECTED_SIZE, EXPECTED_SIZE);
     }
 
     private void assertSize(Function<ArrayGeneratorSpec<?>, ArrayGeneratorSpec<?>> fn, int size) {

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorSpecGenericArrayTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorSpecGenericArrayTest.java
@@ -38,7 +38,7 @@ class ArrayGeneratorSpecGenericArrayTest {
 
     @Test
     void create() {
-        final GenericArrayHolder<Phone> result = Instancio.create(new TypeToken<GenericArrayHolder<Phone>>() {});
+        final GenericArrayHolder<Phone> result = Instancio.create(new TypeToken<>() {});
 
         assertThat(result.getArray())
                 .hasSizeBetween(Constants.MIN_SIZE, Constants.MAX_SIZE)
@@ -49,7 +49,7 @@ class ArrayGeneratorSpecGenericArrayTest {
     @Test
     void arraySpecWithNoSubtypeSpecified() {
         final GenericArrayHolder<Phone> result = Instancio.of(new TypeToken<GenericArrayHolder<Phone>>() {})
-                .generate(field(GenericArrayHolder.class, "array"), gen -> gen.array().length(SIZE))
+                .generate(field(GenericArrayHolder.class, "array"), gen -> gen.array().size(SIZE))
                 .create();
 
         assertThat(result.getArray())
@@ -61,7 +61,7 @@ class ArrayGeneratorSpecGenericArrayTest {
     @Test
     void arraySpecWithSubtype() {
         final GenericArrayHolder<Phone> result = Instancio.of(new TypeToken<GenericArrayHolder<Phone>>() {})
-                .generate(field(GenericArrayHolder.class, "array"), gen -> gen.array().length(SIZE)
+                .generate(field(GenericArrayHolder.class, "array"), gen -> gen.array().size(SIZE)
                         .subtype(PhoneWithType[].class))
                 .create();
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorWithElementOrderTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorWithElementOrderTest.java
@@ -47,8 +47,8 @@ class ArrayGeneratorWithElementOrderTest {
     @RepeatedTest(5)
     void shuffledElementShouldBeInTheSameOrderForAGivenSeed() {
         final ArrayLong result = Instancio.of(ArrayLong.class)
-                .generate(all(long[].class), gen -> gen.array().maxLength(5).with((Object[]) EXPECTED_LONGS))
-                .generate(all(Long[].class), gen -> gen.array().maxLength(5).with((Object[]) EXPECTED_LONGS))
+                .generate(all(long[].class), gen -> gen.array().maxSize(5).with((Object[]) EXPECTED_LONGS))
+                .generate(all(Long[].class), gen -> gen.array().maxSize(5).with((Object[]) EXPECTED_LONGS))
                 .create();
 
         assertThat(result.getPrimitive()).contains(EXPECTED_LONGS);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorWithElementTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/array/ArrayGeneratorWithElementTest.java
@@ -64,7 +64,7 @@ class ArrayGeneratorWithElementTest {
         final Long[] sorted = LongStream.range(1, 100).boxed().toArray(Long[]::new);
 
         final ArrayLong result = Instancio.of(ArrayLong.class)
-                .generate(all(all(long[].class), all(Long[].class)), gen -> gen.array().maxLength(0).with(sorted))
+                .generate(all(all(long[].class), all(Long[].class)), gen -> gen.array().maxSize(0).with(sorted))
                 .create();
 
         assertThat(result.getPrimitive()).containsOnly(sorted);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/CustomGeneratorWithDataStructuresTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/custom/CustomGeneratorWithDataStructuresTest.java
@@ -205,8 +205,8 @@ class CustomGeneratorWithDataStructuresTest {
                     .supply(all(Container.class), generator)
                     .generate(field("list"), gen -> gen.collection().size(NEW_SIZE))
                     .generate(field("blankList"), gen -> gen.collection().size(NEW_SIZE))
-                    .generate(field("array"), gen -> gen.array().length(NEW_SIZE))
-                    .generate(field("blankArray"), gen -> gen.array().length(NEW_SIZE))
+                    .generate(field("array"), gen -> gen.array().size(NEW_SIZE))
+                    .generate(field("blankArray"), gen -> gen.array().size(NEW_SIZE))
                     .onComplete(all(Container.class), (Container result) -> {
                         if (result.map != null) {
                             result.map.put("foo", 1L);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/misc/EmitGeneratorTest.java
@@ -107,7 +107,7 @@ class EmitGeneratorTest {
     void emitNullArrayElements() {
         final int size = 5;
         final Integer[] result = Instancio.of(Integer[].class)
-                .generate(root(), gen -> gen.array().length(size))
+                .generate(root(), gen -> gen.array().size(size))
                 .generate(all(Integer.class), gen -> gen.emit().item(null, size))
                 .create();
 
@@ -129,7 +129,7 @@ class EmitGeneratorTest {
     void whenEmptyEmitNullWithArray() {
         final int size = 5;
         final Integer[] result = Instancio.of(Integer[].class)
-                .generate(root(), gen -> gen.array().length(size))
+                .generate(root(), gen -> gen.array().size(size))
                 .generate(all(Integer.class), gen -> gen.emit().items(1).whenEmptyEmitNull())
                 .create();
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableElementViaSettingsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableElementViaSettingsTest.java
@@ -47,7 +47,7 @@ class NullableElementViaSettingsTest {
     @Test
     void arrayElements() {
         final String[] results = Instancio.of(String[].class)
-                .generate(all(String[].class), gen -> gen.array().length(SAMPLE_SIZE))
+                .generate(all(String[].class), gen -> gen.array().size(SAMPLE_SIZE))
                 .create();
 
         assertThat(results)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableTypeViaGeneratorSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableTypeViaGeneratorSpecTest.java
@@ -60,7 +60,7 @@ class NullableTypeViaGeneratorSpecTest {
     @Test
     void arrayElements() {
         final String[] results = Instancio.of(String[].class)
-                .generate(all(String[].class), gen -> gen.array().length(SAMPLE_SIZE))
+                .generate(all(String[].class), gen -> gen.array().size(SAMPLE_SIZE))
                 .generate(allStrings(), gen -> gen.string().nullable())
                 .create();
 

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableTypeViaSettingsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/NullableTypeViaSettingsTest.java
@@ -65,7 +65,7 @@ class NullableTypeViaSettingsTest {
     @Test
     void arrayElements() {
         final String[] results = Instancio.of(String[].class)
-                .generate(all(String[].class), gen -> gen.array().length(SAMPLE_SIZE))
+                .generate(all(String[].class), gen -> gen.array().size(SAMPLE_SIZE))
                 .create();
 
         assertThat(results)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/WithNullableTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/nullable/WithNullableTest.java
@@ -111,7 +111,7 @@ class WithNullableTest {
     void arrayElements() {
         final String[] results = Instancio.of(String[].class)
                 .withNullable(allStrings())
-                .generate(all(String[].class), gen -> gen.array().length(SAMPLE_SIZE))
+                .generate(all(String[].class), gen -> gen.array().size(SAMPLE_SIZE))
                 .create();
 
         assertThat(results)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/RootSelectorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/RootSelectorTest.java
@@ -70,7 +70,7 @@ class RootSelectorTest {
     void withArray() {
         final int size = 10;
         final String[] result = Instancio.of(String[].class)
-                .generate(root(), gen -> gen.array().length(size))
+                .generate(root(), gen -> gen.array().size(size))
                 .create();
 
         assertThat(result).hasSize(size);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectWithGenerateTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/selector/SelectWithGenerateTest.java
@@ -139,7 +139,7 @@ class SelectWithGenerateTest {
                                 all(Long[].class),
                                 all(String[].class),
                                 all(Item[].class)),
-                        gen -> gen.array().length(expectedLength))
+                        gen -> gen.array().size(expectedLength))
                 .create();
 
         assertThat(result.getPrimitiveLongArray()).hasSize(expectedLength);

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/ArraySettingsTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/settings/ArraySettingsTest.java
@@ -40,8 +40,8 @@ class ArraySettingsTest {
     private static final int MAX_SIZE_OVERRIDE = 102;
 
     private static final Settings settings = Settings.create()
-            .set(Keys.ARRAY_MIN_LENGTH, MIN_SIZE_OVERRIDE)
-            .set(Keys.ARRAY_MAX_LENGTH, MAX_SIZE_OVERRIDE)
+            .set(Keys.ARRAY_MIN_SIZE, MIN_SIZE_OVERRIDE)
+            .set(Keys.ARRAY_MAX_SIZE, MAX_SIZE_OVERRIDE)
             .lock();
 
     @Test

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/ModelReporterTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/ModelReporterTest.java
@@ -98,8 +98,6 @@ class ModelReporterTest {
                         isLockedForModifications: true
                         settingsMap:
                         	'array.elements.nullable': false
-                        	'array.max.length': 6
-                        	'array.min.length': 2
                         """,
 
                 """

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
@@ -175,7 +175,7 @@ class ModelContextTest {
         final GeneratorContext genContext = new InternalGeneratorContext(Settings.defaults(), mock(Random.class));
         final Generators generators = new BuiltInGenerators(genContext);
 
-        final ArrayGeneratorSpec<Object> petsSpec = generators.array().subtype(Pet[].class).length(3);
+        final ArrayGeneratorSpec<Object> petsSpec = generators.array().subtype(Pet[].class).size(3);
 
         final GeneratorSpec<String> stringSpec = generators.string().minLength(5).allowEmpty();
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/array/ArrayGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/array/ArrayGeneratorTest.java
@@ -41,8 +41,8 @@ class ArrayGeneratorTest extends AbstractGeneratorTestTemplate<String[], ArrayGe
     private static final int PERCENTAGE_THRESHOLD = 10;
 
     private static final Settings SETTINGS = Settings.defaults()
-            .set(Keys.ARRAY_MIN_LENGTH, MIN_SIZE)
-            .set(Keys.ARRAY_MAX_LENGTH, MAX_SIZE)
+            .set(Keys.ARRAY_MIN_SIZE, MIN_SIZE)
+            .set(Keys.ARRAY_MAX_SIZE, MAX_SIZE)
             .set(Keys.ARRAY_NULLABLE, true)
             .set(Keys.ARRAY_ELEMENTS_NULLABLE, true)
             .lock();

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/ArrayGeneratorSpecTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/lang/ArrayGeneratorSpecTest.java
@@ -38,7 +38,7 @@ class ArrayGeneratorSpecTest {
 
     @BeforeEach
     void setUp() {
-        generator.minLength(0).minLength(1);
+        generator.minSize(0).minSize(1);
     }
 
     @Test
@@ -46,9 +46,9 @@ class ArrayGeneratorSpecTest {
     void newMaxIsLessThanMin() {
         final int newMax = 50;
         generator
-                .minLength(Integer.MAX_VALUE)
-                .maxLength(newMax);
-        assertThat(generator.getMinLength()).isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+                .minSize(Integer.MAX_VALUE)
+                .maxSize(newMax);
+        assertThat(generator.getMinSize()).isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
     }
 
     @Test
@@ -56,17 +56,17 @@ class ArrayGeneratorSpecTest {
     void newMaxIsEqualToMin() {
         final int newMax = 100;
         generator
-                .minLength(Integer.MAX_VALUE)
-                .maxLength(newMax);
-        assertThat(generator.getMinLength()).isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
+                .minSize(Integer.MAX_VALUE)
+                .maxSize(newMax);
+        assertThat(generator.getMinSize()).isEqualTo(calculatePercentage(newMax, -PERCENTAGE));
     }
 
     @Test
     @DisplayName("newMin > max: new nax should be set to greater than newMin by PERCENTAGE")
     void newMinIsGreaterThanMax() {
         final int newMin = 100;
-        generator.minLength(newMin);
-        assertThat(generator.getMaxLength()).isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+        generator.minSize(newMin);
+        assertThat(generator.getMaxSize()).isEqualTo(calculatePercentage(newMin, PERCENTAGE));
     }
 
     @Test
@@ -74,31 +74,31 @@ class ArrayGeneratorSpecTest {
     void newMinIsEqualToMax() {
         final int newMin = 100;
         generator
-                .maxLength(0)
-                .minLength(newMin);
-        assertThat(generator.getMaxLength()).isEqualTo(calculatePercentage(newMin, PERCENTAGE));
+                .maxSize(0)
+                .minSize(newMin);
+        assertThat(generator.getMaxSize()).isEqualTo(calculatePercentage(newMin, PERCENTAGE));
     }
 
     @Test
-    void length() {
-        final int length = 2;
-        generator.length(length);
-        assertThat(generator.getMinLength()).isEqualTo(length);
-        assertThat(generator.getMaxLength()).isEqualTo(length);
+    void size() {
+        final int size = 2;
+        generator.size(size);
+        assertThat(generator.getMinSize()).isEqualTo(size);
+        assertThat(generator.getMaxSize()).isEqualTo(size);
     }
 
     @Test
     void minValidation() {
-        assertThatThrownBy(() -> generator.minLength(-1))
+        assertThatThrownBy(() -> generator.minSize(-1))
                 .isExactlyInstanceOf(InstancioApiException.class)
-                .hasMessageContaining("length must not be negative: -1");
+                .hasMessageContaining("size must not be negative: -1");
     }
 
     @Test
     void maxValidation() {
-        assertThatThrownBy(() -> generator.maxLength(-1))
+        assertThatThrownBy(() -> generator.maxSize(-1))
                 .isExactlyInstanceOf(InstancioApiException.class)
-                .hasMessageContaining("length must not be negative: -1");
+                .hasMessageContaining("size must not be negative: -1");
     }
 
     private static int calculatePercentage(final int initial, final int percentage) {
@@ -113,12 +113,12 @@ class ArrayGeneratorSpecTest {
             super(context);
         }
 
-        int getMinLength() {
-            return minLength;
+        int getMinSize() {
+            return minSize;
         }
 
-        int getMaxLength() {
-            return maxLength;
+        int getMaxSize() {
+            return maxSize;
         }
     }
 

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsAutoAdjustmentTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsAutoAdjustmentTest.java
@@ -69,10 +69,10 @@ class SettingsAutoAdjustmentTest {
         final int max = 100;
         final int newMin = 101;
         settings
-                .set(Keys.ARRAY_MAX_LENGTH, max)
-                .set(Keys.ARRAY_MIN_LENGTH, newMin);
+                .set(Keys.ARRAY_MAX_SIZE, max)
+                .set(Keys.ARRAY_MIN_SIZE, newMin);
 
-        assertThat(settings.get(Keys.ARRAY_MAX_LENGTH))
+        assertThat(settings.get(Keys.ARRAY_MAX_SIZE))
                 .as("Expecting newMax value to be greater than newMin by %s%%", PERCENTAGE)
                 .isEqualTo((int) Math.round((newMin * (100 + PERCENTAGE)) / 100d));
     }
@@ -183,7 +183,7 @@ class SettingsAutoAdjustmentTest {
                     Arguments.of(Keys.LONG_MIN),
                     Arguments.of(Keys.FLOAT_MIN),
                     Arguments.of(Keys.DOUBLE_MIN),
-                    Arguments.of(Keys.ARRAY_MIN_LENGTH),
+                    Arguments.of(Keys.ARRAY_MIN_SIZE),
                     Arguments.of(Keys.COLLECTION_MIN_SIZE),
                     Arguments.of(Keys.MAP_MIN_SIZE),
                     Arguments.of(Keys.STRING_MIN_LENGTH));
@@ -197,7 +197,7 @@ class SettingsAutoAdjustmentTest {
                     Arguments.of(Keys.LONG_MAX),
                     Arguments.of(Keys.FLOAT_MAX),
                     Arguments.of(Keys.DOUBLE_MAX),
-                    Arguments.of(Keys.ARRAY_MAX_LENGTH),
+                    Arguments.of(Keys.ARRAY_MAX_SIZE),
                     Arguments.of(Keys.COLLECTION_MAX_SIZE),
                     Arguments.of(Keys.MAP_MAX_SIZE),
                     Arguments.of(Keys.STRING_MAX_LENGTH));

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/settings/SettingsTest.java
@@ -213,8 +213,8 @@ class SettingsTest {
                 .set(Keys.DOUBLE_MIN, 345.9)
                 .set(Keys.STRING_NULLABLE, true)
                 .set(customKey, "custom-key-value")
-                .set(Keys.ARRAY_MIN_LENGTH, 1)
-                .set(Keys.ARRAY_MAX_LENGTH, 5)
+                .set(Keys.ARRAY_MIN_SIZE, 1)
+                .set(Keys.ARRAY_MAX_SIZE, 5)
                 .mapType(List.class, ArrayList.class)
                 .lock()
                 .toString()
@@ -222,8 +222,8 @@ class SettingsTest {
                 "Settings[",
                 "isLockedForModifications: true",
                 "settingsMap:",
-                "\t'array.max.length': 5",
-                "\t'array.min.length': 1",
+                "\t'array.max.size': 5",
+                "\t'array.min.size': 1",
                 "\t'custom.key.", "': custom-key-value",
                 "\t'double.min': 345.9",
                 "\t'long.min': 123",
@@ -243,11 +243,11 @@ class SettingsTest {
             final int minLength = 1000;
             final int newMaxLength = 100;
             final Settings settings = Settings.defaults()
-                    .set(Keys.ARRAY_MIN_LENGTH, minLength)
-                    .set(Keys.ARRAY_MAX_LENGTH, newMaxLength);
+                    .set(Keys.ARRAY_MIN_SIZE, minLength)
+                    .set(Keys.ARRAY_MAX_SIZE, newMaxLength);
 
             final int expected = newMaxLength - newMaxLength * Constants.RANGE_ADJUSTMENT_PERCENTAGE / 100;
-            final int newMin = settings.get(Keys.ARRAY_MIN_LENGTH);
+            final int newMin = settings.get(Keys.ARRAY_MIN_SIZE);
             assertThat(newMin).isEqualTo(expected);
         }
 
@@ -290,7 +290,7 @@ class SettingsTest {
         @Test
         void minSizeShouldAutoAdjustToZeroIfMaxIsSetToToZero() {
             final Map<SettingKey<Integer>, SettingKey<Integer>> sizeKeys = Map.of(
-                    Keys.ARRAY_MIN_LENGTH, Keys.ARRAY_MAX_LENGTH,
+                    Keys.ARRAY_MIN_SIZE, Keys.ARRAY_MAX_SIZE,
                     Keys.COLLECTION_MIN_SIZE, Keys.COLLECTION_MAX_SIZE,
                     Keys.MAP_MIN_SIZE, Keys.MAP_MAX_SIZE,
                     Keys.STRING_MIN_LENGTH, Keys.STRING_MAX_LENGTH
@@ -345,11 +345,11 @@ class SettingsTest {
             final int minLength = 1000;
             final int newMaxLength = 100;
             final Settings settings = Settings.defaults()
-                    .set(Keys.ARRAY_MIN_LENGTH, minLength);
+                    .set(Keys.ARRAY_MIN_SIZE, minLength);
 
-            ((InternalSettings) settings).set(Keys.ARRAY_MAX_LENGTH, newMaxLength, AUTO_ADJUST_DISABLED);
+            ((InternalSettings) settings).set(Keys.ARRAY_MAX_SIZE, newMaxLength, AUTO_ADJUST_DISABLED);
 
-            final int newMin = settings.get(Keys.ARRAY_MIN_LENGTH);
+            final int newMin = settings.get(Keys.ARRAY_MIN_SIZE);
             assertThat(newMin).isEqualTo(minLength);
         }
     }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/ArrayUtilsTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/util/ArrayUtilsTest.java
@@ -128,7 +128,7 @@ class ArrayUtilsTest {
 
     private static <T> T createArray(final Class<T> arrayClass) {
         return Instancio.of(arrayClass)
-                .generate(all(arrayClass), gen -> gen.array().length(100))
+                .generate(all(arrayClass), gen -> gen.array().size(100))
                 .create();
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/resources/custom-instancio-test.properties
+++ b/instancio-tests/instancio-core-tests/src/test/resources/custom-instancio-test.properties
@@ -1,7 +1,7 @@
 # custom properties file name - used for unit testing
 array.elements.nullable=true
-array.max.length=11
-array.min.length=0
+array.max.size=11
+array.min.size=0
 array.nullable=true
 boolean.nullable=true
 byte.max=11

--- a/instancio-tests/instancio-core-tests/src/test/resources/instancio.properties
+++ b/instancio-tests/instancio-core-tests/src/test/resources/instancio.properties
@@ -1,7 +1,7 @@
 # Override settings in test scope using default properties file path
 array.elements.nullable=false
-array.max.length=6
-array.min.length=2
+array.max.size=6
+array.min.size=2
 array.nullable=false
 assignment.type=FIELD
 boolean.nullable=false

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/given/GivenWithProviderTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/given/GivenWithProviderTest.java
@@ -145,7 +145,7 @@ class GivenWithProviderTest {
 
             return Instancio.of(context::getTargetType)
                     .generate(Select.root(), gen -> {
-                        ArrayGeneratorSpec<Object> spec = gen.array().length(size.value());
+                        ArrayGeneratorSpec<Object> spec = gen.array().size(size.value());
                         return nullableElements ? spec.nullableElements() : spec;
                     })
                     .create();

--- a/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomGeneratorProvider.java
+++ b/instancio-tests/spi-tests/src/test/java/org/example/spi/CustomGeneratorProvider.java
@@ -141,7 +141,7 @@ public class CustomGeneratorProvider implements InstancioServiceProvider {
                     return generators.collection().size(10);
                 }
                 if (parentClass == WithIntegerArray.class && fieldType == Integer[].class) {
-                    return generators.array().length(10);
+                    return generators.array().size(10);
                 }
                 if (parentClass == MapIntegerString.class && fieldType == Map.class) {
                     return generators.map().size(10);

--- a/website/docs/includes/instancio-properties-sample.md
+++ b/website/docs/includes/instancio-properties-sample.md
@@ -1,7 +1,7 @@
 ```properties linenums="1" title="Sample instancio.properties"
 array.elements.nullable=false
-array.max.length=6
-array.min.length=2
+array.max.size=6
+array.min.size=2
 array.nullable=false
 bigdecimal.scale=2
 boolean.nullable=false


### PR DESCRIPTION
Deprecation will be introduced separately in v5.6.0. This change targets v6.0.0 and removes the old APIs entirely, replacing them with the new implementation.