### PR TITLE
Deprecate `@InstancioSource` annotation

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/InstancioSource.java
@@ -48,7 +48,9 @@ import java.lang.annotation.Target;
  * a randomly populated instance of the {@code Person} class.
  *
  * @since 1.1.8
+ * @deprecated use {@link Given @Given} annotation instead
  */
+@Deprecated(since = "5.6.0", forRemoval = true)
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented


### PR DESCRIPTION
Deprecation was added separately to the v5.6.0 branch.

---

### Usage change:

Before:

```java
@InstancioSource
@ParameterizedTest
void example(String foo, int bar) {}
```

After:

```java
@RepeatedTest(100)
void example(@Given String foo, @Given int bar) {}
```

