### PR TITLE
Support junit parallel execution tests

### DIFF
--- a/instancio-core/src/main/java/org/instancio/support/ThreadLocalRandom.java
+++ b/instancio-core/src/main/java/org/instancio/support/ThreadLocalRandom.java
@@ -24,7 +24,7 @@ public final class ThreadLocalRandom {
 
     private static final ThreadLocalRandom INSTANCE = new ThreadLocalRandom();
 
-    private static final ThreadLocal<Random> RANDOM = new ThreadLocal<>();
+    private static final ThreadLocal<@Nullable Random> RANDOM = new InheritableThreadLocal<>();
 
     private ThreadLocalRandom() {
         // non-instantiable

--- a/instancio-core/src/main/java/org/instancio/support/ThreadLocalSettings.java
+++ b/instancio-core/src/main/java/org/instancio/support/ThreadLocalSettings.java
@@ -24,7 +24,7 @@ public final class ThreadLocalSettings {
 
     private static final ThreadLocalSettings INSTANCE = new ThreadLocalSettings();
 
-    private static final ThreadLocal<Settings> SETTINGS = new ThreadLocal<>();
+    private static final ThreadLocal<@Nullable Settings> SETTINGS = new InheritableThreadLocal<>();
 
     private ThreadLocalSettings() {
         // non-instantiable

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceArgumentsProvider.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/InstancioSourceArgumentsProvider.java
@@ -48,6 +48,8 @@ import static org.instancio.junit.internal.Constants.INSTANCIO_SOURCE_STATE;
 public class InstancioSourceArgumentsProvider
         implements ArgumentsProvider, AnnotationConsumer<InstancioSource> {
 
+    private static final String THREAD_LOCAL_CLEANUP = "instancio.source.threadLocalCleanup";
+
     private InstancioSource instancioSource;
 
     @Initializer
@@ -65,6 +67,18 @@ public class InstancioSourceArgumentsProvider
         final ThreadLocalSettings threadLocalSettings = ThreadLocalSettings.getInstance();
 
         ExtensionSupport.processAnnotations(context, threadLocalRandom, threadLocalSettings);
+
+        // Ensure thread-local state set by processAnnotations() is cleared when the
+        // parameterized test method's store is closed. Without this, using
+        // @InstancioSource without @ExtendWith(InstancioExtension.class) leaks the
+        // seed/settings to subsequent tests on the same thread, since the extension's
+        // afterEach cleanup would otherwise be the only cleanup path.
+        context.getStore(INSTANCIO_NAMESPACE).put(
+                THREAD_LOCAL_CLEANUP,
+                (AutoCloseable) () -> {
+                    threadLocalRandom.remove();
+                    threadLocalSettings.remove();
+                });
 
         final Random random = requireNonNull(threadLocalRandom.get());
         final Settings settings = threadLocalSettings.get();

--- a/instancio-tests/concurrency-tests/pom.xml
+++ b/instancio-tests/concurrency-tests/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.instancio</groupId>
+        <artifactId>instancio-tests</artifactId>
+        <version>6.0.0-RC3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>concurrency-tests</artifactId>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.instancio</groupId>
+            <artifactId>instancio-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/ChildThreadTest.java
+++ b/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/ChildThreadTest.java
@@ -1,0 +1,44 @@
+package org.instancio.test.concurrency;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.Seed;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(InstancioExtension.class)
+class ChildThreadTest {
+
+    private final long SEED = -1L;
+    private final ExecutorService executorService = Executors.newVirtualThreadPerTaskExecutor();
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.STRING_MAX_LENGTH, 15)
+            .set(Keys.STRING_MIN_LENGTH, 15);
+
+    @Seed(SEED)
+    @Test
+    void childThreadShouldInheritSeed() throws ExecutionException, InterruptedException, TimeoutException {
+        var stringResult = executorService.submit(() -> Instancio.of(String.class).asResult()).get(10, TimeUnit.SECONDS);
+        var expected = Instancio.of(String.class).withSeed(SEED).create();
+        assertThat(stringResult.getSeed()).isEqualTo(SEED);
+        assertThat(stringResult.get()).isEqualTo(expected);
+    }
+
+    @Test
+    void childThreadShouldInheritSettings() throws ExecutionException, InterruptedException, TimeoutException {
+        var string = executorService.submit(() -> Instancio.create(String.class)).get(10, TimeUnit.SECONDS);
+        assertThat(string).hasSize(15);
+    }
+}

--- a/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/CleanUpSeedTest.java
+++ b/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/CleanUpSeedTest.java
@@ -1,0 +1,164 @@
+package org.instancio.test.concurrency;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.InstancioSource;
+import org.instancio.junit.Seed;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Execution(ExecutionMode.SAME_THREAD)
+class CleanUpSeedTest {
+    private final long SEED = -1L;
+
+    @Order(1)
+    @Nested
+    class InstancioSourceBefore {
+
+        @Order(1)
+        @Nested
+        class InstancioSourceAfter {
+
+            @Order(1)
+            @Seed(SEED)
+            @ParameterizedTest
+            @InstancioSource(samples = 1)
+            void setSeedInCurrentThread(String string) {
+                assertThat(string).isNotNull();
+            }
+
+            @Order(2)
+            @ParameterizedTest
+            @InstancioSource(samples = 1)
+            void ignoreAlreadyPresentSeedInCurrentThread(String string) {
+                var expected = Instancio.of(String.class).withSeed(SEED).create();
+                assertThat(string).isNotEqualTo(expected);
+            }
+        }
+
+        @Order(2)
+        @Nested
+        class InstancioExtensionAfter {
+
+            @Order(1)
+            @Seed(SEED)
+            @ParameterizedTest
+            @InstancioSource(samples = 1)
+            void setSeedInCurrentThread(String string) {
+                assertThat(string).isNotNull();
+            }
+
+            @ExtendWith(InstancioExtension.class)
+            @Order(2)
+            @Test
+            void ignoreAlreadyPresentSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isNotEqualTo(SEED);
+            }
+        }
+
+        @Order(3)
+        @Nested
+        class SimpleCreationAfter {
+
+            @Order(1)
+            @Seed(SEED)
+            @ParameterizedTest
+            @InstancioSource(samples = 1)
+            void setSeedInCurrentThread(String string) {
+                assertThat(string).isNotNull();
+            }
+
+            @Order(2)
+            @Test
+            void ignoreAlreadyPresentSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isNotEqualTo(SEED);
+            }
+        }
+    }
+
+    @Order(2)
+    @Nested
+    class InstancioExtensionBefore {
+
+        @Order(1)
+        @Nested
+        class InstancioSourceAfter {
+
+            @ExtendWith(InstancioExtension.class)
+            @Order(1)
+            @Test
+            @Seed(SEED)
+            void setSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isEqualTo(SEED);
+            }
+
+            @Order(2)
+            @ParameterizedTest
+            @InstancioSource(samples = 1)
+            void ignoreAlreadyPresentSeedInCurrentThread(String string) {
+                var expected = Instancio.of(String.class).withSeed(SEED).create();
+                assertThat(string).isNotEqualTo(expected);
+            }
+        }
+
+        @Order(2)
+        @Nested
+        class InstancioExtensionAfter {
+
+            @ExtendWith(InstancioExtension.class)
+            @Order(1)
+            @Test
+            @Seed(SEED)
+            void setSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isEqualTo(SEED);
+            }
+
+            @ExtendWith(InstancioExtension.class)
+            @Order(2)
+            @Test
+            void ignoreAlreadyPresentSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isNotEqualTo(SEED);
+            }
+        }
+
+        @Order(3)
+        @Nested
+        class SimpleCreationAfter {
+
+            @ExtendWith(InstancioExtension.class)
+            @Order(1)
+            @Test
+            @Seed(SEED)
+            void setSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isEqualTo(SEED);
+            }
+
+            @Order(2)
+            @Test
+            void ignoreAlreadyPresentSeedInCurrentThread() {
+                var stringResult = Instancio.of(String.class).asResult();
+                assertThat(stringResult.getSeed()).isNotEqualTo(SEED);
+            }
+        }
+
+    }
+}

--- a/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/CleanUpSettingsTest.java
+++ b/instancio-tests/concurrency-tests/src/test/java/org/instancio/test/concurrency/CleanUpSettingsTest.java
@@ -1,0 +1,230 @@
+package org.instancio.test.concurrency;
+
+import org.instancio.Instancio;
+import org.instancio.junit.Given;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.junit.InstancioSource;
+import org.instancio.junit.WithSettings;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Execution(ExecutionMode.SAME_THREAD)
+class CleanUpSettingsTest {
+
+    @Order(1)
+    @Nested
+    class InstancioSourceBefore {
+
+        @Order(1)
+        @Nested
+        class InstancioSourceAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ParameterizedTest
+                @InstancioSource(samples = 1)
+                void setSettingsInCurrentThread(String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @ParameterizedTest
+                @InstancioSource(samples = 1)
+                void ignoreAlreadyPresentSettingsInCurrentThread(String string) {
+                    assertThat(string).hasSizeLessThanOrEqualTo(10);
+                }
+
+            }
+        }
+
+        @Order(2)
+        @Nested
+        class InstancioExtensionAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ParameterizedTest
+                @InstancioSource(samples = 1)
+                void setSettingsInCurrentThread(String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @ExtendWith(InstancioExtension.class)
+                @Test
+                void ignoreAlreadyPresentSettingsInCurrentThread(@Given String string) {
+                    assertThat(string).hasSizeLessThanOrEqualTo(10);
+                }
+            }
+        }
+
+        @Order(3)
+        @Nested
+        class SimpleCreationAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ParameterizedTest
+                @InstancioSource(samples = 1)
+                void setSettingsInCurrentThread(String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @Test
+                void ignoreAlreadyPresentSettingsInCurrentThread() {
+                    assertThat(Instancio.create(String.class)).hasSizeLessThanOrEqualTo(10);
+                }
+            }
+        }
+    }
+
+    @Order(2)
+    @Nested
+    class InstancioExtensionBefore {
+
+        @Order(1)
+        @Nested
+        class InstancioSourceAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ExtendWith(InstancioExtension.class)
+                @Test
+                void setSettingsInCurrentThread(@Given String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @ParameterizedTest
+                @InstancioSource(samples = 1)
+                void ignoreAlreadyPresentSettingsInCurrentThread(String string) {
+                    assertThat(string).hasSizeLessThanOrEqualTo(10);
+                }
+
+            }
+        }
+
+        @Order(2)
+        @Nested
+        class InstancioExtensionAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ExtendWith(InstancioExtension.class)
+                @Test
+                void setSettingsInCurrentThread(@Given String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @ExtendWith(InstancioExtension.class)
+                @Test
+                void ignoreAlreadyPresentSettingsInCurrentThread(@Given String string) {
+                    assertThat(string).hasSizeLessThanOrEqualTo(10);
+                }
+            }
+        }
+
+        @Order(3)
+        @Nested
+        class SimpleCreationAfter {
+
+            @Order(1)
+            @Nested
+            class BeforeWrapper {
+
+                @WithSettings
+                private static final Settings settings = Settings.create()
+                        .set(Keys.STRING_MAX_LENGTH, 15)
+                        .set(Keys.STRING_MIN_LENGTH, 15);
+
+                @ExtendWith(InstancioExtension.class)
+                @Test
+                void setSettingsInCurrentThread(@Given String string) {
+                    assertThat(string).hasSize(15);
+                }
+            }
+
+            @Order(2)
+            @Nested
+            class AfterWrapper {
+
+                @Test
+                void ignoreAlreadyPresentSettingsInCurrentThread() {
+                    assertThat(Instancio.create(String.class)).hasSizeLessThanOrEqualTo(10);
+                }
+            }
+        }
+    }
+}

--- a/instancio-tests/concurrency-tests/src/test/resources/junit-platform.properties
+++ b/instancio-tests/concurrency-tests/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent
+junit.jupiter.execution.parallel.mode.classes.default=concurrent
+junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/instancio-tests/pom.xml
+++ b/instancio-tests/pom.xml
@@ -62,6 +62,7 @@
                 <module>jackson-tests</module>
                 <module>arch-tests</module>
                 <module>jpms-tests</module>
+                <module>concurrency-tests</module>
             </modules>
         </profile>
     </profiles>

--- a/instancio-tests/report-aggregate/pom.xml
+++ b/instancio-tests/report-aggregate/pom.xml
@@ -202,6 +202,12 @@
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.instancio</groupId>
+                    <artifactId>concurrency-tests</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -4322,6 +4322,7 @@ Instancio supports the JUnit framework through the {{InstancioExtension}}, which
 - Ability to use `@InstancioSource` with `@ParameterizedTest` methods
 - Injection of custom settings using the `@WithSettings` annotation
 - Support for reproducing failed tests using the `@Seed` annotation
+- Support for running tests [concurrently](https://docs.junit.org/current/writing-tests/parallel-execution.html)
 
 ## `@Given` Injection
 


### PR DESCRIPTION
- Propagate thread local variables to child threads
- Clean up thread local variables when `@InstancioSource` is used without `InstancioExtension` 