### PR TITLE
Bug fix: ReflectionUtils.collectionAnnotations should deduplicate annotations and filter out "kotlin.*"

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/internal/ReflectionUtils.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/ReflectionUtils.java
@@ -24,7 +24,9 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 
@@ -39,17 +41,25 @@ public final class ReflectionUtils {
     }
 
     public static List<Annotation> collectionAnnotations(final AnnotatedElement element) {
+        final Set<Annotation> results = new HashSet<>();
+        collectionAnnotations(element, results);
+        return new ArrayList<>(results);
+    }
+
+    private static void collectionAnnotations(final AnnotatedElement element, final Set<Annotation> results) {
         final Annotation[] annotations = element.getDeclaredAnnotations();
-        final List<Annotation> results = new ArrayList<>();
         for (Annotation annotation : annotations) {
+            if (results.contains(annotation)) {
+                continue;
+            }
             final Class<? extends Annotation> type = annotation.annotationType();
 
-            if (!type.getPackage().getName().startsWith("java.")) {
+            String packageName = type.getPackage().getName();
+            if (!packageName.startsWith("java.") && !packageName.startsWith("kotlin.") && !"kotlin".equals(packageName)) {
                 results.add(annotation);
-                results.addAll(collectionAnnotations(type));
+                collectionAnnotations(type, results);
             }
         }
-        return results;
     }
 
     static List<Field> getAnnotatedFields(final Class<?> klass, final Class<? extends Annotation> annotation) {

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ReflectionUtilsTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ReflectionUtilsTest.java
@@ -19,6 +19,7 @@ import org.instancio.test.support.pojo.basic.StringHolder;
 import org.instancio.test.support.pojo.person.Person;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Field;
@@ -50,14 +51,26 @@ class ReflectionUtilsTest {
         assertThat(ReflectionUtils.getAnnotatedFields(StringHolder.class, AnnotationX.class)).isEmpty();
     }
 
+    @Test
+    @SuppressWarnings({"rawtypes"})
+    void collectionAnnotations() {
+        final List<Annotation> annotations = ReflectionUtils.collectionAnnotations(WithAnnotatedField.class);
+
+        assertThat(annotations).hasSize(1)
+                .extracting(Annotation::annotationType)
+                .contains((Class) AnnotationY.class);
+    }
+
 
     @Retention(RetentionPolicy.RUNTIME)
     private @interface AnnotationX {}
 
+    @AnnotationY
     @Retention(RetentionPolicy.RUNTIME)
     private @interface AnnotationY {}
 
     @SuppressWarnings("all")
+    @AnnotationY
     private static class WithAnnotatedField {
         @AnnotationX
         private String foo;

--- a/instancio-tests/kotlin-tests/instancio-kotlin-api-tests/src/test/kotlin/org/instancio/test/kotlin/ReflectionUtilsTest.kt
+++ b/instancio-tests/kotlin-tests/instancio-kotlin-api-tests/src/test/kotlin/org/instancio/test/kotlin/ReflectionUtilsTest.kt
@@ -1,0 +1,24 @@
+package org.instancio.test.kotlin
+
+import org.assertj.core.api.Assertions.assertThat
+import org.instancio.junit.internal.ReflectionUtils
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KClass
+
+class ReflectionUtilsTest {
+    @Test
+    fun collectionAnnotations() {
+        val annotations = ReflectionUtils.collectionAnnotations(AnnotatedClass::class.java)
+
+        assertThat(annotations).hasSize(1)
+            .extracting<KClass<*>> { it.annotationClass }
+            .contains(AnnotationY::class)
+    }
+
+    @AnnotationY
+    @Retention(AnnotationRetention.RUNTIME)
+    private annotation class AnnotationY
+
+    @AnnotationY
+    private class AnnotatedClass
+}


### PR DESCRIPTION
Resolves #1695