### PR TITLE
feat: Add MAC address generator

### DIFF
--- a/instancio-core/src/main/java/org/instancio/generator/specs/MacAddressGeneratorSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/MacAddressGeneratorSpec.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.GeneratorSpec;
+
+/**
+ * A spec for generating mac address.
+ *
+ * @since 6.0.0
+ */
+public interface MacAddressGeneratorSpec extends NullableGeneratorSpec<String> {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    GeneratorSpec<String> nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generator/specs/MacAddressSpec.java
+++ b/instancio-core/src/main/java/org/instancio/generator/specs/MacAddressSpec.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.generator.specs;
+
+import org.instancio.generator.ValueSpec;
+
+/**
+ * A spec for generating mac address.
+ *
+ * @since 6.0.0
+ */
+public interface MacAddressSpec extends MacAddressGeneratorSpec, ValueSpec<String> {
+
+    @Override
+    MacAddressSpec nullable();
+}

--- a/instancio-core/src/main/java/org/instancio/generators/NetGenerators.java
+++ b/instancio-core/src/main/java/org/instancio/generators/NetGenerators.java
@@ -19,6 +19,7 @@ import org.instancio.generator.specs.EmailGeneratorSpec;
 import org.instancio.generator.specs.Ip4GeneratorSpec;
 import org.instancio.generator.specs.URIGeneratorSpec;
 import org.instancio.generator.specs.URLGeneratorSpec;
+import org.instancio.generator.specs.MacAddressSpec;
 
 import java.net.URI;
 import java.net.URL;
@@ -61,4 +62,12 @@ public interface NetGenerators {
      * @since 2.3.0
      */
     URLGeneratorSpec url();
+
+    /**
+     * Generates mac address.
+     *
+     * @return generator spec
+     * @since 6.0.0
+     */
+    MacAddressSpec mac();
 }

--- a/instancio-core/src/main/java/org/instancio/generators/NetSpecs.java
+++ b/instancio-core/src/main/java/org/instancio/generators/NetSpecs.java
@@ -19,6 +19,7 @@ import org.instancio.generator.specs.EmailSpec;
 import org.instancio.generator.specs.Ip4Spec;
 import org.instancio.generator.specs.URISpec;
 import org.instancio.generator.specs.URLSpec;
+import org.instancio.generator.specs.MacAddressSpec;
 
 /**
  * Provides generators for {@code java.net} classes.
@@ -58,4 +59,12 @@ public interface NetSpecs extends NetGenerators {
      */
     @Override
     URLSpec url();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    MacAddressSpec mac();
 }

--- a/instancio-core/src/main/java/org/instancio/internal/generator/net/MacAddressGenerator.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generator/net/MacAddressGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.net;
+
+import org.instancio.Random;
+import org.instancio.generator.GeneratorContext;
+import org.instancio.generator.specs.MacAddressSpec;
+import org.instancio.internal.generator.AbstractGenerator;
+import org.jspecify.annotations.Nullable;
+
+public class MacAddressGenerator extends AbstractGenerator<String> implements MacAddressSpec {
+
+    public MacAddressGenerator(GeneratorContext context) {
+        super(context);
+    }
+
+    @Nullable
+    @Override
+    public String apiMethod() {
+        return "mac()";
+    }
+
+    @Nullable
+    @Override
+    protected String tryGenerateNonNull(final Random random) {
+        if (isNullable()) return null;
+        StringBuilder sb = new StringBuilder(17);
+        for (int i = 0; i < 6; i++) {
+            if (i > 0) sb.append(':');
+            int octet = random.intRange(0, 255);
+            sb.append(String.format("%02X", octet));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public MacAddressGenerator nullable() {
+        super.nullable();
+        return this;
+    }
+
+}

--- a/instancio-core/src/main/java/org/instancio/internal/generators/NetSpecsImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/generators/NetSpecsImpl.java
@@ -20,9 +20,11 @@ import org.instancio.generator.specs.EmailSpec;
 import org.instancio.generator.specs.Ip4Spec;
 import org.instancio.generator.specs.URISpec;
 import org.instancio.generator.specs.URLSpec;
+import org.instancio.generator.specs.MacAddressSpec;
 import org.instancio.generators.NetSpecs;
 import org.instancio.internal.generator.domain.internet.EmailGenerator;
 import org.instancio.internal.generator.domain.internet.Ip4Generator;
+import org.instancio.internal.generator.net.MacAddressGenerator;
 import org.instancio.internal.generator.net.URIGenerator;
 import org.instancio.internal.generator.net.URLGenerator;
 
@@ -52,6 +54,11 @@ final class NetSpecsImpl implements NetSpecs {
     @Override
     public URLSpec url() {
         return new URLGenerator(context);
+    }
+
+    @Override
+    public MacAddressSpec mac() {
+        return new MacAddressGenerator(context);
     }
 
 }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/net/MacAddressGeneratorTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/generator/net/MacAddressGeneratorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.generator.net;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.GENERATOR)
+@ExtendWith(InstancioExtension.class)
+class MacAddressGeneratorTest {
+    @Test
+    void create() {
+        final String result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.net().mac())
+                .create();
+        assertThat(result).contains(":");
+        assertThat(result).matches("^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$");
+    }
+
+    @Test
+    void nullable() {
+        final String result = Instancio.of(String.class)
+                .generate(root(), gen -> gen.net().mac().nullable())
+                .create();
+        assertThat(result).isNull();
+    }
+
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/validation/GeneratorMismatchTest.java
@@ -90,6 +90,7 @@ class GeneratorMismatchTest {
     void assertNetTypes() {
         assertMessageContains("uri()", gen -> gen.net().uri());
         assertMessageContains("url()", gen -> gen.net().url());
+        assertMessageContains("mac()", gen -> gen.net().mac());
     }
 
     @Test

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/MacAddressSpecTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/net/MacAddressSpecTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.values.net;
+
+import org.instancio.Instancio;
+import org.instancio.generator.specs.MacAddressSpec;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.features.values.AbstractValueSpecTestTemplate;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FeatureTag(Feature.VALUE_SPEC)
+@ExtendWith(InstancioExtension.class)
+class MacAddressSpecTest extends AbstractValueSpecTestTemplate<String> {
+
+    @Override
+    protected MacAddressSpec spec() {
+        return Instancio.gen().net().mac();
+    }
+
+    @Override
+    protected void assertDefaultSpecValue(final String actual) {
+        assertThat(actual).matches("^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$");
+    }
+
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/net/MacAddressGeneratorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/generator/net/MacAddressGeneratorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.generator.net;
+
+import org.instancio.internal.generator.AbstractGeneratorTestTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MacAddressGeneratorTest extends AbstractGeneratorTestTemplate<String, MacAddressGenerator> {
+
+    private final MacAddressGenerator generator = new MacAddressGenerator(getGeneratorContext());
+
+    @Override
+    protected String getApiMethod() {
+        return "mac()";
+    }
+
+    @Override
+    protected MacAddressGenerator generator() {
+        return generator;
+    }
+
+    @Test
+    @DisplayName("Test the default Mac generation")
+    void macDefaultGeneration() {
+        assertThat(generator.generate(random)).matches("^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$");
+    }
+}


### PR DESCRIPTION
Adds the functionality to generate MAC addresses.
This includes creating the generator, the specification interface, and a test to validate the functionality.