### PR TITLE
New top-level APIs: `size(TargetSelector, int)` and `size(TargetSelector, Size)`

### DIFF
--- a/instancio-core/src/main/java/org/instancio/BaseApi.java
+++ b/instancio-core/src/main/java/org/instancio/BaseApi.java
@@ -757,4 +757,53 @@ public interface BaseApi<T extends @Nullable Object> {
      */
     @ExperimentalApi
     BaseApi<T> withUnique(TargetSelector selector);
+
+    /**
+     * Sets an exact size for the collection, array, or map targeted by the given selector.
+     *
+     * <p>This method provides a shorthand for {@link #size(TargetSelector, Size)}.
+     *
+     * @param selector for the collection, array, or map this method should be applied to
+     * @param size     the exact size
+     * @return API builder reference
+     * @see #size(TargetSelector, Size)
+     * @since 6.0.0
+     */
+    @ExperimentalApi
+    BaseApi<T> size(TargetSelector selector, int size);
+
+    /**
+     * Sets the size for the collection, array, or map targeted by the given selector
+     * using a {@link Size} specification.
+     *
+     * <p>This method supports both exact sizes and ranges:
+     * <pre>{@code
+     * // Exact size
+     * .size(field(Person::getAddresses), Size.of(3))
+     *
+     * // Random size within the given range, inclusive
+     * .size(field(Person::getAddresses), Size.range(1, 5))
+     * }</pre>
+     *
+     * <p>This method has a higher precedence than {@code generate()}, for example,
+     * the following will produce a collection of hobbies of size 1,
+     * despite the collection generator spec which specifies {@code size(2)}.
+     *
+     * <pre>{@code
+     * Person person = Instancio.of(Person.class)
+     *     .size(field(Person::getHobbies), Size.of(1))
+     *     .generate(field(Person::getHobbies), gen -> gen.collection().size(2))
+     *     .create();
+     * }</pre>
+     *
+     * @param selector for the collection, array, or map this method should be applied to
+     * @param size     the size specification
+     * @return API builder reference
+     * @see #size(TargetSelector, int)
+     * @see Size#of(int)
+     * @see Size#range(int, int)
+     * @since 6.0.0
+     */
+    @ExperimentalApi
+    BaseApi<T> size(TargetSelector selector, Size size);
 }

--- a/instancio-core/src/main/java/org/instancio/InstancioApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioApi.java
@@ -371,4 +371,22 @@ public interface InstancioApi<T extends @Nullable Object> extends
     @Override
     @ExperimentalApi
     InstancioApi<T> withUnique(TargetSelector selector);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    @ExperimentalApi
+    InstancioApi<T> size(TargetSelector selector, int size);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    @ExperimentalApi
+    InstancioApi<T> size(TargetSelector selector, Size size);
 }

--- a/instancio-core/src/main/java/org/instancio/InstancioCartesianProductApi.java
+++ b/instancio-core/src/main/java/org/instancio/InstancioCartesianProductApi.java
@@ -297,4 +297,22 @@ public interface InstancioCartesianProductApi<T extends @Nullable Object> extend
      */
     @Override
     InstancioCartesianProductApi<T> verbose();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    @ExperimentalApi
+    InstancioCartesianProductApi<T> size(TargetSelector selector, int size);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 6.0.0
+     */
+    @Override
+    @ExperimentalApi
+    InstancioCartesianProductApi<T> size(TargetSelector selector, Size size);
 }

--- a/instancio-core/src/main/java/org/instancio/Size.java
+++ b/instancio-core/src/main/java/org/instancio/Size.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio;
+
+import org.instancio.documentation.ExperimentalApi;
+import org.instancio.internal.InternalSize;
+
+/**
+ * Represents the size (or size range) of a collection, array, or map.
+ *
+ * <p>Instances are created via the factory methods:
+ * <ul>
+ *   <li>{@link #of(int)} — exact size</li>
+ *   <li>{@link #range(int, int)} — random size within the specified range</li>
+ * </ul>
+ *
+ * @see InstancioApi#size(TargetSelector, int)
+ * @see InstancioApi#size(TargetSelector, Size)
+ * @since 6.0.0
+ */
+@ExperimentalApi
+public sealed interface Size permits InternalSize {
+
+    /**
+     * Creates a {@code Size} with an exact value.
+     *
+     * @param size the exact size
+     * @return a {@code Size} representing the given exact size
+     * @since 6.0.0
+     */
+    @ExperimentalApi
+    static Size of(final int size) {
+        return new InternalSize(size, size);
+    }
+
+    /**
+     * Creates a {@code Size} representing a random value within the specified range.
+     *
+     * @param min the minimum size (inclusive)
+     * @param max the maximum size (inclusive)
+     * @return a {@code Size} representing the given range
+     * @since 6.0.0
+     */
+    @ExperimentalApi
+    static Size range(final int min, final int max) {
+        return new InternalSize(min, max);
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiImpl.java
@@ -24,6 +24,7 @@ import org.instancio.Model;
 import org.instancio.OnCompleteCallback;
 import org.instancio.Random;
 import org.instancio.Result;
+import org.instancio.Size;
 import org.instancio.TargetSelector;
 import org.instancio.TypeTokenSupplier;
 import org.instancio.feed.Feed;
@@ -164,6 +165,17 @@ public class ApiImpl<T> implements InstancioApi<T>, InstancioObjectApi<T> {
     @Override
     public ApiImpl<T> withUnique(final TargetSelector selector) {
         modelContextBuilder.withUnique(selector);
+        return this;
+    }
+
+    @Override
+    public ApiImpl<T> size(final TargetSelector selector, final int size) {
+        return size(selector, Size.of(size));
+    }
+
+    @Override
+    public ApiImpl<T> size(final TargetSelector selector, final Size size) {
+        modelContextBuilder.withContainerSize(selector, size);
         return this;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/ApiMethodSelector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/ApiMethodSelector.java
@@ -30,6 +30,7 @@ public enum ApiMethodSelector {
     ON_COMPLETE("onComplete()"),
     SET("set()"),
     SET_MODEL("setModel()"),
+    SIZE("size()"),
     SUBTYPE("subtype()"),
     SUPPLY("supply()"),
     WITH_NULLABLE("withNullable()"),

--- a/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CartesianProductApiImpl.java
@@ -22,6 +22,7 @@ import org.instancio.InstancioCartesianProductApi;
 import org.instancio.Model;
 import org.instancio.OnCompleteCallback;
 import org.instancio.Select;
+import org.instancio.Size;
 import org.instancio.TargetSelector;
 import org.instancio.TypeTokenSupplier;
 import org.instancio.feed.Feed;
@@ -221,6 +222,17 @@ public class CartesianProductApiImpl<T> implements InstancioCartesianProductApi<
     @Override
     public InstancioCartesianProductApi<T> verbose() {
         modelContextBuilder.verbose();
+        return this;
+    }
+
+    @Override
+    public InstancioCartesianProductApi<T> size(final TargetSelector selector, final int size) {
+        return size(selector, Size.of(size));
+    }
+
+    @Override
+    public InstancioCartesianProductApi<T> size(final TargetSelector selector, final Size size) {
+        modelContextBuilder.withContainerSize(selector, size);
         return this;
     }
 

--- a/instancio-core/src/main/java/org/instancio/internal/CollectionsApiImpl.java
+++ b/instancio-core/src/main/java/org/instancio/internal/CollectionsApiImpl.java
@@ -50,7 +50,7 @@ public final class CollectionsApiImpl<T, C extends Collection<T>>
 
     @Override
     public InstancioCollectionsApi<C> size(final int size) {
-        generate(Select.root(), gen -> gen.collection().size(size));
+        size(Select.root(), size);
         return this;
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InstancioEngine.java
@@ -127,13 +127,13 @@ class InstancioEngine {
         final GeneratorResult generatorResult = createObject(rootNode);
         callbackHandler.invokeCallbacks();
         processDelayedNodes(true);
-        context.reportWarnings();
+        context.reportWarnings(rootNode);
 
         if (generatorResult.isUnresolved()) {
             final Class<?> rootClass = rootNode.getTargetClass();
 
             if (Modifier.isAbstract(rootClass.getModifiers())
-                && !context.getSubtypeSelectorMap().getSubtype(rootNode).isPresent()) {
+                    && !context.getSubtypeSelectorMap().getSubtype(rootNode).isPresent()) {
                 throw Fail.withUsageError(ErrorMessageUtils.abstractRootWithoutSubtype(rootClass));
             }
         }
@@ -182,7 +182,7 @@ class InstancioEngine {
                 } else {
                     Log.msg(Log.Category.MAX_GENERATION_ATTEMPTS,
                             "Max generation attempts ({}) reached (configurable via '{}'). " +
-                            "Using random value as fallback.",
+                                    "Using random value as fallback.",
                             maxGenerationAttempts,
                             Keys.MAX_GENERATION_ATTEMPTS.propertyKey());
                     break;
@@ -281,6 +281,7 @@ class InstancioEngine {
     @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.NPathComplexity"})
     private GeneratorResult generateMap(final InternalNode node) {
         final GeneratorResult generatorResult = generateValue(node);
+        final InternalSize sizeOverride = context.getContainerSize(node);
 
         if (generatorResult.getValue() == null || node.getChildren().size() < 2) {
             return generatorResult;
@@ -312,10 +313,14 @@ class InstancioEngine {
         final boolean nullableValue = hint.nullableMapValues();
         final Iterator<Object> withKeysIterator = hint.withKeys().iterator();
 
-        int entriesToGenerate = hint.generateEntries();
+        final int targetSize = sizeOverride != null
+                ? context.getRandom().intRange(sizeOverride.min(), sizeOverride.max())
+                : hint.generateEntries();
+
+        int remaining = targetSize;
         int failedAdditions = 0;
 
-        while (entriesToGenerate > 0) {
+        while (remaining > 0) {
 
             assigmentObjectStore.enterScope();
             final GeneratorResult mapKeyResult = createObject(keyNode, nullableKey);
@@ -334,7 +339,7 @@ class InstancioEngine {
 
             // Note: map key does not support emit() null
             if ((mapKey != null || nullableKey)
-                && (mapValue != null || nullableValue || mapValueResult.hasEmitNullHint())) {
+                    && (mapValue != null || nullableValue || mapValueResult.hasEmitNullHint())) {
                 if (!map.containsKey(mapKey)) {
                     ApiValidator.validateValueIsAssignableToElementNode(
                             "error adding key to map", mapKey, node, keyNode);
@@ -343,7 +348,7 @@ class InstancioEngine {
                             "error adding value to map", mapValue, node, valueNode);
 
                     map.put(mapKey, mapValue);
-                    entriesToGenerate--;
+                    remaining--;
                 } else {
                     failedAdditions++;
                 }
@@ -356,7 +361,7 @@ class InstancioEngine {
                     errorHandler.conditionalFailOnError(() -> {
                         throw Fail.withInternalError(
                                 ErrorMessageUtils.mapCouldNotBePopulated(
-                                        context, node, hint.generateEntries()));
+                                        context, node, targetSize));
                     });
                 }
                 break;
@@ -376,17 +381,29 @@ class InstancioEngine {
             "PMD.AvoidReassigningLoopVariables"})
     private GeneratorResult generateArray(final InternalNode node) {
         final GeneratorResult generatorResult = generateValue(node);
+        final InternalSize sizeOverride = context.getContainerSize(node);
 
         if (generatorResult.getValue() == null || node.getChildren().isEmpty()) {
             return generatorResult;
         }
 
-        final Object arrayObj = generatorResult.getValue();
+        Object arrayObj = generatorResult.getValue();
+        if (sizeOverride != null) {
+            final int overrideLength = context.getRandom().intRange(sizeOverride.min(), sizeOverride.max());
+            arrayObj = Array.newInstance(arrayObj.getClass().getComponentType(), overrideLength);
+        }
         final Hints hints = generatorResult.getHints();
         final ArrayHint hint = defaultIfNull(hints.get(ArrayHint.class), ArrayHint.empty());
 
         final List<?> withElements = hint.withElements();
         final int arrayLength = Array.getLength(arrayObj);
+
+        if (sizeOverride != null && withElements.size() > arrayLength) {
+            throw Fail.withUsageError(
+                    "array generator specifies more 'with()' elements (%s) than the size() override allows (%s)"
+                            .formatted(withElements.size(), arrayLength));
+        }
+
         final InternalNode elementNode = node.getOnlyChild();
         int lastIndex = 0;
 
@@ -445,10 +462,10 @@ class InstancioEngine {
 
             // If elements are not nullable, keep generating until a non-null
             while (elementValue == null
-                   && !hint.nullableElements()
-                   && !elementResult.hasEmitNullHint()
-                   && !context.isIgnored(elementNode)
-                   && failedAdditions < maxGenerationAttempts) {
+                    && !hint.nullableElements()
+                    && !elementResult.hasEmitNullHint()
+                    && !context.isIgnored(elementNode)
+                    && failedAdditions < maxGenerationAttempts) {
 
                 failedAdditions++;
                 elementValue = createObject(elementNode, false).getValue();
@@ -466,12 +483,13 @@ class InstancioEngine {
         if (hint.shuffle()) {
             ArrayUtils.shuffle(arrayObj, context.getRandom());
         }
-        return generatorResult;
+        return GeneratorResult.resolved(arrayObj, hints);
     }
 
     @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.NPathComplexity"})
     private GeneratorResult generateCollection(final InternalNode node) {
         final GeneratorResult generatorResult = generateValue(node);
+        final InternalSize sizeOverride = context.getContainerSize(node);
 
         if (generatorResult.getValue() == null || node.getChildren().isEmpty()) {
             return generatorResult;
@@ -498,12 +516,16 @@ class InstancioEngine {
         final boolean nullableElements = hint.nullableElements();
         final boolean requireUnique = hint.unique();
 
-        int elementsToGenerate = hint.generateElements();
+        final int targetSize = sizeOverride != null
+                ? context.getRandom().intRange(sizeOverride.min(), sizeOverride.max())
+                : hint.generateElements();
+
+        final Set<Object> generated = new HashSet<>(targetSize);
+
+        int remaining = targetSize;
         int failedAdditions = 0;
 
-        final Set<Object> generated = new HashSet<>(elementsToGenerate);
-
-        while (elementsToGenerate > 0) {
+        while (remaining > 0) {
             assigmentObjectStore.enterScope();
             final GeneratorResult elementResult = createObject(elementNode, nullableElements);
             assigmentObjectStore.exitScope();
@@ -526,7 +548,7 @@ class InstancioEngine {
                     ApiValidator.validateValueIsAssignableToElementNode(
                             "error adding element to collection", elementValue, node, elementNode);
 
-                    elementsToGenerate--;
+                    remaining--;
 
                 } else {
                     // Special case for hash based collections.
@@ -544,7 +566,7 @@ class InstancioEngine {
                     errorHandler.conditionalFailOnError(() -> {
                         throw Fail.withInternalError(
                                 ErrorMessageUtils.collectionCouldNotBePopulated(
-                                        context, node, hint.generateElements()));
+                                        context, node, targetSize));
                     });
                 }
                 break;
@@ -737,10 +759,15 @@ class InstancioEngine {
             return generatorResult;
         }
 
+        final InternalSize sizeOverride = context.getContainerSize(node);
         final ContainerAddFunction<Object> addFunction = hint.addFunction();
 
         if (addFunction != null) {
-            for (int i = 0; i < hint.generateEntries(); i++) {
+            int remaining = sizeOverride != null
+                    ? context.getRandom().intRange(sizeOverride.min(), sizeOverride.max())
+                    : hint.generateEntries();
+
+            for (int i = 0; i < remaining; i++) {
                 final @Nullable Object[] args = new Object[children.size()];
 
                 assigmentObjectStore.enterScope();

--- a/instancio-core/src/main/java/org/instancio/internal/InternalSize.java
+++ b/instancio-core/src/main/java/org/instancio/internal/InternalSize.java
@@ -15,24 +15,19 @@
  */
 package org.instancio.internal;
 
-import org.instancio.InstancioCollectionsApi;
-import org.instancio.Select;
-import org.instancio.internal.reflect.ParameterizedTypeImpl;
+import org.instancio.Size;
 
-import java.lang.reflect.Type;
-import java.util.Map;
+public record InternalSize(int min, int max) implements Size {
 
-public final class MapApiImpl<K, V, M extends Map<K, V>>
-        extends ClassApiImpl<M>
-        implements InstancioCollectionsApi<M> {
-
-    public MapApiImpl(final Class<M> mapType, final Type keyType, final Type valueType) {
-        super(new ParameterizedTypeImpl(mapType, keyType, valueType));
+    public InternalSize(final int min, final int max) {
+        this.min = ApiValidator.validateSize(min);
+        this.max = ApiValidator.validateSize(max);
+        ApiValidator.isTrue(min <= max,
+                "min (%s) must be less than or equal to max (%s)".formatted(min, max));
     }
 
     @Override
-    public InstancioCollectionsApi<M> size(final int size) {
-        size(Select.root(), size);
-        return this;
+    public String toString() {
+        return "Size[min=%s, max=%s]".formatted(min, max);
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/context/ContainerSizeSelectorMap.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ContainerSizeSelectorMap.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.internal.context;
+
+import org.instancio.TargetSelector;
+import org.instancio.internal.InternalSize;
+import org.instancio.internal.nodes.InternalNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+final class ContainerSizeSelectorMap {
+
+    private final SelectorMap<InternalSize> selectorMap = new SelectorMapImpl<>();
+
+    void put(final TargetSelector selector, final InternalSize size) {
+        selectorMap.put(selector, size);
+    }
+
+    void putAll(final Map<TargetSelector, InternalSize> map) {
+        map.forEach(this::put);
+    }
+
+    Optional<InternalSize> getSize(final InternalNode node) {
+        return selectorMap.getValue(node);
+    }
+
+    SelectorMap<InternalSize> getSelectorMap() {
+        return selectorMap;
+    }
+}

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContext.java
@@ -23,6 +23,7 @@ import org.instancio.OnCompleteCallback;
 import org.instancio.Random;
 import org.instancio.Scope;
 import org.instancio.Select;
+import org.instancio.Size;
 import org.instancio.TargetSelector;
 import org.instancio.feed.Feed;
 import org.instancio.feed.FeedProvider;
@@ -32,6 +33,7 @@ import org.instancio.internal.ApiMethodSelector;
 import org.instancio.internal.ApiValidator;
 import org.instancio.internal.Flattener;
 import org.instancio.internal.InternalModel;
+import org.instancio.internal.InternalSize;
 import org.instancio.internal.RandomHelper;
 import org.instancio.internal.RootType;
 import org.instancio.internal.assignment.InternalAssignment;
@@ -47,8 +49,8 @@ import org.instancio.internal.selectors.SelectorProcessor;
 import org.instancio.internal.selectors.SetterSelectorHolder;
 import org.instancio.internal.settings.InternalSettings;
 import org.instancio.internal.spi.InternalExtension;
-import org.instancio.internal.spi.InternalServiceProviderContext;
 import org.instancio.internal.spi.InternalExtensionImpl;
+import org.instancio.internal.spi.InternalServiceProviderContext;
 import org.instancio.internal.spi.Providers;
 import org.instancio.internal.util.CollectionUtils;
 import org.instancio.internal.util.ErrorMessageUtils;
@@ -153,8 +155,8 @@ public final class ModelContext {
         return providers;
     }
 
-    public void reportWarnings() {
-        reportUnusedSelectorWarnings();
+    public void reportWarnings(final InternalNode rootNode) {
+        reportUnusedSelectorWarnings(rootNode);
         reportEmitGeneratorWarnings();
     }
 
@@ -164,9 +166,9 @@ public final class ModelContext {
         reporter.report();
     }
 
-    void reportUnusedSelectorWarnings() {
+    void reportUnusedSelectorWarnings(final InternalNode rootNode) {
         if (settings.get(Keys.MODE) == Mode.STRICT && !selectorMaps.allEmpty()) {
-            new UnusedSelectorReporter(getMaxDepth(), selectorMaps).report();
+            new UnusedSelectorReporter(getMaxDepth(), selectorMaps).report(rootNode);
         }
     }
 
@@ -222,6 +224,11 @@ public final class ModelContext {
     @SuppressWarnings(Sonar.GENERIC_WILDCARD_IN_RETURN)
     public Optional<Generator<?>> getGenerator(final InternalNode node) {
         return selectorMaps.getGeneratorSelectorMap().getGenerator(node);
+    }
+
+    @Nullable
+    public InternalSize getContainerSize(final InternalNode node) {
+        return selectorMaps.getContainerSizeSelectorMap().getSize(node).orElse(null);
     }
 
     public void putGenerator(TargetSelector selector, Generator<?> generator) {
@@ -281,6 +288,7 @@ public final class ModelContext {
         builder.assignmentMap = new LinkedHashMap<>(copyAsLinkedHashMap(this.contextSource.getAssignmentMap()));
         builder.setModelMap = new LinkedHashMap<>(this.contextSource.getSetModelMap());
         builder.feedMap = new LinkedHashMap<>(this.contextSource.getFeedMap());
+        builder.containerSizeMap = new LinkedHashMap<>(this.contextSource.getContainerSizeMap());
         return builder;
     }
 
@@ -302,6 +310,7 @@ public final class ModelContext {
         private @Nullable Map<TargetSelector, List<Assignment>> assignmentMap;
         private @Nullable Map<TargetSelector, ModelContext> setModelMap;
         private @Nullable Map<TargetSelector, Function<GeneratorContext, Feed>> feedMap;
+        private @Nullable Map<TargetSelector, InternalSize> containerSizeMap;
         private @Nullable Set<TargetSelector> ignoreSet;
         private @Nullable Set<TargetSelector> withNullableSet;
         private @Nullable Settings settings;
@@ -525,6 +534,11 @@ public final class ModelContext {
             return this;
         }
 
+        public Builder withContainerSize(final TargetSelector selector, final Size size) {
+            containerSizeMap = CollectionUtils.newLinkedHashMapIfNull(containerSizeMap);
+            return addSelector(containerSizeMap, selector, (InternalSize) size, ApiMethodSelector.SIZE);
+        }
+
         public Builder setBlank(final TargetSelector selector) {
             if (selector instanceof InternalSelector internalSelector && internalSelector.isRootSelector()) {
                 setBlankTargets(); // special case for root selector (no scopes)
@@ -575,6 +589,7 @@ public final class ModelContext {
             assignmentMap = new LinkedHashMap<>(src.getAssignmentMap());
             setModelMap = new LinkedHashMap<>(src.getSetModelMap());
             feedMap = new LinkedHashMap<>(src.getFeedMap());
+            containerSizeMap = new LinkedHashMap<>(src.getContainerSizeMap());
 
             // Increment max depth to account for the additional layer added by the collection
             maxDepth = otherContext.maxDepth == null ? null : otherContext.maxDepth + 1; //NOPMD
@@ -620,6 +635,7 @@ public final class ModelContext {
                     assignmentMap,
                     setModelMap,
                     feedMap,
+                    containerSizeMap,
                     ignoreSet,
                     withNullableSet);
         }

--- a/instancio-core/src/main/java/org/instancio/internal/context/ModelContextSource.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/ModelContextSource.java
@@ -22,6 +22,7 @@ import org.instancio.TargetSelector;
 import org.instancio.feed.Feed;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.InternalSize;
 import org.instancio.internal.util.Sonar;
 import org.jspecify.annotations.Nullable;
 
@@ -49,6 +50,7 @@ final class ModelContextSource {
     private final Map<TargetSelector, List<Assignment>> assignmentMap;
     private final Map<TargetSelector, ModelContext> setModelMap;
     private final Map<TargetSelector, Function<GeneratorContext, Feed>> feedMap;
+    private final Map<TargetSelector, InternalSize> containerSizeMap;
     private final Set<TargetSelector> ignoreSet;
     private final Set<TargetSelector> withNullableSet;
 
@@ -63,6 +65,7 @@ final class ModelContextSource {
             @Nullable final Map<TargetSelector, List<Assignment>> assignmentMap,
             @Nullable final Map<TargetSelector, ModelContext> setModelMap,
             @Nullable final Map<TargetSelector, Function<GeneratorContext, Feed>> feedMap,
+            @Nullable final Map<TargetSelector, InternalSize> containerSizeMap,
             @Nullable final Set<TargetSelector> ignoreSet,
             @Nullable final Set<TargetSelector> withNullableSet) {
 
@@ -75,6 +78,7 @@ final class ModelContextSource {
         this.assignmentMap = asUnmodifiableLinkedHashMapOfLists(assignmentMap);
         this.setModelMap = asUnmodifiableMap(setModelMap);
         this.feedMap = asUnmodifiableMap(feedMap);
+        this.containerSizeMap = asUnmodifiableMap(containerSizeMap);
         this.ignoreSet = asUnmodifiableSet(ignoreSet);
         this.withNullableSet = asUnmodifiableSet(withNullableSet);
     }
@@ -113,6 +117,10 @@ final class ModelContextSource {
 
     Map<TargetSelector, Function<GeneratorContext, Feed>> getFeedMap() {
         return feedMap;
+    }
+
+    Map<TargetSelector, InternalSize> getContainerSizeMap() {
+        return containerSizeMap;
     }
 
     Set<TargetSelector> getIgnoreSet() {

--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorMaps.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorMaps.java
@@ -22,6 +22,7 @@ import org.instancio.TargetSelector;
 import org.instancio.feed.Feed;
 import org.instancio.generator.Generator;
 import org.instancio.generator.GeneratorContext;
+import org.instancio.internal.InternalSize;
 import org.instancio.internal.assignment.InternalAssignment;
 import org.instancio.internal.util.TypeUtils;
 
@@ -43,6 +44,7 @@ public final class SelectorMaps {
     private final OnCompleteCallbackSelectorMap onCompleteSelectorMap = new OnCompleteCallbackSelectorMap();
     private final PredicateSelectorMap filterSelectorMap = new PredicateSelectorMap();
     private final SubtypeSelectorMap subtypeSelectorMap = new SubtypeSelectorMap();
+    private final ContainerSizeSelectorMap containerSizeSelectorMap = new ContainerSizeSelectorMap();
 
     SelectorMaps(final ModelContextSource contextSource, final GeneratorContext generatorContext) {
         this.generatorContext = generatorContext;
@@ -70,6 +72,7 @@ public final class SelectorMaps {
         filterSelectorMap.putAll(contextSource.getFilterMap());
         generatorSelectorMap.putAllGeneratorSpecs(contextSource.getGeneratorSpecMap());
         generatorSelectorMap.putAllGenerators(contextSource.getGeneratorMap());
+        containerSizeSelectorMap.putAll(contextSource.getContainerSizeMap());
         assignmentSelectorMap.putAll(contextSource.getAssignmentMap());
 
         // subtype map must be last as it needs subtypes from assignment/generator spec subtypes
@@ -146,6 +149,11 @@ public final class SelectorMaps {
             subtypeSelectorMap.put(resolvedSelector, entry.getValue());
         }
 
+        for (Map.Entry<TargetSelector, InternalSize> entry : src.getContainerSizeMap().entrySet()) {
+            final TargetSelector resolvedSelector = setModelSelectorHelper.applyModelSelectorScopes(modelTarget, entry.getKey());
+            containerSizeSelectorMap.put(resolvedSelector, entry.getValue());
+        }
+
         for (Map.Entry<TargetSelector, ModelContext> entry : src.getSetModelMap().entrySet()) {
             final TargetSelector resolvedSelector = setModelSelectorHelper.applyModelSelectorScopes(modelTarget, entry.getKey());
             setModelSelectorMap.put(resolvedSelector, entry.getValue());
@@ -190,6 +198,10 @@ public final class SelectorMaps {
         return subtypeSelectorMap;
     }
 
+    ContainerSizeSelectorMap getContainerSizeSelectorMap() {
+        return containerSizeSelectorMap;
+    }
+
     public boolean allEmpty() {
         return !hasAssignments()
                 && !hasGenerators()
@@ -199,7 +211,8 @@ public final class SelectorMaps {
                 && feedSelectorMap.getSelectorMap().isEmpty()
                 && ignoreSelectorMap.getSelectorMap().isEmpty()
                 && withNullableSelectorMap.getSelectorMap().isEmpty()
-                && subtypeSelectorMap.getSelectorMap().isEmpty();
+                && subtypeSelectorMap.getSelectorMap().isEmpty()
+                && containerSizeSelectorMap.getSelectorMap().isEmpty();
     }
 
     public boolean hasGenerators() {

--- a/instancio-core/src/main/java/org/instancio/internal/context/SelectorNodeMatchesCollector.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/SelectorNodeMatchesCollector.java
@@ -34,6 +34,7 @@ final class SelectorNodeMatchesCollector {
 
     private final SelectorMap<?> assignDestinationToAssignmentsMap;
     private final SelectorMap<?> assignOriginToDestinationSelectorsMap;
+    private final SelectorMap<?> containerSizeSelectorMap;
     private final SelectorMap<?> feedSelectorMap;
     private final SelectorMap<?> filterSelectorMap;
     private final SelectorMap<?> generatorSelectorMap;
@@ -46,6 +47,7 @@ final class SelectorNodeMatchesCollector {
     SelectorNodeMatchesCollector(final SelectorMaps selectorMaps) {
         this.assignDestinationToAssignmentsMap = selectorMaps.getAssignmentSelectorMap().getDestinationToAssignmentsMap();
         this.assignOriginToDestinationSelectorsMap = selectorMaps.getAssignmentSelectorMap().getOriginToDestinationSelectorsMap();
+        this.containerSizeSelectorMap = selectorMaps.getContainerSizeSelectorMap().getSelectorMap();
         this.feedSelectorMap = selectorMaps.getFeedSelectorMap().getSelectorMap();
         this.filterSelectorMap = selectorMaps.getFilterSelectorMap().getSelectorMap();
         this.generatorSelectorMap = selectorMaps.getGeneratorSelectorMap().getSelectorMap();
@@ -72,6 +74,7 @@ final class SelectorNodeMatchesCollector {
             collectNodes(map, ApiMethodSelector.ON_COMPLETE, node, onCompleteCallbackSelectorMap);
             collectNodes(map, ApiMethodSelector.SET_MODEL, node, setModelSelectorMap);
             collectNodes(map, ApiMethodSelector.SET, node, generatorSelectorMap);
+            collectNodes(map, ApiMethodSelector.SIZE, node, containerSizeSelectorMap);
             collectNodes(map, ApiMethodSelector.SUBTYPE, node, subtypeSelectorMap);
             collectNodes(map, ApiMethodSelector.SUPPLY, node, generatorSelectorMap);
             collectNodes(map, ApiMethodSelector.WITH_NULLABLE, node, nullableSelectorMap);
@@ -102,6 +105,29 @@ final class SelectorNodeMatchesCollector {
     }
 
     /**
+     * Returns all size selectors that match any non-container node, without duplicates.
+     * Reports selectors regardless of whether they also matched a container node.
+     */
+    Set<TargetSelector> findMisappliedSizeSelectors(final InternalNode rootNode) {
+        if (containerSizeSelectorMap.isEmpty()) {
+            return Set.of();
+        }
+
+        final Set<TargetSelector> results = new LinkedHashSet<>();
+        final Queue<InternalNode> queue = new ArrayDeque<>();
+        queue.offer(rootNode);
+
+        while (!queue.isEmpty()) {
+            final InternalNode node = queue.poll();
+            if (!node.isContainer()) {
+                results.addAll(containerSizeSelectorMap.getSelectors(node));
+            }
+            queue.addAll(node.getChildren());
+        }
+        return results;
+    }
+
+    /**
      * {@link SelectorMap} marks keys (selectors) that have an associated value
      * when doing a lookup. Therefore, this method must be called after the root
      * object has been created (all map lookups have been done).
@@ -110,6 +136,7 @@ final class SelectorNodeMatchesCollector {
         List<TargetSelector> results = new ArrayList<>();
         results.addAll(assignDestinationToAssignmentsMap.getUnusedKeys());
         results.addAll(assignOriginToDestinationSelectorsMap.getUnusedKeys());
+        results.addAll(containerSizeSelectorMap.getUnusedKeys());
         results.addAll(feedSelectorMap.getUnusedKeys());
         results.addAll(filterSelectorMap.getUnusedKeys());
         results.addAll(generatorSelectorMap.getUnusedKeys());

--- a/instancio-core/src/main/java/org/instancio/internal/context/UnusedSelectorReporter.java
+++ b/instancio-core/src/main/java/org/instancio/internal/context/UnusedSelectorReporter.java
@@ -18,12 +18,16 @@ package org.instancio.internal.context;
 import org.instancio.TargetSelector;
 import org.instancio.exception.UnusedSelectorException;
 import org.instancio.internal.ApiMethodSelector;
+import org.instancio.internal.nodes.InternalNode;
 import org.instancio.internal.selectors.InternalSelector;
 import org.instancio.internal.selectors.UnusedSelectorDescription;
+import org.instancio.internal.util.Fail;
 import org.instancio.internal.util.Sonar;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
@@ -39,7 +43,12 @@ final class UnusedSelectorReporter {
     }
 
     @SuppressWarnings(Sonar.STRING_LITERALS_DUPLICATED)
-    void report() {
+    void report(final InternalNode rootNode) {
+        final Set<TargetSelector> misapplied = collector.findMisappliedSizeSelectors(rootNode);
+        if (!misapplied.isEmpty()) {
+            throw Fail.withUsageError(formatMisappliedSizeError(misapplied));
+        }
+
         final List<TargetSelector> unusedSelectors = collector.getUnusedSelectors();
         if (unusedSelectors.isEmpty()) {
             return;
@@ -140,5 +149,22 @@ final class UnusedSelectorReporter {
                 .sorted()
                 .map(it -> String.format(" %s: %s", count[0]++, it))
                 .collect(joining(NL));
+    }
+
+    private static String formatMisappliedSizeError(final Collection<TargetSelector> misapplied) {
+        final StringBuilder sb = new StringBuilder(512)
+                .append("'size()' can only be applied to a collection, array, or map.")
+                .append(NL)
+                .append(NL)
+                .append("Found selector(s) targeting an incompatible type:")
+                .append(NL);
+
+        for (TargetSelector selector : misapplied) {
+            sb.append(NL)
+                    .append(String.format(" -> %s", ((UnusedSelectorDescription) selector).getDescription()))
+                    .append(NL);
+        }
+
+        return sb.toString();
     }
 }

--- a/instancio-core/src/main/java/org/instancio/internal/nodes/InternalNode.java
+++ b/instancio-core/src/main/java/org/instancio/internal/nodes/InternalNode.java
@@ -80,7 +80,7 @@ public final class InternalNode implements Node {
         return cyclic;
     }
 
-    boolean isContainer() {
+    public boolean isContainer() {
         return is(NodeKind.COLLECTION)
                || is(NodeKind.MAP)
                || is(NodeKind.ARRAY)

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListSizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/oflist/OfListSizeTest.java
@@ -62,9 +62,9 @@ class OfListSizeTest {
 
     @Test
     void withNegativeSize() {
-        final InstancioCollectionsApi<List<Phone>> api = Instancio.ofList(Phone.class).size(-1);
+        final InstancioCollectionsApi<List<Phone>> api = Instancio.ofList(Phone.class);
 
-        assertThatThrownBy(api::create)
+        assertThatThrownBy(() -> api.size(-1))
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("size must not be negative: -1");
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofmap/OfMapSizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/ofmap/OfMapSizeTest.java
@@ -62,9 +62,9 @@ class OfMapSizeTest {
 
     @Test
     void withNegativeSize() {
-        final InstancioCollectionsApi<Map<String, Integer>> api = Instancio.ofMap(String.class, Integer.class).size(-1);
+        final InstancioCollectionsApi<Map<String, Integer>> api = Instancio.ofMap(String.class, Integer.class);
 
-        assertThatThrownBy(api::create)
+        assertThatThrownBy(() -> api.size(-1))
                 .isExactlyInstanceOf(InstancioApiException.class)
                 .hasMessageContaining("size must not be negative: -1");
     }

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizePrecedenceTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizePrecedenceTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.size;
+
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.collections.lists.ListString;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.LinkedList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+
+@FeatureTag(Feature.SIZE)
+@ExtendWith(InstancioExtension.class)
+class SizePrecedenceTest {
+
+    private static final int SIZE = 7;
+
+    @Test
+    void sizeHasHigherPrecedenceThanGenerate_regardlessOfDeclarationOrder() {
+        final ListString result = Instancio.of(ListString.class)
+                .size(field(ListString::getList), SIZE)
+                .generate(field(ListString::getList), gen -> gen.collection().subtype(LinkedList.class).size(SIZE + 1))
+                .create();
+
+        assertThat(result.getList())
+                .hasSize(SIZE)
+                .isExactlyInstanceOf(LinkedList.class); // generate() subtype is preserved
+    }
+
+
+    @Test
+    void sizeHasHigherPrecedenceThanGenerate_regardlessOfDeclarationOrder_usingSetModel() {
+        record Holder(ListString listString) {}
+
+        final Model<ListString> model = Instancio.of(ListString.class)
+                .size(field(ListString::getList), SIZE)
+                .toModel();
+
+        final Holder result = Instancio.of(Holder.class)
+                .setModel(all(ListString.class), model)
+                .generate(field(ListString::getList), gen -> gen.collection().subtype(LinkedList.class).size(SIZE + 1))
+                .create();
+
+        assertThat(result.listString.getList())
+                .hasSize(SIZE)
+                .isExactlyInstanceOf(LinkedList.class);
+    }
+
+    @Test
+    void givenSameSizeSelectors_lastSizeCallWins() {
+        final ListString result = Instancio.of(ListString.class)
+                .size(field(ListString::getList), SIZE + 1)
+                .size(field(ListString::getList), SIZE)
+                .create();
+
+        assertThat(result.getList()).hasSize(SIZE);
+    }
+
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.size;
+
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+import org.instancio.PredicateSelector;
+import org.instancio.Size;
+import org.instancio.exception.InstancioApiException;
+import org.instancio.exception.UnusedSelectorException;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.arrays.ArrayLong;
+import org.instancio.test.support.pojo.collections.lists.ListString;
+import org.instancio.test.support.pojo.collections.lists.TwoListsOfInteger;
+import org.instancio.test.support.pojo.collections.maps.MapIntegerArrayString;
+import org.instancio.test.support.pojo.person.Address;
+import org.instancio.test.support.pojo.person.Gender;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.instancio.Select.all;
+import static org.instancio.Select.field;
+import static org.instancio.Select.root;
+
+@FeatureTag(Feature.SIZE)
+@ExtendWith(InstancioExtension.class)
+class SizeTest {
+
+    private static final int SIZE = 7;
+
+    @Nested
+    class SizeInteger {
+
+        @Test
+        void array() {
+            final ArrayLong result = Instancio.of(ArrayLong.class)
+                    .size(field(ArrayLong::getWrapper), SIZE)
+                    .create();
+
+            assertThat(result.getWrapper()).hasSize(SIZE);
+        }
+
+        @Test
+        void collection() {
+            final ListString result = Instancio.of(ListString.class)
+                    .size(field(ListString::getList), SIZE)
+                    .create();
+
+            assertThat(result.getList()).hasSize(SIZE);
+        }
+
+        @Test
+        void map() {
+            final MapIntegerArrayString result = Instancio.of(MapIntegerArrayString.class)
+                    .size(field(MapIntegerArrayString::getMap), SIZE)
+                    .create();
+
+            assertThat(result.getMap()).hasSize(SIZE);
+        }
+    }
+
+    @Nested
+    class SizeObjectExact {
+
+        @Test
+        void array() {
+            final ArrayLong result = Instancio.of(ArrayLong.class)
+                    .size(field(ArrayLong::getWrapper), Size.of(SIZE))
+                    .create();
+
+            assertThat(result.getWrapper()).hasSize(SIZE);
+        }
+
+        @Test
+        void collection() {
+            final ListString result = Instancio.of(ListString.class)
+                    .size(field(ListString::getList), Size.of(SIZE))
+                    .create();
+
+            assertThat(result.getList()).hasSize(SIZE);
+        }
+
+        @Test
+        void map() {
+            final MapIntegerArrayString result = Instancio.of(MapIntegerArrayString.class)
+                    .size(field(MapIntegerArrayString::getMap), Size.of(SIZE))
+                    .create();
+
+            assertThat(result.getMap()).hasSize(SIZE);
+        }
+    }
+
+    @Nested
+    class SizeObjectRange {
+
+        @RepeatedTest(Constants.SAMPLE_SIZE_D)
+        void array() {
+            final ArrayLong result = Instancio.of(ArrayLong.class)
+                    .size(field(ArrayLong::getWrapper), Size.range(0, SIZE))
+                    .create();
+
+            assertThat(result.getWrapper()).hasSizeBetween(0, SIZE);
+        }
+
+        @RepeatedTest(Constants.SAMPLE_SIZE_D)
+        void collection() {
+            final ListString result = Instancio.of(ListString.class)
+                    .size(field(ListString::getList), Size.range(0, SIZE))
+                    .create();
+
+            assertThat(result.getList()).hasSizeBetween(0, SIZE);
+        }
+
+        @RepeatedTest(Constants.SAMPLE_SIZE_D)
+        void map() {
+            final MapIntegerArrayString result = Instancio.of(MapIntegerArrayString.class)
+                    .size(field(MapIntegerArrayString::getMap), Size.range(0, SIZE))
+                    .create();
+
+            assertThat(result.getMap()).hasSizeBetween(0, SIZE);
+        }
+    }
+
+    @Test
+    void ofListAndAllListSize() {
+        final int nestedListSize = SIZE + 5;
+
+        final List<ListString> result = Instancio.ofList(ListString.class)
+                .size(SIZE)
+                .size(all(List.class), nestedListSize)
+                .create();
+
+        assertThat(result)
+                .hasSize(SIZE)
+                .extracting(ListString::getList)
+                .allMatch(list -> list.size() == nestedListSize);
+    }
+
+    @Test
+    void ofListRootSize() {
+        final int sizeOverride = SIZE + 5;
+
+        final List<ListString> result = Instancio.ofList(ListString.class)
+                .size(SIZE)
+                .size(root(), sizeOverride)
+                .create();
+
+        assertThat(result)
+                .hasSize(sizeOverride)
+                .extracting(ListString::getList)
+                // random sizes based on default settings
+                .noneMatch(list -> list.size() == sizeOverride);
+    }
+
+    @Test
+    void allListsInObject() {
+        final TwoListsOfInteger result = Instancio.of(TwoListsOfInteger.class)
+                .size(all(List.class), SIZE)
+                .create();
+
+        assertThat(result.getList1()).hasSize(SIZE);
+        assertThat(result.getList2()).hasSize(SIZE);
+    }
+
+    @Test
+    void enumSet() {
+        record Holder(EnumSet<Gender> genders) {}
+
+        final Holder result = Instancio.of(Holder.class)
+                .size(field(Holder::genders), 1)
+                .create();
+
+        assertThat(result.genders()).hasSize(1);
+    }
+
+    @Nested
+    class Validation {
+
+        @Test
+        void unusedSelectorErrorWhenSizeSelectorHasNoMatch() {
+            final InstancioApi<ListString> api = Instancio.of(ListString.class)
+                    .size(all(Set.class), 3);
+
+            assertThatThrownBy(api::create)
+                    .isExactlyInstanceOf(UnusedSelectorException.class)
+                    .hasMessageContaining("Unused selector in: size()");
+        }
+
+        @Test
+        void arrayWith_exceedsSize() {
+            final InstancioApi<ArrayLong> api = Instancio.of(ArrayLong.class)
+                    .size(field(ArrayLong::getWrapper), 2)
+                    .generate(field(ArrayLong::getWrapper), gen -> gen.array().with(10L, 20L, 30L));
+
+            assertThatThrownBy(api::create)
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("array generator specifies more 'with()' elements (3) than the size() override allows (2)");
+        }
+
+        @Test
+        void negativeIntThrowsAtCallTime() {
+            final InstancioApi<Person> api = Instancio.of(Person.class);
+            final PredicateSelector selector = field(Address::getPhoneNumbers);
+
+            assertThatThrownBy(() -> api.size(selector, -1))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("size must not be negative: -1");
+        }
+
+        @Test
+        void sizeRangeWithMinGreaterThanMaxThrowsAtCallTime() {
+            assertThatThrownBy(() -> Size.range(5, 2))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("min (5) must be less than or equal to max (2)");
+        }
+
+        @Test
+        void sizeRangeWithNegativeMinThrowsAtCallTime() {
+            assertThatThrownBy(() -> Size.range(-1, 5))
+                    .isExactlyInstanceOf(InstancioApiException.class)
+                    .hasMessageContaining("size must not be negative: -1");
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithCartesianProductTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithCartesianProductTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.size;
+
+import org.instancio.Instancio;
+import org.instancio.Size;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.SIZE, Feature.CARTESIAN_PRODUCT})
+@ExtendWith(InstancioExtension.class)
+class SizeWithCartesianProductTest {
+
+    private static final int SIZE = 7;
+
+    private record Sample(int x, List<String> list) {}
+
+    @Test
+    void sizeInteger() {
+        final List<Sample> results = Instancio.ofCartesianProduct(Sample.class)
+                .with(field(Sample::x), 1, 2, 3)
+                .size(field(Sample::list), SIZE)
+                .create();
+
+        assertThat(results)
+                .allSatisfy(r -> assertThat(r.list()).hasSize(SIZE))
+                .extracting(r -> r.x)
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void sizeObject() {
+        final List<Sample> results = Instancio.ofCartesianProduct(Sample.class)
+                .with(field(Sample::x), 1, 2, 3)
+                .size(field(Sample::list), Size.of(SIZE))
+                .create();
+
+        assertThat(results)
+                .allSatisfy(r -> assertThat(r.list()).hasSize(SIZE))
+                .extracting(r -> r.x)
+                .containsExactly(1, 2, 3);
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithModelTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithModelTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.size;
+
+import org.instancio.Instancio;
+import org.instancio.Model;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.collections.lists.ListString;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.SIZE, Feature.MODEL})
+@ExtendWith(InstancioExtension.class)
+class SizeWithModelTest {
+
+    private static final int SIZE = 7;
+
+    @Test
+    void modelWithSizeCanBeOverriddenInDerivedInstance() {
+        final int sizeOverride = SIZE + 5;
+
+        final Model<ListString> model = Instancio.of(ListString.class)
+                .size(field(ListString::getList), SIZE)
+                .toModel();
+
+        final ListString result = Instancio.of(model)
+                .size(field(ListString::getList), sizeOverride)
+                .create();
+
+        assertThat(result.getList()).hasSize(sizeOverride);
+    }
+
+    @Test
+    void modelWithSizeIsPreservedWhenDerivedInstanceDoesNotOverride() {
+        final Model<ListString> model = Instancio.of(ListString.class)
+                .size(field(ListString::getList), SIZE)
+                .toModel();
+
+        final ListString result = Instancio.of(model).create();
+
+        assertThat(result.getList()).hasSize(SIZE);
+    }
+
+    @Nested
+    class SetModel {
+
+        record Holder(ListString listString) {}
+
+        @Test
+        void originalModelSize() {
+            final Model<ListString> model = Instancio.of(ListString.class)
+                    .size(field(ListString::getList), SIZE)
+                    .toModel();
+
+            final Holder result = Instancio.of(Holder.class)
+                    .setModel(field(Holder::listString), model)
+                    .create();
+
+            assertThat(result.listString.getList()).hasSize(SIZE);
+        }
+
+        @Test
+        void overrideModelSize() {
+            final int sizeOverride = SIZE + 5;
+
+            final Model<ListString> model = Instancio.of(ListString.class)
+                    .size(field(ListString::getList), SIZE)
+                    .toModel();
+
+            final Holder result = Instancio.of(Holder.class)
+                    .setModel(field(Holder::listString), model)
+                    .size(field(ListString::getList), sizeOverride)
+                    .create();
+
+            assertThat(result.listString.getList()).hasSize(sizeOverride);
+        }
+    }
+}

--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithNullableTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/size/SizeWithNullableTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.test.features.size;
+
+import org.instancio.Instancio;
+import org.instancio.junit.InstancioExtension;
+import org.instancio.test.support.pojo.collections.lists.ListString;
+import org.instancio.test.support.tags.Feature;
+import org.instancio.test.support.tags.FeatureTag;
+import org.instancio.test.support.util.Constants;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@FeatureTag({Feature.SIZE, Feature.WITH_NULLABLE})
+@ExtendWith(InstancioExtension.class)
+class SizeWithNullableTest {
+
+    private static final int SIZE = 7;
+
+    @Test
+    void sizeIsAppliedWhenCollectionIsNotNull() {
+        final List<ListString> result = Instancio.ofList(ListString.class)
+                .size(Constants.SAMPLE_SIZE_DD)
+                .withNullable(field(ListString::getList))
+                .size(field(ListString::getList), SIZE)
+                .create();
+
+        // Lists should either be null, or non-null with the expected size
+        assertThat(result)
+                .extracting(ListString::getList)
+                .containsNull()
+                .filteredOn(Objects::nonNull)
+                .isNotEmpty()
+                .allMatch(list -> list.size() == SIZE);
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/InvalidSizeTargetTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/InvalidSizeTargetTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.person.Person;
+import org.instancio.test.support.pojo.person.Pet;
+
+import static org.instancio.Select.field;
+
+class InvalidSizeTargetTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.of(Person.class)
+                .size(field(Pet::getName), 2)
+                .size(field(Person::getAge), 3)
+                .create();
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+                
+                
+                Error creating an object
+                 -> at org.external.errorhandling.InvalidSizeTargetTest.methodUnderTest(InvalidSizeTargetTest.java:31)
+                
+                Reason: 'size()' can only be applied to a collection, array, or map.
+                
+                Found selector(s) targeting an incompatible type:
+                
+                 -> field(Person::getAge)
+                    at org.external.errorhandling.InvalidSizeTargetTest.methodUnderTest(InvalidSizeTargetTest.java:30)
+                
+                 -> field(Pet::getName)
+                    at org.external.errorhandling.InvalidSizeTargetTest.methodUnderTest(InvalidSizeTargetTest.java:29)
+                
+                
+                """;
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/InvalidSizeTargetWithPredicateSelectorTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/external/errorhandling/InvalidSizeTargetWithPredicateSelectorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.external.errorhandling;
+
+import org.instancio.Instancio;
+import org.instancio.test.support.pojo.person.Person;
+
+import static org.instancio.Select.field;
+import static org.instancio.Select.fields;
+
+class InvalidSizeTargetWithPredicateSelectorTest extends AbstractErrorMessageTestTemplate {
+
+    @Override
+    void methodUnderTest() {
+        Instancio.of(Person.class)
+                .size(fields(f -> f.getDeclaringClass() == Person.class), 3)
+                .size(field(Person::getName), 2)
+                .create();
+    }
+
+    @Override
+    String expectedMessage() {
+        return """
+
+
+                Error creating an object
+                 -> at org.external.errorhandling.InvalidSizeTargetWithPredicateSelectorTest.methodUnderTest(InvalidSizeTargetWithPredicateSelectorTest.java:31)
+
+                Reason: 'size()' can only be applied to a collection, array, or map.
+
+                Found selector(s) targeting an incompatible type:
+
+                 -> fields(Predicate<Field>)
+                    at org.external.errorhandling.InvalidSizeTargetWithPredicateSelectorTest.methodUnderTest(InvalidSizeTargetWithPredicateSelectorTest.java:29)
+
+                 -> field(Person::getName)
+                    at org.external.errorhandling.InvalidSizeTargetWithPredicateSelectorTest.methodUnderTest(InvalidSizeTargetWithPredicateSelectorTest.java:30)
+
+
+                """;
+    }
+}

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/InternalSizeTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/InternalSizeTest.java
@@ -15,24 +15,15 @@
  */
 package org.instancio.internal;
 
-import org.instancio.InstancioCollectionsApi;
-import org.instancio.Select;
-import org.instancio.internal.reflect.ParameterizedTypeImpl;
+import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Type;
-import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
 
-public final class MapApiImpl<K, V, M extends Map<K, V>>
-        extends ClassApiImpl<M>
-        implements InstancioCollectionsApi<M> {
+class InternalSizeTest {
 
-    public MapApiImpl(final Class<M> mapType, final Type keyType, final Type valueType) {
-        super(new ParameterizedTypeImpl(mapType, keyType, valueType));
-    }
-
-    @Override
-    public InstancioCollectionsApi<M> size(final int size) {
-        size(Select.root(), size);
-        return this;
+    @Test
+    void verifyToString() {
+        assertThat(new InternalSize(3, 7))
+                .hasToString("Size[min=3, max=7]");
     }
 }

--- a/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
+++ b/instancio-tests/instancio-core-tests/src/test/java/org/instancio/internal/context/ModelContextTest.java
@@ -233,15 +233,15 @@ class ModelContextTest {
                 .withIgnored(field("address"))
                 .build();
 
-        assertThatThrownBy(ctx::reportUnusedSelectorWarnings).isInstanceOf(UnusedSelectorException.class);
+        assertThatThrownBy(() -> ctx.reportUnusedSelectorWarnings(null)).isInstanceOf(UnusedSelectorException.class);
 
         ctx.getGenerator(mockNode(Person.class, NAME_FIELD));
         ctx.isIgnored(mockNode(Person.class, ADDRESS_FIELD));
-        ctx.reportUnusedSelectorWarnings(); // no error
+        ctx.reportUnusedSelectorWarnings(null); // no error
 
         final ModelContext newCtx = ctx.toBuilder().build();
 
-        assertThatThrownBy(newCtx::reportUnusedSelectorWarnings)
+        assertThatThrownBy(() -> newCtx.reportUnusedSelectorWarnings(null))
                 .as("Cloned context should have its own unused selectors state")
                 .isInstanceOf(UnusedSelectorException.class);
     }

--- a/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
+++ b/instancio-tests/instancio-test-support/src/main/java/org/instancio/test/support/tags/Feature.java
@@ -108,6 +108,7 @@ public enum Feature {
     SET,
     SET_BACK_REFERENCES,
     SETTINGS,
+    SIZE,
     BLANK, // createBlank(), ofBlank(), setBlank() APIs
     STREAM,
     STRING_FIELD_PREFIX,


### PR DESCRIPTION
Motivation: reduce verbosity when specifying an array/collection size. Previously setting a collection size required using the `generate()`  method with the collection spec lambda, e.g.:

```java
Person person = Instancio.of(Person.class)
    .generate(field(Person::getHobbies), gen -> gen.collection().size(2))
    .create();
```

The new API provides a more concise and readable syntax:

```java
Person person = Instancio.of(Person.class)
    .size(field(Person::getHobbies), 2)
    .create();
```

An additional overload that takes a `Size` object allows generating a collection of random size within the specified range (inclusive):

```java
Person person = Instancio.of(Person.class)
    .size(field(Person::getHobbies), Size.range(0, 5))
    .create();
```
