### PR TITLE
Fix test regression introduced by running `feature-tests` in parallel mode

### DIFF
--- a/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/ValuesWithGenerateAndSeedAnnotationTest.java
+++ b/instancio-tests/feature-tests/src/test/java/org/instancio/test/features/values/ValuesWithGenerateAndSeedAnnotationTest.java
@@ -24,8 +24,8 @@ import org.instancio.test.support.tags.FeatureTag;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.instancio.Select.allStrings;
@@ -35,7 +35,7 @@ import static org.instancio.Select.allStrings;
 class ValuesWithGenerateAndSeedAnnotationTest {
 
     private static final long SEED = -1;
-    private static final Set<String> results = new HashSet<>();
+    private static final Set<String> results = ConcurrentHashMap.newKeySet();
 
     @Seed(SEED)
     @RepeatedTest(10)


### PR DESCRIPTION
Related to #1638
