### PR TITLE
Cleanup: remove `@InstancioSource` leftovers from instancio-junit

### DIFF
--- a/instancio-junit/pom.xml
+++ b/instancio-junit/pom.xml
@@ -52,8 +52,6 @@
                             org.instancio.support;version=!,
                             org.instancio;version=!,
                             org.junit.jupiter.api.extension;version=!,
-                            org.junit.jupiter.params.provider;version=!;resolution:=optional,
-                            org.junit.jupiter.params.support;version=!;resolution:=optional,
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -71,12 +69,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/instancio-junit/src/main/java/module-info.java
+++ b/instancio-junit/src/main/java/module-info.java
@@ -1,8 +1,6 @@
 module org.instancio.junit {
   requires transitive org.instancio.core;
 
-  requires static org.junit.jupiter.params;
-
   requires org.jspecify;
   requires org.junit.jupiter.api;
 

--- a/instancio-junit/src/main/java/org/instancio/junit/WithSettings.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/WithSettings.java
@@ -29,6 +29,10 @@ import java.lang.annotation.Target;
  * <p>This annotation must be placed on a {@link Settings} field.
  * There can be at most one field annotated {@code @WithSettings} per test class.
  *
+ * <p>The annotated field may be static or non-static. Prior to version {@code 6.0.0},
+ * a static field was required if the test class contained a {@code @ParameterizedTest}
+ * method; this restriction no longer applies.
+ *
  * <pre>{@code
  * @ExtendWith(InstancioExtension.class)
  * class ExampleTest {

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
@@ -100,16 +100,14 @@ public final class ExtensionSupport {
 
         final Field field = fields.get(0);
 
-        // Test instance is not present for parameterized tests, in which case
-        // we expect the settings annotation to be on a static field
-        final Optional<Object> testInstance = context.getTestInstances().flatMap(testInstances -> testInstances.findInstance(testClass));
-        final Object settings = ReflectionUtils.getFieldValue(field, testInstance.orElse(null));
+        final Object testInstance = context.getTestInstances()
+                .flatMap(testInstances -> testInstances.findInstance(testClass))
+                .orElse(null);
 
-        if (testInstance.isPresent() && settings == null) {
-            throw Fail.withSettingsOnNullField();
-        }
+        final Object settings = ReflectionUtils.getFieldValue(field, testInstance);
+
         if (settings == null) {
-            throw Fail.withSettingsOnNullOrNonStaticField();
+            throw Fail.withSettingsOnNullField();
         }
         if (!(settings instanceof Settings s)) {
             throw Fail.withSettingsOnWrongFieldType(field);

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/Fail.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/Fail.java
@@ -41,17 +41,6 @@ final class Fail {
         return apiException(msg);
     }
 
-    static InstancioApiException withSettingsOnNullOrNonStaticField() {
-        final String msg = new StringBuilder(SB_SIZE)
-                .append("Possible causes:").append(NL)
-                .append(" -> @WithSettings must be annotated on a non-null field.").append(NL)
-                .append(" -> If @WithSettings is used in a test class that contains a @ParameterizedTest,").append(NL)
-                .append("    the annotated Settings field must be static.")
-                .toString();
-
-        return apiException(msg);
-    }
-
     static InstancioApiException withSettingsOnWrongFieldType(final Field field) {
         final String msg = new StringBuilder(SB_SIZE)
                 .append("Cause:").append(NL)

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
@@ -197,28 +197,6 @@ class InstancioExtensionTest {
         assertApiExceptionWithMessage(() -> extension.beforeEach(context), expectedMsg);
     }
 
-    /**
-     * Mimics a test class with a {@code ParameterizedTest} and a non-static
-     * {@code Settings} field (a JUnit extension can only access static fields
-     * when ParameterizedTest is executed).
-     */
-    @Test
-    @DisplayName("Verify exception is thrown if @WithSettings is on a non-static field")
-    void withNonStaticSettingsField() {
-        doReturn(Optional.of(DummyWithNonStaticSettingsTest.class)).when(context).getTestClass();
-
-        final String expectedMsg = """
-                Error running test
-                
-                Possible causes:
-                 -> @WithSettings must be annotated on a non-null field.
-                 -> If @WithSettings is used in a test class that contains a @ParameterizedTest,
-                    the annotated Settings field must be static.
-                """;
-
-        assertApiExceptionWithMessage(() -> extension.beforeEach(context), expectedMsg);
-    }
-
     @SuppressWarnings("NullAway")
     private static void assertApiExceptionWithMessage(final ThrowingCallable throwingCallable, final String expectedMsg) {
         assertThatThrownBy(throwingCallable)
@@ -289,11 +267,6 @@ class InstancioExtensionTest {
         private final Settings settings1 = SETTINGS;
         @WithSettings
         private final Settings settings2 = SETTINGS;
-    }
-
-    static class DummyWithNonStaticSettingsTest {
-        @WithSettings
-        private Settings settings = SETTINGS;
     }
 
     static class DummyWithNullSettingsTest {

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithSettingsOnNonStaticFieldTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithSettingsOnNonStaticFieldTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit;
+
+import org.instancio.Instancio;
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a non-static {@code @WithSettings} field is supported even when
+ * the test class contains a {@code @ParameterizedTest} method. Prior to version
+ * {@code 6.0.0}, this combination was rejected because of {@code @InstancioSource},
+ * which required the settings field to be static.
+ */
+@ExtendWith(InstancioExtension.class)
+class InstancioExtensionWithSettingsOnNonStaticFieldTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+            .set(Keys.INTEGER_MIN, -1)
+            .set(Keys.INTEGER_MAX, -1);
+
+    @Test
+    void nonStaticSettingsFieldWithRegularTest() {
+        assertThat(Instancio.create(Integer.class)).isEqualTo(-1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"foo", "bar"})
+    void nonStaticSettingsFieldWithParameterizedTest(final String value) {
+        assertThat(Instancio.create(Integer.class)).isEqualTo(-1);
+    }
+}

--- a/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
+++ b/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
@@ -62,9 +62,7 @@ class ManifestFileTest {
             "org.instancio.settings,",
             "org.instancio.support,",
             "org.instancio,",
-            "org.junit.jupiter.api.extension,",
-            "org.junit.jupiter.params.provider;resolution:=optional",
-            "org.junit.jupiter.params.support;resolution:=optional"
+            "org.junit.jupiter.api.extension"
     };
 
     private static final String[] INSTANCIO_KOTLIN_EXPECTED_IMPORTS = {

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -4754,8 +4754,12 @@ class ExampleTest {
 !!! attention ""
     <lnum>11</lnum> Settings passed to the builder method take precedence over the injected settings.
 
-Instancio supports `@WithSettings` placed on static and non-static fields.
-However, if the test class contains a `@ParameterizedTest` method, then the settings field *must be static*.
+Instancio supports `@WithSettings` placed on static and non-static fields,
+including in test classes that contain `@ParameterizedTest` methods.
+
+!!! note ""
+    Prior to version `6.0.0`, a test class containing a `@ParameterizedTest` method
+    required the `@WithSettings` field to be static. This restriction no longer applies.
 
 ## Reproducing Failed Tests
 


### PR DESCRIPTION
`@WithSettings` on a non-static field in a test class containing `@ParameterizedTest` used to fail, because `@InstancioSource` resolved settings at the container level, before test instances are created. Since its removal in #1782, settings are only resolved from `beforeEach()`, where a test instance always exists — so the restriction no longer applies, the validation branch became unreachable, and the documented requirement is stale.

This removes the dead branch and its error message, and corrects the user guide and `@WithSettings` javadoc. The combination is already exercised by existing tests (e.g. `GivenWithSettingsAnnotationTest`); a dedicated regression test is added to lock it in.

Also drops the `junit-jupiter-params` dependency from `instancio-junit`, along with its `requires static` clause and optional OSGi imports — no main source has referenced it since #1782.
