### PR TITLE
Add support for inheriting `@WithSettings` from supertypes

### DIFF
--- a/instancio-junit/pom.xml
+++ b/instancio-junit/pom.xml
@@ -52,6 +52,8 @@
                             org.instancio.support;version=!,
                             org.instancio;version=!,
                             org.junit.jupiter.api.extension;version=!,
+                            org.junit.platform.commons.function;version=!,
+                            org.junit.platform.commons.support;version=!,
                         </Import-Package>
                     </instructions>
                 </configuration>
@@ -68,6 +70,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/instancio-junit/src/main/java/module-info.java
+++ b/instancio-junit/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module org.instancio.junit {
 
   requires org.jspecify;
   requires org.junit.jupiter.api;
+  requires org.junit.platform.commons;
 
   exports org.instancio.junit;
 }

--- a/instancio-junit/src/main/java/org/instancio/junit/WithSettings.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/WithSettings.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * An annotation for supplying custom settings to a unit test class.
  *
  * <p>This annotation must be placed on a {@link Settings} field.
- * There can be at most one field annotated {@code @WithSettings} per test class.
+ * There can be at most one field annotated {@code @WithSettings} per class.
  *
  * <p>The annotated field may be static or non-static. Prior to version {@code 6.0.0},
  * a static field was required if the test class contained a {@code @ParameterizedTest}
@@ -73,6 +73,49 @@ import java.lang.annotation.Target;
  *     // Effective value of STRING_MIN_LENGTH = 10 and STRING_MAX_LENGTH = 20
  * }
  * }</pre>
+ *
+ * <h2>Inheritance</h2>
+ *
+ * <p>Since version {@code 6.0.0}, settings declared by a superclass or an
+ * implemented interface are inherited by subclasses. This allows a common
+ * set of settings to be shared by extending a base test class:
+ *
+ * <pre>{@code
+ * abstract class BaseTest {
+ *     @WithSettings
+ *     protected final Settings settings = Settings.create()
+ *         .set(Keys.STRING_MIN_LENGTH, 3)
+ *         .set(Keys.STRING_MAX_LENGTH, 20);
+ * }
+ *
+ * @ExtendWith(InstancioExtension.class)
+ * class ExampleTest extends BaseTest {
+ *
+ *     // Effective value of STRING_MIN_LENGTH = 3 and STRING_MAX_LENGTH = 20
+ * }
+ * }</pre>
+ *
+ * <p>As with {@code @Nested} test classes, inherited settings are merged
+ * rather than replaced: a subclass that declares its own {@code @WithSettings}
+ * field overrides only the matching settings, and inherits the rest.
+ *
+ * <pre>{@code
+ * @ExtendWith(InstancioExtension.class)
+ * class ExampleTest extends BaseTest {
+ *
+ *     @WithSettings
+ *     private final Settings settings = Settings.create()
+ *         .set(Keys.STRING_MIN_LENGTH, 10);
+ *
+ *     // Effective value of STRING_MIN_LENGTH = 10 and STRING_MAX_LENGTH = 20
+ * }
+ * }</pre>
+ *
+ * <p>When both mechanisms are combined, settings are applied from the
+ * outermost enclosing class down to the test class itself, and within each
+ * class from its supertypes down to the class itself. In other words, the
+ * closer a declaration is to the test class being executed, the higher its
+ * precedence.
  *
  * @since 1.1.1
  */

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
@@ -27,11 +27,15 @@ import org.instancio.support.Seeds;
 import org.instancio.support.ThreadLocalTestContext;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.ReflectionSupport;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public final class ExtensionSupport {
 
@@ -77,34 +81,50 @@ public final class ExtensionSupport {
     }
 
     @Nullable
-    @SuppressWarnings("java:S3011")
     private static Settings processWithSettingsAnnotation(final ExtensionContext context) {
-        final List<Class<?>> testClasses = new ArrayList<>(context.getEnclosingTestClasses());
-        context.getTestClass().ifPresent(testClasses::add);
-
-        return testClasses.stream()
-                .map(t -> findSettings(t, context))
+        // instances are ordered from outermost to innermost, so settings
+        // declared by inner classes are overlaid on those of their outer classes
+        return context.getRequiredTestInstances().getAllInstances().stream()
+                .map(ExtensionSupport::findSettings)
                 .flatMap(Optional::stream)
                 .reduce(Settings::merge)
                 .orElse(null);
     }
 
-    private static Optional<Settings> findSettings(Class<?> testClass, ExtensionContext context) {
-        final List<Field> fields = ReflectionUtils.getAnnotatedFields(testClass, WithSettings.class);
+    /**
+     * Returns the settings declared by the given instance's class and its supertypes,
+     * merged such that settings declared by subtypes take precedence.
+     */
+    private static Optional<Settings> findSettings(final Object testInstance) {
+        final List<Field> fields = AnnotationSupport.findAnnotatedFields(
+                testInstance.getClass(), WithSettings.class);
 
-        if (fields.size() > 1) {
-            throw Fail.multipleAnnotatedFields(fields);
-        } else if (fields.isEmpty()) {
+        if (fields.isEmpty()) {
             return Optional.empty();
         }
 
-        final Field field = fields.get(0);
+        checkAtMostOneFieldPerDeclaringClass(fields);
 
-        final Object testInstance = context.getTestInstances()
-                .flatMap(testInstances -> testInstances.findInstance(testClass))
+        return fields.stream()
+                .map(field -> getSettingsValue(field, testInstance))
+                .reduce(Settings::merge);
+    }
+
+    private static void checkAtMostOneFieldPerDeclaringClass(final List<Field> fields) {
+        final Map<Class<?>, List<Field>> fieldsByDeclaringClass = fields.stream()
+                .collect(Collectors.groupingBy(Field::getDeclaringClass, LinkedHashMap::new, Collectors.toList()));
+
+        for (List<Field> declaredFields : fieldsByDeclaringClass.values()) {
+            if (declaredFields.size() > 1) {
+                throw Fail.multipleAnnotatedFields(declaredFields);
+            }
+        }
+    }
+
+    private static Settings getSettingsValue(final Field field, final Object testInstance) {
+        final Object settings = ReflectionSupport.tryToReadFieldValue(field, testInstance)
+                .toOptional()
                 .orElse(null);
-
-        final Object settings = ReflectionUtils.getFieldValue(field, testInstance);
 
         if (settings == null) {
             throw Fail.withSettingsOnNullField();
@@ -112,7 +132,7 @@ public final class ExtensionSupport {
         if (!(settings instanceof Settings s)) {
             throw Fail.withSettingsOnWrongFieldType(field);
         }
-        return Optional.of(s);
+        return s;
     }
 
     private ExtensionSupport() {

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/Fail.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/Fail.java
@@ -65,7 +65,7 @@ final class Fail {
         }
 
         final String msg = sb.append(NL)
-                .append("Only one annotated Settings field is expected")
+                .append("Only one annotated Settings field per class is expected")
                 .toString();
 
         return apiException(msg);

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/ReflectionUtils.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/ReflectionUtils.java
@@ -16,19 +16,14 @@
 package org.instancio.junit.internal;
 
 import org.instancio.internal.util.Sonar;
-import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static java.util.stream.Collectors.toList;
 
 public final class ReflectionUtils {
 
@@ -59,23 +54,6 @@ public final class ReflectionUtils {
                 results.add(annotation);
                 collectionAnnotations(type, results);
             }
-        }
-    }
-
-    static List<Field> getAnnotatedFields(final Class<?> klass, final Class<? extends Annotation> annotation) {
-        return Arrays.stream(klass.getDeclaredFields())
-                .filter(field -> field.getAnnotation(annotation) != null)
-                .collect(toList());
-    }
-
-    @Nullable
-    @SuppressWarnings("java:S3011")
-    static Object getFieldValue(final Field field, @Nullable final Object target) {
-        try {
-            field.setAccessible(true);
-            return field.get(target);
-        } catch (Exception ex) {
-            return null;
         }
     }
 

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionTest.java
@@ -116,11 +116,8 @@ class InstancioExtensionTest {
     @Test
     @DisplayName("Verify annotated Settings are passed to thread local")
     void beforeEachWithSettingsAnnotation() throws IllegalAccessException {
-        doReturn(Optional.of(DummyTest.class)).when(context).getTestClass();
         doReturn(testInstances).when(context).getRequiredTestInstances();
-        doReturn(Optional.of(testInstances)).when(context).getTestInstances();
         doReturn(List.of(new DummyTest())).when(testInstances).getAllInstances();
-        doReturn(Optional.of(new DummyTest())).when(testInstances).findInstance(DummyTest.class);
 
         final ExtensionContext.Store store = mock(ExtensionContext.Store.class);
         doReturn(store).when(context).getStore(ExtensionContext.Namespace.create("org.instancio"));
@@ -138,7 +135,8 @@ class InstancioExtensionTest {
     @Test
     @DisplayName("Verify exception is thrown if test class has more than one field annotated @WithSettings")
     void moreThanOneFieldAnnotatedWithSettings() {
-        doReturn(Optional.of(DummyWithTwoSettingsTest.class)).when(context).getTestClass();
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyWithTwoSettingsTest())).when(testInstances).getAllInstances();
 
         final String expectedMsg = """
                 Error running test
@@ -149,7 +147,30 @@ class InstancioExtensionTest {
                     (1) private final org.instancio.settings.Settings org.instancio.junit.InstancioExtensionTest$DummyWithTwoSettingsTest.settings1
                     (2) private final org.instancio.settings.Settings org.instancio.junit.InstancioExtensionTest$DummyWithTwoSettingsTest.settings2
                 
-                Only one annotated Settings field is expected
+                Only one annotated Settings field per class is expected
+                """;
+
+        assertApiExceptionWithMessage(() -> extension.beforeEach(context), expectedMsg);
+    }
+
+    @Test
+    @DisplayName("Verify only the offending class is reported when a superclass has more than one annotated field")
+    void moreThanOneFieldAnnotatedWithSettingsInSuperclass() {
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyWithTwoSettingsInSuperclassTest())).when(testInstances).getAllInstances();
+
+        // the subclass declares one annotated field, which is legal;
+        // only the two fields declared by the superclass are reported
+        final String expectedMsg = """
+                Error running test
+
+                Cause:
+                 -> Found more than one field annotated '@WithSettings'
+
+                    (1) private final org.instancio.settings.Settings org.instancio.junit.InstancioExtensionTest$DummyWithTwoSettingsTest.settings1
+                    (2) private final org.instancio.settings.Settings org.instancio.junit.InstancioExtensionTest$DummyWithTwoSettingsTest.settings2
+
+                Only one annotated Settings field per class is expected
                 """;
 
         assertApiExceptionWithMessage(() -> extension.beforeEach(context), expectedMsg);
@@ -158,11 +179,8 @@ class InstancioExtensionTest {
     @Test
     @DisplayName("Verify exception is thrown if @WithSettings is not on Settings field")
     void withSettingsOnWrongFieldType() {
-        doReturn(Optional.of(DummyWithSettingsOnWrongFieldTypeTest.class)).when(context).getTestClass();
-        doReturn(Optional.of(testInstances)).when(context).getTestInstances();
-        doReturn(Optional.of(new DummyWithSettingsOnWrongFieldTypeTest()))
-                .when(testInstances)
-                .findInstance(DummyWithSettingsOnWrongFieldTypeTest.class);
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyWithSettingsOnWrongFieldTypeTest())).when(testInstances).getAllInstances();
 
         final String expectedMsg = """
                 Error running test
@@ -180,11 +198,8 @@ class InstancioExtensionTest {
     @Test
     @DisplayName("Verify exception is thrown if @WithSettings is on a field with null value")
     void withSettingsOnNullField() {
-        doReturn(Optional.of(DummyWithNullSettingsTest.class)).when(context).getTestClass();
-        doReturn(Optional.of(testInstances)).when(context).getTestInstances();
-        doReturn(Optional.of(new DummyWithNullSettingsTest()))
-                .when(testInstances)
-                .findInstance(DummyWithNullSettingsTest.class);
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new DummyWithNullSettingsTest())).when(testInstances).getAllInstances();
 
         final String expectedMsg = """
                 Error running test
@@ -267,6 +282,11 @@ class InstancioExtensionTest {
         private final Settings settings1 = SETTINGS;
         @WithSettings
         private final Settings settings2 = SETTINGS;
+    }
+
+    static class DummyWithTwoSettingsInSuperclassTest extends DummyWithTwoSettingsTest {
+        @WithSettings
+        private final Settings settings3 = SETTINGS;
     }
 
     static class DummyWithNullSettingsTest {

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithInheritedSettingsTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithInheritedSettingsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit;
+
+import org.instancio.settings.Keys;
+import org.instancio.settings.Settings;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code @WithSettings} declared by a superclass or an interface
+ * is inherited by subclasses, and merged with the subclass settings.
+ */
+class InstancioExtensionWithInheritedSettingsTest {
+
+    @ExtendWith(InstancioExtension.class)
+    abstract static class BaseTest {
+
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.INTEGER_MIN, -1)
+                .set(Keys.INTEGER_MAX, -1)
+                .set(Keys.STRING_MIN_LENGTH, 5)
+                .set(Keys.STRING_MAX_LENGTH, 5);
+    }
+
+    @Nested
+    class InheritSettingsTest extends BaseTest {
+
+        private @Given int intField;
+        private @Given String stringField;
+
+        @Test
+        void shouldInheritSettingsFromSuperclass(@Given final int intParam, @Given final String stringParam) {
+            assertThat(intParam).isEqualTo(-1);
+            assertThat(intField).isEqualTo(-1);
+            assertThat(stringParam).hasSize(5);
+            assertThat(stringField).hasSize(5);
+        }
+    }
+
+    @Nested
+    class MergeSettingsTest extends BaseTest {
+
+        @WithSettings
+        private final Settings settings = Settings.create()
+                .set(Keys.STRING_MIN_LENGTH, 15)
+                .set(Keys.STRING_MAX_LENGTH, 15);
+
+        private @Given int intField;
+        private @Given String stringField;
+
+        @Test
+        void subclassSettingsShouldBeOverlaidOnSuperclassSettings(
+                @Given final int intParam, @Given final String stringParam) {
+
+            // not set by the subclass: inherited from the superclass
+            assertThat(intParam).isEqualTo(-1);
+            assertThat(intField).isEqualTo(-1);
+            // set by both: the subclass wins
+            assertThat(stringParam).hasSize(15);
+            assertThat(stringField).hasSize(15);
+        }
+    }
+
+    @ExtendWith(InstancioExtension.class)
+    interface SettingsMixin {
+
+        @WithSettings
+        Settings settings = Settings.create()
+                .set(Keys.LONG_MIN, -7L)
+                .set(Keys.LONG_MAX, -7L);
+    }
+
+    @Nested
+    class InheritSettingsFromInterfaceTest implements SettingsMixin {
+
+        private @Given long longField;
+
+        @Test
+        void shouldInheritSettingsFromInterface(@Given final long longParam) {
+            assertThat(longParam).isEqualTo(-7L);
+            assertThat(longField).isEqualTo(-7L);
+        }
+    }
+
+    @Nested
+    class InheritSettingsFromSuperclassAndInterfaceTest extends BaseTest implements SettingsMixin {
+
+        @Test
+        void shouldMergeSuperclassAndInterfaceSettings(
+                @Given final int intParam, @Given final long longParam, @Given final String stringParam) {
+
+            assertThat(intParam).isEqualTo(-1);
+            assertThat(longParam).isEqualTo(-7L);
+            assertThat(stringParam).hasSize(5);
+        }
+    }
+}

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ExtensionSupportTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ExtensionSupportTest.java
@@ -23,10 +23,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +39,9 @@ class ExtensionSupportTest {
     @Mock
     private ExtensionContext context;
 
+    @Mock
+    private TestInstances testInstances;
+
     @AfterEach
     void cleanup() {
         ThreadLocalTestContext.getInstance().remove();
@@ -48,7 +52,8 @@ class ExtensionSupportTest {
         ThreadLocalTestContext.getInstance().set(
                 new InternalTestContext(new DefaultRandom(), Settings.create()));
 
-        doReturn(Optional.of(NoSettingsTest.class)).when(context).getTestClass();
+        doReturn(testInstances).when(context).getRequiredTestInstances();
+        doReturn(List.of(new NoSettingsTest())).when(testInstances).getAllInstances();
 
         ExtensionSupport.processAnnotations(context, ThreadLocalTestContext.getInstance());
 

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ReflectionUtilsTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/internal/ReflectionUtilsTest.java
@@ -15,41 +15,16 @@
  */
 package org.instancio.junit.internal;
 
-import org.instancio.test.support.pojo.basic.StringHolder;
-import org.instancio.test.support.pojo.person.Person;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.reflect.Field;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ReflectionUtilsTest {
-
-    @Test
-    void getFieldValueShouldReturnNullIfExceptionIsThrown() {
-        final Field field = org.instancio.internal.util.ReflectionUtils.getField(Person.class, "name");
-        final String target = "invalid target";
-
-        assertThat(ReflectionUtils.getFieldValue(field, target)).isNull();
-    }
-
-    @Test
-    void getAnnotatedFields() {
-        final List<Field> fields = ReflectionUtils.getAnnotatedFields(WithAnnotatedField.class, AnnotationX.class);
-
-        assertThat(fields).hasSize(2)
-                .extracting(Field::getName)
-                .contains("foo", "bar");
-    }
-
-    @Test
-    void getAnnotatedFieldsReturnsEmptyList() {
-        assertThat(ReflectionUtils.getAnnotatedFields(StringHolder.class, AnnotationX.class)).isEmpty();
-    }
 
     @Test
     @SuppressWarnings({"rawtypes"})

--- a/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
+++ b/instancio-tests/packaging-tests/src/test/java/org/instancio/test/packaging/ManifestFileTest.java
@@ -62,7 +62,9 @@ class ManifestFileTest {
             "org.instancio.settings,",
             "org.instancio.support,",
             "org.instancio,",
-            "org.junit.jupiter.api.extension"
+            "org.junit.jupiter.api.extension",
+            "org.junit.platform.commons.function",
+            "org.junit.platform.commons.support"
     };
 
     private static final String[] INSTANCIO_KOTLIN_EXPECTED_IMPORTS = {

--- a/website/docs/user-guide.md
+++ b/website/docs/user-guide.md
@@ -4725,7 +4725,7 @@ class ExampleTest {
     <lnum>4</lnum> Inject custom settings to be used by every test method within the class.<br/>
     <lnum>10</lnum> Every object will be created using the injected settings.
 
-!!! warning "There can be only one field annotated `@WithSettings` per test class."
+!!! warning "There can be only one field annotated `@WithSettings` per class."
 
 Instancio also supports overriding the injected settings using the `withSettings` method as shown below.
 The settings provided via the method take precedence over the injected settings (see [Settings Precedence](#settings-precedence) for further information).
@@ -4760,6 +4760,57 @@ including in test classes that contain `@ParameterizedTest` methods.
 !!! note ""
     Prior to version `6.0.0`, a test class containing a `@ParameterizedTest` method
     required the `@WithSettings` field to be static. This restriction no longer applies.
+
+### Inherited and Nested Settings
+
+Injected settings are not confined to the class that declares them.
+Settings are also picked up from:
+
+- superclasses and implemented interfaces of the test class
+- enclosing classes, when using `@Nested` test classes
+
+Where more than one `@WithSettings` field applies, the settings are *merged* rather than replaced.
+Each declaration overrides only the keys it sets explicitly, and inherits the rest.
+This makes it possible to share a common baseline of settings and refine it per test class.
+
+``` java linenums="1" title="Inheriting and overriding Settings" hl_lines="3 12"
+abstract class BaseTest {
+
+    @WithSettings
+    protected final Settings settings = Settings.create()
+        .set(Keys.STRING_MIN_LENGTH, 3)
+        .set(Keys.STRING_MAX_LENGTH, 20);
+}
+
+@ExtendWith(InstancioExtension.class)
+class ExampleTest extends BaseTest {
+
+    @WithSettings
+    private final Settings settings = Settings.create()
+        .set(Keys.STRING_MIN_LENGTH, 10);
+
+    @Test
+    void example() {
+        // STRING_MIN_LENGTH = 10 (overridden)
+        // STRING_MAX_LENGTH = 20 (inherited)
+    }
+}
+```
+!!! attention ""
+    <lnum>3</lnum> The baseline settings declared by the base class.<br/>
+    <lnum>12</lnum> Only `STRING_MIN_LENGTH` is overridden; `STRING_MAX_LENGTH` is inherited.
+
+The same applies to `@Nested` test classes, where the inner class settings
+are overlaid on top of the outer class settings.
+
+When both mechanisms are combined, settings are applied from the outermost enclosing
+class down to the test class itself, and within each class from its supertypes down to
+the class itself. In short, **the closer a declaration is to the test class being
+executed, the higher its precedence**.
+
+!!! note ""
+    Prior to version `6.0.0`, settings were resolved from the test class alone.
+    Settings declared by supertypes and enclosing classes were ignored.
 
 ## Reproducing Failed Tests
 


### PR DESCRIPTION
Settings declared by a superclass or an implemented interface were ignored: only fields declared directly by the test class were considered, so a shared base test class holding common settings had no effect on its subclasses.

**Before:**

```java
abstract class BaseTest {
    @WithSettings
    protected final Settings settings = Settings.create()
        .set(Keys.STRING_MIN_LENGTH, 3)
        .set(Keys.STRING_MAX_LENGTH, 20);
}

@ExtendWith(InstancioExtension.class)
class ExampleTest extends BaseTest {

    // the inherited settings are ignored: both string lengths use the defaults
}
```

**Now:**

Settings are resolved from the entire type hierarchy and merged, so a subclass overrides only the keys it sets explicitly and inherits the rest:

```java
@ExtendWith(InstancioExtension.class)
class ExampleTest extends BaseTest {

    @WithSettings
    private final Settings settings = Settings.create()
        .set(Keys.STRING_MIN_LENGTH, 10);

    // Effective value of STRING_MIN_LENGTH = 10 and STRING_MAX_LENGTH = 20
}
```

This mirrors the merging already done for `@Nested` test classes. Where both apply, settings are applied from the outermost enclosing class down to the test class, and within each class from its supertypes down to the class itself, so the closer a declaration is to the test class being executed, the higher its precedence.

Field discovery and access are delegated to `AnnotationSupport` and `ReflectionSupport`, which also brings support for interfaces and meta-annotations, and lets the custom reflection helpers go. Resolution now walks the test instances, which are already ordered from outermost to innermost, instead of reconstructing the enclosing class hierarchy.

Since a class and its supertypes may now each contribute settings, the "at most one annotated field" rule is enforced per declaring class rather than per hierarchy, and its error message says so.
