### PR TITLE
Add support for using `@Seed` as a meta-annotation

### DIFF
--- a/instancio-junit/src/main/java/org/instancio/junit/Seed.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/Seed.java
@@ -43,9 +43,12 @@ import java.lang.annotation.Target;
  * <p>
  * If the seed annotation is not specified, a random seed will be used, resulting
  * in random data generated on each test run.
+ * <p>
+ * This annotation can also be used as a meta-annotation. A {@code @Seed} declared
+ * directly on a test method takes precedence over one that is meta-present.
  */
 @Documented
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Seed {
 

--- a/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
+++ b/instancio-junit/src/main/java/org/instancio/junit/internal/ExtensionSupport.java
@@ -52,8 +52,8 @@ public final class ExtensionSupport {
             final ExtensionContext context,
             @Nullable final Settings settings) {
 
-        final Seed seedAnnotation = context.getTestMethod()
-                .map(m -> m.getAnnotation(Seed.class))
+        final Seed seedAnnotation = AnnotationSupport
+                .findAnnotation(context.getTestMethod(), Seed.class)
                 .orElse(null);
 
         final long seed;

--- a/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithComposedSeedAnnotationTest.java
+++ b/instancio-tests/instancio-junit-tests/src/test/java/org/instancio/junit/InstancioExtensionWithComposedSeedAnnotationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.instancio.junit;
+
+import org.instancio.Instancio;
+import org.instancio.Result;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code @Seed} is resolved when it is meta-present
+ * on a composed annotation.
+ */
+@ExtendWith(InstancioExtension.class)
+class InstancioExtensionWithComposedSeedAnnotationTest {
+
+    private static final long SEED = 1234;
+    private static final long OTHER_SEED = 4567;
+
+    @Test
+    @Seed(SEED)
+    @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SeededTest {}
+
+    /**
+     * Composed of {@link SeededTest}: {@code @Seed} is meta-present indirectly.
+     */
+    @SeededTest
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface IndirectlySeededTest {}
+
+    @SeededTest
+    void shouldUseSeedFromComposedAnnotation() {
+        final Result<String> result = Instancio.of(String.class).asResult();
+
+        assertThat(result.getSeed()).isEqualTo(SEED);
+    }
+
+    @IndirectlySeededTest
+    void shouldUseSeedFromTransitiveMetaAnnotation() {
+        final Result<String> result = Instancio.of(String.class).asResult();
+
+        assertThat(result.getSeed()).isEqualTo(SEED);
+    }
+
+    @SeededTest
+    @Seed(OTHER_SEED)
+    void declaredAnnotationShouldTakePrecedenceOverMetaAnnotation() {
+        final Result<String> result = Instancio.of(String.class).asResult();
+
+        assertThat(result.getSeed()).isEqualTo(OTHER_SEED);
+    }
+}


### PR DESCRIPTION
The seed was resolved with `Method#getAnnotation()`, which only finds an annotation that is directly present. A fixed seed therefore had to be repeated on every test method that needed it, and could not be shared through a composed annotation.

Resolution is now delegated to `AnnotationSupport.findAnnotation()`, which also considers meta-annotations, and `@Seed` accepts `ANNOTATION_TYPE` as a target:

```java
@Test
@Seed(12345)
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME)
public @interface SeededTest {}

@ExtendWith(InstancioExtension.class)
class ExampleTest {

    @SeededTest
    void someTestMethod() {
        Person person = Instancio.create(Person.class); // will use seed 12345
    }
}
```

A `@Seed` declared directly on a test method takes precedence over one that is meta-present.

This is the same meta-annotation support that `@WithSettings` picked up in #1823, which this PR is stacked on.